### PR TITLE
Fix crash when .dockerignore is missing during cloud build

### DIFF
--- a/src/agentex/lib/sdk/config/agent_manifest.py
+++ b/src/agentex/lib/sdk/config/agent_manifest.py
@@ -94,10 +94,15 @@ class BuildContextManager:
             dockerignore_path = (
                 self.build_context_root / self.agent_manifest.build.context.dockerignore
             )
-            self.add_dockerignore(
-                root_path=self.path, dockerignore_path=dockerignore_path
-            )
-            ignore_patterns = _extract_dockerignore_patterns(dockerignore_path)
+            if dockerignore_path.exists():
+                self.add_dockerignore(
+                    root_path=self.path, dockerignore_path=dockerignore_path
+                )
+                ignore_patterns = _extract_dockerignore_patterns(dockerignore_path)
+            else:
+                logger.warning(
+                    f"Dockerignore file not found at {dockerignore_path}, skipping."
+                )
 
         for directory in self.agent_manifest.build.context.include_paths:
             directory_path = self.build_context_root / directory


### PR DESCRIPTION
## Summary
- `BuildContextManager.__enter__` crashes with `FileNotFoundError` when a manifest declares a `.dockerignore` path but the file doesn't exist on disk
- This causes `sgpctl agentex-cloud build submit` to fail for any agent created without a `.dockerignore` (e.g. manually created agents that didn't use `agentex init`)
- Fix: check if the file exists before attempting to copy/parse it, log a warning, and proceed with no ignore patterns

## Test plan
- [ ] Verify cloud build succeeds for an agent with `.dockerignore` present (no behavior change)
- [ ] Verify cloud build succeeds for an agent without `.dockerignore` (previously crashed, now warns and continues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `dockerignore_path.exists()` guard in `BuildContextManager.__enter__` so a missing `.dockerignore` file emits a warning and falls back to an empty ignore-patterns list instead of raising `FileNotFoundError`. The change is minimal, correctly scoped, and the existing `ignore_patterns = []` initialisation on line 92 ensures directory-copy logic downstream still receives a valid list.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — fix is minimal, correct, and handles the missing-file case gracefully with no regressions.

No P0 or P1 findings. The existence check is correctly placed, `ignore_patterns` is already initialised to `[]` before the guard so downstream logic is unaffected, and the warning follows the f-string logging convention used throughout the file.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The new warning log records a local file path, which is expected and benign in a build-tool context.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/sdk/config/agent_manifest.py | Adds existence check before copying/parsing `.dockerignore`; gracefully warns and continues when file is absent. Logic is correct and consistent with the rest of the file's f-string logging style. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[__enter__ called] --> B[Copy Dockerfile to temp dir]
    B --> C{dockerignore path configured?}
    C -- No --> F[ignore_patterns = empty list]
    C -- Yes --> D{dockerignore_path.exists?}
    D -- Yes --> E[Copy .dockerignore and extract patterns]
    D -- No --> G[Log warning, keep ignore_patterns empty]
    E --> H[add_directory for each include_path]
    F --> H
    G --> H
    H --> I[Return self]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix crash when .dockerignore file is mis..."](https://github.com/scaleapi/scale-agentex-python/commit/ba91e9ca3faf78fd98d931dadeb002aa9f7f76c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27807542)</sub>

<!-- /greptile_comment -->