### PR TITLE
fix(temporal): allowing-ACP-temporal-telemetry

### DIFF
--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -89,16 +89,17 @@ def _validate_interceptors(interceptors: list) -> None:
             )
 
 
-async def get_temporal_client(temporal_address: str, metrics_url: str | None = None, plugins: list = []) -> Client:
+async def get_temporal_client(
+    temporal_address: str, metrics_url: str | None = None, plugins: list = []
+) -> Client:
     if plugins != []:  # We don't need to validate the plugins if they are empty
         _validate_plugins(plugins)
 
     # Check if OpenAI plugin is present - it needs to configure its own data converter
     # Lazy import to avoid pulling in opentelemetry.sdk for non-Temporal agents
     from temporalio.contrib.openai_agents import OpenAIAgentsPlugin
-    has_openai_plugin = any(
-        isinstance(p, OpenAIAgentsPlugin) for p in (plugins or [])
-    )
+
+    has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
     # Build connection kwargs
     connect_kwargs = {
@@ -113,7 +114,9 @@ async def get_temporal_client(temporal_address: str, metrics_url: str | None = N
     if not metrics_url:
         client = await Client.connect(**connect_kwargs)
     else:
-        runtime = Runtime(telemetry=TelemetryConfig(metrics=OpenTelemetryConfig(url=metrics_url)))
+        runtime = Runtime(
+            telemetry=TelemetryConfig(metrics=OpenTelemetryConfig(url=metrics_url))
+        )
         connect_kwargs["runtime"] = runtime
         client = await Client.connect(**connect_kwargs)
     return client
@@ -128,6 +131,7 @@ class AgentexWorker:
         health_check_port: int | None = None,
         plugins: list = [],
         interceptors: list = [],
+        metrics_url: str | None = None,
     ):
         self.task_queue = task_queue
         self.activity_handles = []
@@ -135,9 +139,14 @@ class AgentexWorker:
         self.max_concurrent_activities = max_concurrent_activities
         self.health_check_server_running = False
         self.healthy = False
-        self.health_check_port = health_check_port if health_check_port is not None else EnvironmentVariables.refresh().HEALTH_CHECK_PORT
+        self.health_check_port = (
+            health_check_port
+            if health_check_port is not None
+            else EnvironmentVariables.refresh().HEALTH_CHECK_PORT
+        )
         self.plugins = plugins
         self.interceptors = interceptors
+        self.metrics_url = metrics_url
 
     @overload
     async def run(
@@ -172,12 +181,17 @@ class AgentexWorker:
         temporal_client = await get_temporal_client(
             temporal_address=os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"),
             plugins=self.plugins,
+            metrics_url=self.metrics_url,
         )
 
         # Enable debug mode if AgentEx debug is enabled (disables deadlock detection)
-        debug_enabled = os.environ.get("AGENTEX_DEBUG_ENABLED", "false").lower() == "true"
+        debug_enabled = (
+            os.environ.get("AGENTEX_DEBUG_ENABLED", "false").lower() == "true"
+        )
         if debug_enabled:
-            logger.info("🐛 [WORKER] Temporal debug mode enabled - deadlock detection disabled")
+            logger.info(
+                "🐛 [WORKER] Temporal debug mode enabled - deadlock detection disabled"
+            )
 
         if workflow is None and workflows is None:
             raise ValueError("Either workflow or workflows must be provided")
@@ -207,7 +221,9 @@ class AgentexWorker:
     async def start_health_check_server(self):
         if not self.health_check_server_running:
             app = web.Application()
-            app.router.add_get("/readyz", lambda request: self._health_check())  # noqa: ARG005
+            app.router.add_get(
+                "/readyz", lambda request: self._health_check()
+            )  # noqa: ARG005
 
             # Disable access logging
             runner = web.AppRunner(app, access_log=None)
@@ -216,19 +232,27 @@ class AgentexWorker:
             try:
                 site = web.TCPSite(runner, "0.0.0.0", self.health_check_port)
                 await site.start()
-                logger.info(f"Health check server running on http://0.0.0.0:{self.health_check_port}/readyz")
+                logger.info(
+                    f"Health check server running on http://0.0.0.0:{self.health_check_port}/readyz"
+                )
                 self.health_check_server_running = True
             except OSError as e:
-                logger.error(f"Failed to start health check server on port {self.health_check_port}: {e}")
+                logger.error(
+                    f"Failed to start health check server on port {self.health_check_port}: {e}"
+                )
                 # Try alternative port if default fails
                 try:
                     alt_port = self.health_check_port + 1
                     site = web.TCPSite(runner, "0.0.0.0", alt_port)
                     await site.start()
-                    logger.info(f"Health check server running on alternative port http://0.0.0.0:{alt_port}/readyz")
+                    logger.info(
+                        f"Health check server running on alternative port http://0.0.0.0:{alt_port}/readyz"
+                    )
                     self.health_check_server_running = True
                 except OSError as e:
-                    logger.error(f"Failed to start health check server on alternative port {alt_port}: {e}")
+                    logger.error(
+                        f"Failed to start health check server on alternative port {alt_port}: {e}"
+                    )
                     raise
 
     """


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes the existing `metrics_url` parameter (already supported by `get_temporal_client`) through `AgentexWorker.__init__`, stores it as `self.metrics_url`, and passes it to `get_temporal_client()` in `run()`. The remaining diff is purely formatting (line-length wrapping to satisfy the linter).

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the functional change is correct and limited in scope; both findings are P2 style suggestions.

The core fix (wiring `metrics_url` through `AgentexWorker` to `get_temporal_client`) is correct and straightforward. All remaining feedback is P2: a Runtime singleton pattern for efficiency, and an optional env-var fallback. Neither affects correctness in the normal worker lifecycle.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/temporal/workers/worker.py | Adds `metrics_url` to `AgentexWorker.__init__` and wires it through to `get_temporal_client()`; no env-var fallback unlike `TEMPORAL_ADDRESS`, and `Runtime` is instantiated fresh on every `run()` call. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant AgentexWorker
    participant get_temporal_client
    participant Runtime
    participant Client

    Caller->>AgentexWorker: __init__(task_queue, ..., metrics_url)
    Note over AgentexWorker: stores self.metrics_url

    Caller->>AgentexWorker: run(activities, workflow=...)
    AgentexWorker->>get_temporal_client: get_temporal_client(temporal_address, plugins, metrics_url)

    alt metrics_url is None
        get_temporal_client->>Client: Client.connect(**connect_kwargs)
    else metrics_url provided
        get_temporal_client->>Runtime: Runtime(telemetry=TelemetryConfig(...))
        get_temporal_client->>Client: Client.connect(**connect_kwargs, runtime=runtime)
    end

    Client-->>get_temporal_client: client
    get_temporal_client-->>AgentexWorker: client
    AgentexWorker->>AgentexWorker: Worker(..., client=client).run()
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fworkers%2Fworker.py%3A114-121%0A**%60Runtime%60%20created%20fresh%20on%20every%20call%20%E2%80%94%20consider%20a%20module-level%20singleton**%0A%0AA%20new%20%60Runtime%60%20%28with%20its%20own%20thread%20pool%20and%20OTEL%20exporter%20connection%29%20is%20instantiated%20every%20time%20%60get_temporal_client%60%20is%20called%20with%20a%20%60metrics_url%60.%20For%20the%20normal%20worker%20lifecycle%20this%20happens%20once%2C%20so%20it's%20harmless%20in%20production%3B%20but%20in%20tests%20or%20anywhere%20the%20function%20is%20called%20more%20than%20once%20the%20runtimes%20accumulate%20and%20waste%20resources.%20The%20Temporal%20Python%20SDK%20docs%20recommend%20creating%20the%20runtime%20once%20per%20process.%0A%0A%60%60%60python%0A_runtime_cache%3A%20dict%5Bstr%2C%20Runtime%5D%20%3D%20%7B%7D%0A%0Adef%20_get_or_create_runtime%28metrics_url%3A%20str%29%20-%3E%20Runtime%3A%0A%20%20%20%20if%20metrics_url%20not%20in%20_runtime_cache%3A%0A%20%20%20%20%20%20%20%20_runtime_cache%5Bmetrics_url%5D%20%3D%20Runtime%28%0A%20%20%20%20%20%20%20%20%20%20%20%20telemetry%3DTelemetryConfig%28metrics%3DOpenTelemetryConfig%28url%3Dmetrics_url%29%29%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20return%20_runtime_cache%5Bmetrics_url%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fworkers%2Fworker.py%3A181-185%0A**%60metrics_url%60%20has%20no%20env-var%20fallback%20unlike%20%60TEMPORAL_ADDRESS%60**%0A%0A%60TEMPORAL_ADDRESS%60%20falls%20back%20to%20%60os.environ.get%28%22TEMPORAL_ADDRESS%22%2C%20%22localhost%3A7233%22%29%60%20inside%20%60run%28%29%60%2C%20but%20%60metrics_url%60%20must%20be%20passed%20explicitly%20through%20the%20constructor.%20If%20a%20deployment%20sets%20the%20metrics%20endpoint%20via%20an%20environment%20variable%20%28a%20common%20pattern%20for%2012-factor%20apps%29%2C%20telemetry%20will%20silently%20not%20be%20enabled.%20Consider%20reading%20a%20fallback%20like%20%60os.environ.get%28%22TEMPORAL_METRICS_URL%22%29%60%20when%20%60self.metrics_url%60%20is%20%60None%60.%0A%0A%60%60%60python%0Ametrics_url%3Dself.metrics_url%20or%20os.environ.get%28%22TEMPORAL_METRICS_URL%22%29%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fworkers%2Fworker.py%3A114-121%0A**%60Runtime%60%20created%20fresh%20on%20every%20call%20%E2%80%94%20consider%20a%20module-level%20singleton**%0A%0AA%20new%20%60Runtime%60%20%28with%20its%20own%20thread%20pool%20and%20OTEL%20exporter%20connection%29%20is%20instantiated%20every%20time%20%60get_temporal_client%60%20is%20called%20with%20a%20%60metrics_url%60.%20For%20the%20normal%20worker%20lifecycle%20this%20happens%20once%2C%20so%20it's%20harmless%20in%20production%3B%20but%20in%20tests%20or%20anywhere%20the%20function%20is%20called%20more%20than%20once%20the%20runtimes%20accumulate%20and%20waste%20resources.%20The%20Temporal%20Python%20SDK%20docs%20recommend%20creating%20the%20runtime%20once%20per%20process.%0A%0A%60%60%60python%0A_runtime_cache%3A%20dict%5Bstr%2C%20Runtime%5D%20%3D%20%7B%7D%0A%0Adef%20_get_or_create_runtime%28metrics_url%3A%20str%29%20-%3E%20Runtime%3A%0A%20%20%20%20if%20metrics_url%20not%20in%20_runtime_cache%3A%0A%20%20%20%20%20%20%20%20_runtime_cache%5Bmetrics_url%5D%20%3D%20Runtime%28%0A%20%20%20%20%20%20%20%20%20%20%20%20telemetry%3DTelemetryConfig%28metrics%3DOpenTelemetryConfig%28url%3Dmetrics_url%29%29%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20return%20_runtime_cache%5Bmetrics_url%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fworkers%2Fworker.py%3A181-185%0A**%60metrics_url%60%20has%20no%20env-var%20fallback%20unlike%20%60TEMPORAL_ADDRESS%60**%0A%0A%60TEMPORAL_ADDRESS%60%20falls%20back%20to%20%60os.environ.get%28%22TEMPORAL_ADDRESS%22%2C%20%22localhost%3A7233%22%29%60%20inside%20%60run%28%29%60%2C%20but%20%60metrics_url%60%20must%20be%20passed%20explicitly%20through%20the%20constructor.%20If%20a%20deployment%20sets%20the%20metrics%20endpoint%20via%20an%20environment%20variable%20%28a%20common%20pattern%20for%2012-factor%20apps%29%2C%20telemetry%20will%20silently%20not%20be%20enabled.%20Consider%20reading%20a%20fallback%20like%20%60os.environ.get%28%22TEMPORAL_METRICS_URL%22%29%60%20when%20%60self.metrics_url%60%20is%20%60None%60.%0A%0A%60%60%60python%0Ametrics_url%3Dself.metrics_url%20or%20os.environ.get%28%22TEMPORAL_METRICS_URL%22%29%2C%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex-python"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/agentex/lib/core/temporal/workers/worker.py
Line: 114-121

Comment:
**`Runtime` created fresh on every call — consider a module-level singleton**

A new `Runtime` (with its own thread pool and OTEL exporter connection) is instantiated every time `get_temporal_client` is called with a `metrics_url`. For the normal worker lifecycle this happens once, so it's harmless in production; but in tests or anywhere the function is called more than once the runtimes accumulate and waste resources. The Temporal Python SDK docs recommend creating the runtime once per process.

```python
_runtime_cache: dict[str, Runtime] = {}

def _get_or_create_runtime(metrics_url: str) -> Runtime:
    if metrics_url not in _runtime_cache:
        _runtime_cache[metrics_url] = Runtime(
            telemetry=TelemetryConfig(metrics=OpenTelemetryConfig(url=metrics_url))
        )
    return _runtime_cache[metrics_url]
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/agentex/lib/core/temporal/workers/worker.py
Line: 181-185

Comment:
**`metrics_url` has no env-var fallback unlike `TEMPORAL_ADDRESS`**

`TEMPORAL_ADDRESS` falls back to `os.environ.get("TEMPORAL_ADDRESS", "localhost:7233")` inside `run()`, but `metrics_url` must be passed explicitly through the constructor. If a deployment sets the metrics endpoint via an environment variable (a common pattern for 12-factor apps), telemetry will silently not be enabled. Consider reading a fallback like `os.environ.get("TEMPORAL_METRICS_URL")` when `self.metrics_url` is `None`.

```python
metrics_url=self.metrics_url or os.environ.get("TEMPORAL_METRICS_URL"),
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(temporal): allowing-ACP-temporal-tel..."](https://github.com/scaleapi/scale-agentex-python/commit/1f81521362c3f1dd931c15ddb133481eeaaba2f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28026967)</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->