### PR TITLE
fix(temporal): allowing-ACP-temporal-telemetry

### DIFF
--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -128,6 +128,7 @@ class AgentexWorker:
         health_check_port: int | None = None,
         plugins: list = [],
         interceptors: list = [],
+        metrics_url: str | None = None,
     ):
         self.task_queue = task_queue
         self.activity_handles = []
@@ -138,6 +139,7 @@ class AgentexWorker:
         self.health_check_port = health_check_port if health_check_port is not None else EnvironmentVariables.refresh().HEALTH_CHECK_PORT
         self.plugins = plugins
         self.interceptors = interceptors
+        self.metrics_url = metrics_url
 
     @overload
     async def run(
@@ -172,6 +174,7 @@ class AgentexWorker:
         temporal_client = await get_temporal_client(
             temporal_address=os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"),
             plugins=self.plugins,
+            metrics_url=self.metrics_url,
         )
 
         # Enable debug mode if AgentEx debug is enabled (disables deadlock detection)


### PR DESCRIPTION
# Summary
Plumb metrics_url string through to AgentexWorker into get_temporal_client and leverage out-of-the-box temporal metrics through a push model. 

get_temporal_client already supports an optional metrics_url and configures the Temporal Python SDK runtime with OpenTelemetry metrics when it is set. AgentexWorker did not expose that parameter, so worker-based runs could not pass a metrics endpoint even though the client helper could use one.

This allows the same pattern as seen [here](https://github.com/scaleapi/scaleapi/blob/master/packages/egp-api-backend/egp_api_backend/server/utils/temporal_client.py#L28) to instrument temporal workers with an OTEL endpoint. 

This change adds an optional metrics_url on AgentexWorker and forwards it when creating the Temporal client, so workers can emit Temporal telemetry (e.g. for ACP / observability) the same way other code paths can.

Scope: src/agentex/lib/core/temporal/workers/worker.py only (+3 lines: constructor arg, instance field, and call argument).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR plumbs an optional `metrics_url` parameter through `AgentexWorker.__init__` → `self.metrics_url` → `get_temporal_client`, enabling Temporal SDK OpenTelemetry metric emission from worker-based runs. The change is minimal (3 lines), follows the existing pattern already implemented in `get_temporal_client`, and is correctly scoped to `worker.py`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it is a minimal, focused 3-line change that wires an already-supported parameter through one additional layer.

The change follows the exact same pattern already present in `get_temporal_client`, introduces no new logic, and has no edge-case concerns. No P0/P1 findings were identified.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/temporal/workers/worker.py | Adds optional `metrics_url` constructor arg to `AgentexWorker` and forwards it to `get_temporal_client`; follows existing pattern exactly, no issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant AgentexWorker
    participant get_temporal_client
    participant TemporalRuntime
    participant TemporalClient

    Caller->>AgentexWorker: __init__(metrics_url=..., ...)
    AgentexWorker->>AgentexWorker: self.metrics_url = metrics_url
    Caller->>AgentexWorker: run(activities, workflow=...)
    AgentexWorker->>get_temporal_client: get_temporal_client(temporal_address, plugins, metrics_url)
    alt metrics_url is set
        get_temporal_client->>TemporalRuntime: Runtime(TelemetryConfig(OpenTelemetryConfig(url=metrics_url)))
        get_temporal_client->>TemporalClient: Client.connect(..., runtime=runtime)
    else metrics_url is None
        get_temporal_client->>TemporalClient: Client.connect(...)
    end
    get_temporal_client-->>AgentexWorker: client
    AgentexWorker->>AgentexWorker: Worker(client, ...)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(temporal): allowing-ACP-temporal-tel..."](https://github.com/scaleapi/scale-agentex-python/commit/9b44eb0f5c6482984f972674d7a8612980c5b576) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28027710)</sub>

<!-- /greptile_comment -->