### PR TITLE
fix(tutorial_test): allow tool_request & tool_retrieves to be read be…

### DIFF
--- a/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
+++ b/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
@@ -118,8 +118,11 @@ class TestNonStreamingEvents:
                 content_length = len(str(agent_text))
                 final_message = message
 
-                # Stop when we get DONE status
+                # Stop when we get DONE status (after tool_response if a tool was used;
+                # tool rows can appear on a later poll than final text).
                 if message.streaming_status == "DONE" and content_length > 0:
+                    if seen_tool_request and not seen_tool_response:
+                        continue
                     break
 
         # Verify we got all the expected pieces

--- a/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py
+++ b/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py
@@ -148,9 +148,12 @@ class TestNonStreamingEvents:
             if message.content and message.content.type == "text" and message.content.author == "agent":
                 content_length = len(message.content.content) if message.content.content else 0
 
-                # Stop when we get DONE status with actual content
+                # Stop when we get DONE with content (after tool_response if a tool ran;
+                # tool rows can appear on a later poll than final text).
                 if message.streaming_status == "DONE" and content_length > 0:
                     found_final_response = True
+                    if seen_tool_request and not seen_tool_response:
+                        continue
                     break
 
         # Verify that we saw the complete flow: tool_request -> human approval -> tool_response -> final answer

--- a/examples/tutorials/test_utils/async_utils.py
+++ b/examples/tutorials/test_utils/async_utils.py
@@ -19,6 +19,20 @@ from agentex.types.agent_rpc_result import StreamTaskMessageDone, StreamTaskMess
 from agentex.types.text_content_param import TextContentParam
 
 
+def _task_message_poll_sort_key(message: TaskMessage) -> tuple[int, datetime]:
+    """Order messages within one poll so tool lifecycle rows precede other content.
+
+    Streaming assistant ``text`` rows are often created before ``tool_request`` /
+    ``tool_response`` rows from the same model turn (earlier ``created_at``). Sorting
+    only by ``created_at`` makes consumers that ``break`` on DONE agent text exit the
+    poll generator before tool rows in the same ``list()`` batch are yielded.
+    """
+    ts = message.created_at if message.created_at else datetime.min.replace(tzinfo=timezone.utc)
+    ctype = getattr(message.content, "type", None) if message.content else None
+    phase = 0 if ctype in ("tool_request", "tool_response") else 1
+    return (phase, ts)
+
+
 async def send_event_and_poll_yielding(
     client: AsyncAgentex,
     agent_id: str,
@@ -90,7 +104,11 @@ async def poll_messages(
                       If False, only yield each message ID once (default: False)
 
     Yields:
-        TaskMessage objects as they are discovered or updated
+        TaskMessage objects as they are discovered or updated.
+
+    Within each poll, ``tool_request`` and ``tool_response`` messages are yielded before
+    other types (when present in the same batch), so streaming tests can stop on DONE
+    agent text without missing tool lifecycle rows.
     """
     # Keep track of messages we've already yielded
     seen_message_ids = set()
@@ -102,12 +120,9 @@ async def poll_messages(
     while (datetime.now() - start_time).seconds < timeout:
         messages = await client.messages.list(task_id=task_id)
 
-        # Sort messages by created_at to ensure chronological order
-        # Use datetime.min for messages without created_at timestamp
-        sorted_messages = sorted(
-            messages,
-            key=lambda m: m.created_at if m.created_at else datetime.min.replace(tzinfo=timezone.utc)
-        )
+        # Sort so tool_request / tool_response appear before agent text in the same poll;
+        # then by created_at (see _task_message_poll_sort_key).
+        sorted_messages = sorted(messages, key=_task_message_poll_sort_key)
 
         new_messages_found = 0
         for message in sorted_messages:

--- a/examples/tutorials/test_utils/async_utils.py
+++ b/examples/tutorials/test_utils/async_utils.py
@@ -17,19 +17,26 @@ from agentex.types.task_message import TaskMessage
 from agentex.types.agent_rpc_params import ParamsSendEventRequest
 from agentex.types.agent_rpc_result import StreamTaskMessageDone, StreamTaskMessageFull
 from agentex.types.text_content_param import TextContentParam
+from agentex.types.tool_request_content import ToolRequestContent
+from agentex.types.tool_response_content import ToolResponseContent
 
 
-def _task_message_poll_sort_key(message: TaskMessage) -> tuple[int, datetime]:
-    """Order messages within one poll so tool lifecycle rows precede other content.
+def _is_tool_lifecycle_message(message: TaskMessage) -> bool:
+    """True for tool request/response rows (by model type or ``content.type`` string)."""
+    c = message.content
+    if c is None:
+        return False
+    if isinstance(c, (ToolRequestContent, ToolResponseContent)):
+        return True
+    ctype = getattr(c, "type", None)
+    return ctype in ("tool_request", "tool_response")
 
-    Streaming assistant ``text`` rows are often created before ``tool_request`` /
-    ``tool_response`` rows from the same model turn (earlier ``created_at``). Sorting
-    only by ``created_at`` makes consumers that ``break`` on DONE agent text exit the
-    poll generator before tool rows in the same ``list()`` batch are yielded.
-    """
-    ts = message.created_at if message.created_at else datetime.min.replace(tzinfo=timezone.utc)
-    ctype = getattr(message.content, "type", None) if message.content else None
-    phase = 0 if ctype in ("tool_request", "tool_response") else 1
+
+def _pending_poll_sort_key(item: tuple[TaskMessage, int | None]) -> tuple[int, datetime]:
+    """Yield tool lifecycle messages before other content in the same poll batch."""
+    m, _ = item
+    ts = m.created_at if m.created_at else datetime.min.replace(tzinfo=timezone.utc)
+    phase = 0 if _is_tool_lifecycle_message(m) else 1
     return (phase, ts)
 
 
@@ -106,12 +113,14 @@ async def poll_messages(
     Yields:
         TaskMessage objects as they are discovered or updated.
 
-    Within each poll, ``tool_request`` and ``tool_response`` messages are yielded before
-    other types (when present in the same batch), so streaming tests can stop on DONE
-    agent text without missing tool lifecycle rows.
+    Within each poll, messages to emit are collected first, then re-ordered so
+    ``tool_request`` / ``tool_response`` rows are yielded before other content in that
+    batch. ``tool_response`` can also appear on a later poll than final assistant text;
+    callers that ``break`` on DONE text should keep polling until they have seen
+    ``tool_response`` after a ``tool_request`` (see tutorial tests).
     """
     # Keep track of messages we've already yielded
-    seen_message_ids = set()
+    seen_message_ids: set[str] = set()
     # Track message content hashes to detect updates (for streaming)
     message_content_hashes: dict[str, int] = {}
     start_time = datetime.now()
@@ -120,11 +129,15 @@ async def poll_messages(
     while (datetime.now() - start_time).seconds < timeout:
         messages = await client.messages.list(task_id=task_id)
 
-        # Sort so tool_request / tool_response appear before agent text in the same poll;
-        # then by created_at (see _task_message_poll_sort_key).
-        sorted_messages = sorted(messages, key=_task_message_poll_sort_key)
+        sorted_messages = sorted(
+            messages,
+            key=lambda m: m.created_at if m.created_at else datetime.min.replace(tzinfo=timezone.utc),
+        )
 
-        new_messages_found = 0
+        # Collect (message, hash) for this poll without mutating dedupe state yet, then
+        # yield tool lifecycle rows before streaming text / other updates in the same batch.
+        pending: list[tuple[TaskMessage, int | None]] = []
+
         for message in sorted_messages:
             # Check if message passes timestamp filter
             if messages_created_after and message.created_at:
@@ -156,16 +169,22 @@ async def poll_messages(
                 is_updated = message.id in message_content_hashes and message_content_hashes[message.id] != content_hash
 
                 if is_new_message or is_updated:
-                    message_content_hashes[message.id] = content_hash
-                    seen_message_ids.add(message.id)
-                    new_messages_found += 1
-                    yield message
+                    pending.append((message, content_hash))
             else:
                 # Original behavior: only yield each message ID once
                 if is_new_message:
-                    seen_message_ids.add(message.id)
-                    new_messages_found += 1
-                    yield message
+                    pending.append((message, None))
+
+        pending.sort(key=_pending_poll_sort_key)
+
+        for message, content_hash in pending:
+            mid = message.id
+            if not mid:
+                continue
+            if yield_updates and content_hash is not None:
+                message_content_hashes[mid] = content_hash
+            seen_message_ids.add(mid)
+            yield message
 
         # Sleep before next poll
         await asyncio.sleep(sleep_interval)


### PR DESCRIPTION
…fore final message in message order

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition in tutorial tests where `tool_request`/`tool_response` messages could appear on a later poll than the final DONE text message. It does this by (1) refactoring `poll_messages` to collect a per-poll batch, sort tool lifecycle rows to the front via `_pending_poll_sort_key`, and only then yield; and (2) adding a `continue` guard in both tutorial tests that keeps polling when the DONE checkpoint is reached but `tool_response` hasn't been seen yet.

The intra-batch sort in `async_utils.py` is solid, but the `continue` guard in the tests has a gap: once it fires and `tool_response` finally arrives on a later poll, the DONE text message won't be re-yielded (`yield_updates=True` caches its hash), so there is no remaining `break` path and both tests would poll until their full timeout (60 s / 120 s).

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor fix — core utility change is correct, but the `continue` guard in both tests can cause up to 60–120 s of unnecessary polling when `tool_response` lags across poll boundaries.
- The `async_utils.py` refactor is correct and well-structured. The two P2 findings in the test files describe a performance bug (not a correctness bug) where the test passes but wastes the full timeout duration in a specific race condition. Worth fixing before merging to avoid flaky-slow CI runs.
- Both tutorial test files need a secondary `break` when `tool_response` arrives after the DONE text checkpoint has already been set.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/tutorials/test_utils/async_utils.py | Refactors `poll_messages` to collect pending messages per poll batch, sort tool lifecycle rows first via `_pending_poll_sort_key`, then yield — correctly delays dedupe-state mutation until after the sort. New helpers `_is_tool_lifecycle_message` and `_pending_poll_sort_key` are well-typed and defensively implemented. |
| examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py | Adds a `continue` guard at the DONE checkpoint to keep polling when `tool_response` hasn't arrived yet. The guard itself is correct but leaves no break path once `tool_response` eventually arrives; with `yield_updates=True` the DONE message won't be re-yielded, so the test will poll until the full 60 s timeout in that scenario. |
| examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py | Same `continue` guard pattern as tutorial 070, with the additional nuance that `found_final_response=True` is set before the guard check. Carries the same polling-until-timeout problem when `tool_response` lags the DONE text across poll boundaries; worst case adds 120 s to the test run. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test loop
    participant G as poll_messages generator
    participant API as AgentEx API

    Note over G: Poll N
    G->>API: messages.list()
    API-->>G: [tool_request, DONE_text] (same batch)
    Note over G: _pending_poll_sort_key reorders:<br/>tool_request first, then DONE_text
    G-->>T: "yield tool_request → seen_tool_request=True"
    G-->>T: yield DONE_text
    T->>T: "guard: seen_tool_request=True, seen_tool_response=False → continue"

    Note over G: Poll N+1
    G->>API: messages.list()
    API-->>G: [tool_response] (new)
    G-->>T: "yield tool_response → seen_tool_response=True"
    T->>T: ⚠️ No break path — DONE_text hash cached, won't be re-yielded

    loop Until timeout (60s / 120s)
        G->>API: messages.list()
        API-->>G: [same messages, no new]
        Note over G: DONE_text: is_updated=False (same hash) → skipped
    end
    Note over T: Generator exhausts → assertions run (all pass, but slow)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F070_open_ai_agents_sdk_tools%2Ftests%2Ftest_agent.py%3A108-126%0A**%60continue%60%20guard%20leaves%20no%20exit%20path%20after%20%60tool_response%60%20arrives**%0A%0AWhen%20%60tool_response%60%20lands%20on%20a%20later%20poll%20than%20the%20DONE%20text%20message%2C%20the%20guard%20fires%20%28%60continue%60%29%20on%20line%20125.%20But%20because%20%60yield_updates%3DTrue%60%20stores%20the%20DONE%20message's%20content%20hash%2C%20%60poll_messages%60%20will%20never%20re-yield%20it%20%28same%20%60content_hash%60%20%E2%86%92%20%60is_updated%3DFalse%60%29.%20Once%20%60tool_response%60%20is%20eventually%20received%20and%20%60seen_tool_response%3DTrue%60%2C%20there%20is%20no%20remaining%20%60break%60%20path%2C%20so%20the%20test%20keeps%20polling%20until%20the%20full%2060-second%20timeout%20expires.%0A%0AAdd%20a%20break%20when%20%60tool_response%60%20arrives%20and%20the%20final%20message%20has%20already%20been%20seen%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20tool_request%20messages%20%28agent%20calling%20get_weather%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_request%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20seen_tool_request%20%3D%20True%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20tool_response%20messages%20%28get_weather%20result%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_response%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20seen_tool_response%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20If%20we%20already%20passed%20the%20DONE%20text%20checkpoint%20%28guard%20fired%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20we%20have%20everything%20we%20need%20now%20%E2%80%94%20stop%20polling.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20final_message%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20agent%20text%20messages%20and%20their%20streaming%20updates%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22text%22%20and%20message.content.author%20%3D%3D%20%22agent%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20agent_text%20%3D%20getattr%28message.content%2C%20%22content%22%2C%20%22%22%29%20or%20%22%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20content_length%20%3D%20len%28str%28agent_text%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20final_message%20%3D%20message%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Stop%20when%20we%20get%20DONE%20status%20%28after%20tool_response%20if%20a%20tool%20was%20used%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20tool%20rows%20can%20appear%20on%20a%20later%20poll%20than%20final%20text%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20message.streaming_status%20%3D%3D%20%22DONE%22%20and%20content_length%20%3E%200%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20seen_tool_request%20and%20not%20seen_tool_response%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20continue%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Cursor%22%20links%20for%20remaining%20issues.%29%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F070_open_ai_agents_sdk_tools%2Ftests%2Ftest_agent.py%3A108-126%0A**%60continue%60%20guard%20leaves%20no%20exit%20path%20after%20%60tool_response%60%20arrives**%0A%0AWhen%20%60tool_response%60%20lands%20on%20a%20later%20poll%20than%20the%20DONE%20text%20message%2C%20the%20guard%20fires%20%28%60continue%60%29%20on%20line%20125.%20But%20because%20%60yield_updates%3DTrue%60%20stores%20the%20DONE%20message's%20content%20hash%2C%20%60poll_messages%60%20will%20never%20re-yield%20it%20%28same%20%60content_hash%60%20%E2%86%92%20%60is_updated%3DFalse%60%29.%20Once%20%60tool_response%60%20is%20eventually%20received%20and%20%60seen_tool_response%3DTrue%60%2C%20there%20is%20no%20remaining%20%60break%60%20path%2C%20so%20the%20test%20keeps%20polling%20until%20the%20full%2060-second%20timeout%20expires.%0A%0AAdd%20a%20break%20when%20%60tool_response%60%20arrives%20and%20the%20final%20message%20has%20already%20been%20seen%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20tool_request%20messages%20%28agent%20calling%20get_weather%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_request%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20seen_tool_request%20%3D%20True%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20tool_response%20messages%20%28get_weather%20result%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_response%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20seen_tool_response%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20If%20we%20already%20passed%20the%20DONE%20text%20checkpoint%20%28guard%20fired%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20we%20have%20everything%20we%20need%20now%20%E2%80%94%20stop%20polling.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20final_message%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20agent%20text%20messages%20and%20their%20streaming%20updates%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22text%22%20and%20message.content.author%20%3D%3D%20%22agent%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20agent_text%20%3D%20getattr%28message.content%2C%20%22content%22%2C%20%22%22%29%20or%20%22%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20content_length%20%3D%20len%28str%28agent_text%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20final_message%20%3D%20message%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Stop%20when%20we%20get%20DONE%20status%20%28after%20tool_response%20if%20a%20tool%20was%20used%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20tool%20rows%20can%20appear%20on%20a%20later%20poll%20than%20final%20text%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20message.streaming_status%20%3D%3D%20%22DONE%22%20and%20content_length%20%3E%200%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20seen_tool_request%20and%20not%20seen_tool_response%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20continue%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F080_open_ai_agents_sdk_human_in_the_loop%2Ftests%2Ftest_agent.py%3A144-157%0A**%60continue%60%20guard%20leaves%20no%20exit%20path%20after%20%60tool_response%60%20arrives**%0A%0ASame%20issue%20as%20tutorial%20070%3A%20when%20%60tool_response%60%20lands%20on%20a%20later%20poll%20than%20the%20DONE%20text%20message%20the%20guard%20fires%20and%20%60continue%60s.%20%60yield_updates%3DTrue%60%20caches%20the%20DONE%20message's%20hash%2C%20so%20it%20won't%20be%20re-yielded%2C%20and%20the%20test%20polls%20until%20the%20120-second%20timeout%20even%20though%20all%20required%20messages%20have%20already%20been%20collected.%0A%0A%60found_final_response%3DTrue%60%20is%20also%20set%20_before_%20the%20guard%20check%3B%20it%20stays%20%60True%60%20even%20on%20the%20slow%20path%2C%20which%20is%20fine%20for%20the%20final%20assertion%20but%20is%20worth%20noting.%0A%0AAdding%20a%20break%20when%20%60tool_response%60%20arrives%20after%20the%20DONE%20checkpoint%20has%20been%20seen%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20tool_request%20messages%20%28agent%20calling%20wait_for_confirmation%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_request%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20seen_tool_request%20%3D%20True%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20approval_signal_sent%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Send%20signal%20to%20child%20workflow%20to%20approve%20the%20order%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20The%20child%20workflow%20ID%20is%20fixed%20as%20%22child-workflow-id%22%20%28see%20tools.py%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Give%20Temporal%20a%20brief%20moment%20to%20materialize%20the%20child%20workflow%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20asyncio.sleep%281%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20handle%20%3D%20temporal_client.get_workflow_handle%28%22child-workflow-id%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20handle.signal%28%22fulfill_order_signal%22%2C%20True%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20approval_signal_sent%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20except%20Exception%20as%20e%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20It's%20okay%20if%20the%20workflow%20completed%20before%20we%20could%20signal%20it.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_%20%3D%20e%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20tool_response%20messages%20%28child%20workflow%20completion%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_response%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20seen_tool_response%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20If%20we%20already%20passed%20the%20DONE%20text%20checkpoint%20%28guard%20fired%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20we%20have%20everything%20we%20need%20now%20%E2%80%94%20stop%20polling.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20found_final_response%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20agent%20text%20messages%20and%20their%20streaming%20updates%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22text%22%20and%20message.content.author%20%3D%3D%20%22agent%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20content_length%20%3D%20len%28message.content.content%29%20if%20message.content.content%20else%200%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Stop%20when%20we%20get%20DONE%20with%20content%20%28after%20tool_response%20if%20a%20tool%20ran%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20tool%20rows%20can%20appear%20on%20a%20later%20poll%20than%20final%20text%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20message.streaming_status%20%3D%3D%20%22DONE%22%20and%20content_length%20%3E%200%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20found_final_response%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20seen_tool_request%20and%20not%20seen_tool_response%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20continue%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex-python"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
Line: 108-126

Comment:
**`continue` guard leaves no exit path after `tool_response` arrives**

When `tool_response` lands on a later poll than the DONE text message, the guard fires (`continue`) on line 125. But because `yield_updates=True` stores the DONE message's content hash, `poll_messages` will never re-yield it (same `content_hash` → `is_updated=False`). Once `tool_response` is eventually received and `seen_tool_response=True`, there is no remaining `break` path, so the test keeps polling until the full 60-second timeout expires.

Add a break when `tool_response` arrives and the final message has already been seen:

```suggestion
            # Track tool_request messages (agent calling get_weather)
            if message.content and message.content.type == "tool_request":
                seen_tool_request = True

            # Track tool_response messages (get_weather result)
            if message.content and message.content.type == "tool_response":
                seen_tool_response = True
                # If we already passed the DONE text checkpoint (guard fired),
                # we have everything we need now — stop polling.
                if final_message is not None:
                    break

            # Track agent text messages and their streaming updates
            if message.content and message.content.type == "text" and message.content.author == "agent":
                agent_text = getattr(message.content, "content", "") or ""
                content_length = len(str(agent_text))
                final_message = message

                # Stop when we get DONE status (after tool_response if a tool was used;
                # tool rows can appear on a later poll than final text).
                if message.streaming_status == "DONE" and content_length > 0:
                    if seen_tool_request and not seen_tool_response:
                        continue
                    break
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py
Line: 144-157

Comment:
**`continue` guard leaves no exit path after `tool_response` arrives**

Same issue as tutorial 070: when `tool_response` lands on a later poll than the DONE text message the guard fires and `continue`s. `yield_updates=True` caches the DONE message's hash, so it won't be re-yielded, and the test polls until the 120-second timeout even though all required messages have already been collected.

`found_final_response=True` is also set _before_ the guard check; it stays `True` even on the slow path, which is fine for the final assertion but is worth noting.

Adding a break when `tool_response` arrives after the DONE checkpoint has been seen:

```suggestion
            # Track tool_request messages (agent calling wait_for_confirmation)
            if message.content and message.content.type == "tool_request":
                seen_tool_request = True

                if not approval_signal_sent:
                    # Send signal to child workflow to approve the order
                    # The child workflow ID is fixed as "child-workflow-id" (see tools.py)
                    # Give Temporal a brief moment to materialize the child workflow
                    await asyncio.sleep(1)
                    try:
                        handle = temporal_client.get_workflow_handle("child-workflow-id")
                        await handle.signal("fulfill_order_signal", True)
                        approval_signal_sent = True
                    except Exception as e:
                        # It's okay if the workflow completed before we could signal it.
                        _ = e

            # Track tool_response messages (child workflow completion)
            if message.content and message.content.type == "tool_response":
                seen_tool_response = True
                # If we already passed the DONE text checkpoint (guard fired),
                # we have everything we need now — stop polling.
                if found_final_response:
                    break

            # Track agent text messages and their streaming updates
            if message.content and message.content.type == "text" and message.content.author == "agent":
                content_length = len(message.content.content) if message.content.content else 0

                # Stop when we get DONE with content (after tool_response if a tool ran;
                # tool rows can appear on a later poll than final text).
                if message.streaming_status == "DONE" and content_length > 0:
                    found_final_response = True
                    if seen_tool_request and not seen_tool_response:
                        continue
                    break
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tutorial\_test): allow tool\_request &amp;..."](https://github.com/scaleapi/scale-agentex-python/commit/5b14d4c5097d6cd20531d018477e1048795aa988) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28342756)</sub>

<!-- /greptile_comment -->