### PR TITLE
fix(test): waiting for tool activity response before assessing tests

### DIFF
--- a/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
+++ b/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
@@ -118,9 +118,12 @@ class TestNonStreamingEvents:
                 content_length = len(str(agent_text))
                 final_message = message
 
-                # Stop when we get DONE status
+                # Stop when we get DONE with content. If the agent invoked a tool, keep polling
+                # until tool_response is visible: the final text can be marked DONE before the
+                # lifecycle activity persists tool_response to the message list.
                 if message.streaming_status == "DONE" and content_length > 0:
-                    break
+                    if not seen_tool_request or seen_tool_response:
+                        break
 
         # Verify we got all the expected pieces
         assert seen_tool_request, "Expected to see tool_request message (agent calling get_weather)"

--- a/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py
+++ b/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py
@@ -148,10 +148,13 @@ class TestNonStreamingEvents:
             if message.content and message.content.type == "text" and message.content.author == "agent":
                 content_length = len(message.content.content) if message.content.content else 0
 
-                # Stop when we get DONE status with actual content
+                # Stop when we get DONE with content. If the agent invoked a tool, keep polling
+                # until tool_response is visible: final text can be marked DONE before the
+                # lifecycle activity persists tool_response to the message list.
                 if message.streaming_status == "DONE" and content_length > 0:
                     found_final_response = True
-                    break
+                    if not seen_tool_request or seen_tool_response:
+                        break
 
         # Verify that we saw the complete flow: tool_request -> human approval -> tool_response -> final answer
         assert seen_tool_request, "Expected to see tool_request message (agent calling wait_for_confirmation)"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a test flakiness issue where the polling loop would break on a `DONE` streaming status before the `tool_response` message was persisted, causing assertions like `assert seen_tool_response` to fail intermittently. The fix correctly holds off breaking when a tool was requested but no response has been seen yet — a well-reasoned guard backed by a clear comment.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — the race-condition guard is logically correct and the only feedback is a P2 performance improvement.
- All remaining findings are P2: in the exact race-condition path the loop drains to the timeout instead of exiting early after tool_response arrives, but the assertions still pass and no data or correctness is affected. Per the scoring guidance, P2-only findings default to 5/5.
- No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py | Correctly guards against a race where DONE arrives before tool_response, but lacks an early-exit when tool_response finally arrives after DONE, causing the test to drain to the 60s timeout in the exact race-condition scenario. |
| examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py | Same race-condition fix and same missing early-exit gap as tutorial 070; `found_final_response` is already available to drive the missing break in the tool_response handler. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Poll: new message received] --> B{message type}
    B -- tool_request --> C[mark tool_request seen]
    B -- tool_response --> D[mark tool_response seen]
    B -- agent text --> E{DONE status with content?}
    C --> A
    D --> A
    E -- No --> A
    E -- Yes --> F{no tool requested\nOR tool response seen?}
    F -- True --> G[break - assertions pass]
    F -- False: tool requested but\nresponse not yet visible --> H[keep polling]
    H --> A
    A -- timeout reached --> I[generator exits cleanly\nbut full timeout elapsed]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F070_open_ai_agents_sdk_tools%2Ftests%2Ftest_agent.py%3A121-126%0A**No%20early%20exit%20after%20%60tool_response%60%20in%20race-condition%20path**%0A%0AWhen%20the%20race%20condition%20actually%20fires%20%28DONE%20arrives%20before%20%60tool_response%60%20is%20persisted%29%2C%20the%20loop%20does%20the%20right%20thing%20and%20keeps%20polling%20%E2%80%94%20but%20once%20%60tool_response%60%20is%20finally%20seen%2C%20%60seen_tool_response%60%20becomes%20%60True%60%20inside%20the%20%60tool_response%60%20branch%20and%20there%20is%20no%20corresponding%20%60break%60.%20The%20%60break%60%20can%20only%20execute%20inside%20the%20%60%22text%22%2F%22DONE%22%60%20block%2C%20and%20the%20agent%20won't%20emit%20a%20second%20DONE%20message.%20So%20in%20that%20exact%20scenario%20the%20test%20will%20keep%20polling%20for%20the%20full%2060-second%20timeout%20before%20the%20generator%20expires%20and%20the%20assertions%20are%20checked.%0A%0AAdding%20an%20early-exit%20in%20the%20%60tool_response%60%20handler%20when%20a%20DONE%20text%20was%20already%20seen%20avoids%20the%20unnecessary%20wait%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Stop%20when%20we%20get%20DONE%20with%20content.%20If%20the%20agent%20invoked%20a%20tool%2C%20keep%20polling%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20until%20tool_response%20is%20visible%3A%20the%20final%20text%20can%20be%20marked%20DONE%20before%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20lifecycle%20activity%20persists%20tool_response%20to%20the%20message%20list.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20message.streaming_status%20%3D%3D%20%22DONE%22%20and%20content_length%20%3E%200%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20seen_tool_request%20or%20seen_tool_response%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20tool_response%20messages%20%28get_weather%20result%29%20%E2%80%94%20placed%20after%20the%20DONE%20check%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20so%20that%20if%20tool_response%20arrives%20after%20DONE%2C%20we%20can%20break%20immediately.%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_response%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20seen_tool_response%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20If%20we%20already%20saw%20the%20final%20DONE%20text%20but%20held%20off%20because%20tool_response%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20hadn't%20arrived%20yet%2C%20we%20can%20safely%20exit%20now.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20final_message%20is%20not%20None%20and%20getattr%28final_message%2C%20%22streaming_status%22%2C%20None%29%20%3D%3D%20%22DONE%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F080_open_ai_agents_sdk_human_in_the_loop%2Ftests%2Ftest_agent.py%3A151-157%0A**No%20early%20exit%20after%20%60tool_response%60%20in%20race-condition%20path**%0A%0ASame%20issue%20as%20tutorial%20070%3A%20when%20DONE%20lands%20before%20%60tool_response%60%20is%20persisted%2C%20the%20loop%20correctly%20keeps%20polling%20%E2%80%94%20but%20after%20%60tool_response%60%20is%20finally%20seen%2C%20%60seen_tool_response%20%3D%20True%60%20is%20set%20inside%20the%20%60tool_response%60%20branch%20with%20no%20break%2C%20and%20the%20agent%20won't%20emit%20a%20second%20DONE%20text.%20The%20test%20will%20keep%20polling%20for%20the%20full%20120-second%20timeout%20before%20the%20generator%20exits.%0A%0AIn%20this%20file%2C%20%60found_final_response%60%20already%20captures%20%22we%20have%20seen%20a%20DONE%20text%22%2C%20so%20the%20fix%20is%20straightforward%20%E2%80%94%20add%20a%20break%20in%20the%20%60tool_response%60%20handler%3A%0A%0A%60%60%60python%0A%23%20Track%20tool_response%20messages%20%28child%20workflow%20completion%29%0Aif%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_response%22%3A%0A%20%20%20%20seen_tool_response%20%3D%20True%0A%20%20%20%20%23%20If%20DONE%20was%20already%20observed%20%28but%20we%20were%20waiting%20for%20tool_response%29%2C%0A%20%20%20%20%23%20we%20can%20exit%20immediately%20instead%20of%20waiting%20for%20the%20timeout.%0A%20%20%20%20if%20found_final_response%3A%0A%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F070_open_ai_agents_sdk_tools%2Ftests%2Ftest_agent.py%3A121-126%0A**No%20early%20exit%20after%20%60tool_response%60%20in%20race-condition%20path**%0A%0AWhen%20the%20race%20condition%20actually%20fires%20%28DONE%20arrives%20before%20%60tool_response%60%20is%20persisted%29%2C%20the%20loop%20does%20the%20right%20thing%20and%20keeps%20polling%20%E2%80%94%20but%20once%20%60tool_response%60%20is%20finally%20seen%2C%20%60seen_tool_response%60%20becomes%20%60True%60%20inside%20the%20%60tool_response%60%20branch%20and%20there%20is%20no%20corresponding%20%60break%60.%20The%20%60break%60%20can%20only%20execute%20inside%20the%20%60%22text%22%2F%22DONE%22%60%20block%2C%20and%20the%20agent%20won't%20emit%20a%20second%20DONE%20message.%20So%20in%20that%20exact%20scenario%20the%20test%20will%20keep%20polling%20for%20the%20full%2060-second%20timeout%20before%20the%20generator%20expires%20and%20the%20assertions%20are%20checked.%0A%0AAdding%20an%20early-exit%20in%20the%20%60tool_response%60%20handler%20when%20a%20DONE%20text%20was%20already%20seen%20avoids%20the%20unnecessary%20wait%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Stop%20when%20we%20get%20DONE%20with%20content.%20If%20the%20agent%20invoked%20a%20tool%2C%20keep%20polling%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20until%20tool_response%20is%20visible%3A%20the%20final%20text%20can%20be%20marked%20DONE%20before%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20lifecycle%20activity%20persists%20tool_response%20to%20the%20message%20list.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20message.streaming_status%20%3D%3D%20%22DONE%22%20and%20content_length%20%3E%200%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20seen_tool_request%20or%20seen_tool_response%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Track%20tool_response%20messages%20%28get_weather%20result%29%20%E2%80%94%20placed%20after%20the%20DONE%20check%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20so%20that%20if%20tool_response%20arrives%20after%20DONE%2C%20we%20can%20break%20immediately.%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_response%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20seen_tool_response%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20If%20we%20already%20saw%20the%20final%20DONE%20text%20but%20held%20off%20because%20tool_response%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20hadn't%20arrived%20yet%2C%20we%20can%20safely%20exit%20now.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20final_message%20is%20not%20None%20and%20getattr%28final_message%2C%20%22streaming_status%22%2C%20None%29%20%3D%3D%20%22DONE%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F080_open_ai_agents_sdk_human_in_the_loop%2Ftests%2Ftest_agent.py%3A151-157%0A**No%20early%20exit%20after%20%60tool_response%60%20in%20race-condition%20path**%0A%0ASame%20issue%20as%20tutorial%20070%3A%20when%20DONE%20lands%20before%20%60tool_response%60%20is%20persisted%2C%20the%20loop%20correctly%20keeps%20polling%20%E2%80%94%20but%20after%20%60tool_response%60%20is%20finally%20seen%2C%20%60seen_tool_response%20%3D%20True%60%20is%20set%20inside%20the%20%60tool_response%60%20branch%20with%20no%20break%2C%20and%20the%20agent%20won't%20emit%20a%20second%20DONE%20text.%20The%20test%20will%20keep%20polling%20for%20the%20full%20120-second%20timeout%20before%20the%20generator%20exits.%0A%0AIn%20this%20file%2C%20%60found_final_response%60%20already%20captures%20%22we%20have%20seen%20a%20DONE%20text%22%2C%20so%20the%20fix%20is%20straightforward%20%E2%80%94%20add%20a%20break%20in%20the%20%60tool_response%60%20handler%3A%0A%0A%60%60%60python%0A%23%20Track%20tool_response%20messages%20%28child%20workflow%20completion%29%0Aif%20message.content%20and%20message.content.type%20%3D%3D%20%22tool_response%22%3A%0A%20%20%20%20seen_tool_response%20%3D%20True%0A%20%20%20%20%23%20If%20DONE%20was%20already%20observed%20%28but%20we%20were%20waiting%20for%20tool_response%29%2C%0A%20%20%20%20%23%20we%20can%20exit%20immediately%20instead%20of%20waiting%20for%20the%20timeout.%0A%20%20%20%20if%20found_final_response%3A%0A%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex-python"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
Line: 121-126

Comment:
**No early exit after `tool_response` in race-condition path**

When the race condition actually fires (DONE arrives before `tool_response` is persisted), the loop does the right thing and keeps polling — but once `tool_response` is finally seen, `seen_tool_response` becomes `True` inside the `tool_response` branch and there is no corresponding `break`. The `break` can only execute inside the `"text"/"DONE"` block, and the agent won't emit a second DONE message. So in that exact scenario the test will keep polling for the full 60-second timeout before the generator expires and the assertions are checked.

Adding an early-exit in the `tool_response` handler when a DONE text was already seen avoids the unnecessary wait:

```suggestion
                # Stop when we get DONE with content. If the agent invoked a tool, keep polling
                # until tool_response is visible: the final text can be marked DONE before the
                # lifecycle activity persists tool_response to the message list.
                if message.streaming_status == "DONE" and content_length > 0:
                    if not seen_tool_request or seen_tool_response:
                        break

            # Track tool_response messages (get_weather result) — placed after the DONE check
            # so that if tool_response arrives after DONE, we can break immediately.
            if message.content and message.content.type == "tool_response":
                seen_tool_response = True
                # If we already saw the final DONE text but held off because tool_response
                # hadn't arrived yet, we can safely exit now.
                if final_message is not None and getattr(final_message, "streaming_status", None) == "DONE":
                    break
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py
Line: 151-157

Comment:
**No early exit after `tool_response` in race-condition path**

Same issue as tutorial 070: when DONE lands before `tool_response` is persisted, the loop correctly keeps polling — but after `tool_response` is finally seen, `seen_tool_response = True` is set inside the `tool_response` branch with no break, and the agent won't emit a second DONE text. The test will keep polling for the full 120-second timeout before the generator exits.

In this file, `found_final_response` already captures "we have seen a DONE text", so the fix is straightforward — add a break in the `tool_response` handler:

```python
# Track tool_response messages (child workflow completion)
if message.content and message.content.type == "tool_response":
    seen_tool_response = True
    # If DONE was already observed (but we were waiting for tool_response),
    # we can exit immediately instead of waiting for the timeout.
    if found_final_response:
        break
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): waiting for tool activity res..."](https://github.com/scaleapi/scale-agentex-python/commit/ca79ab1e0f8273f484d7abc9641e8dc1190e81b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28351877)</sub>

<!-- /greptile_comment -->