### PR TITLE
fix: Temporal Union deserialization causing tool_response messages to be lost

### DIFF
--- a/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
+++ b/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
@@ -111,6 +111,9 @@ class TestNonStreamingEvents:
             # Track tool_response messages (get_weather result)
             if message.content and message.content.type == "tool_response":
                 seen_tool_response = True
+                # If we already saw DONE but were waiting for tool_response, exit now
+                if final_message and getattr(final_message, "streaming_status", None) == "DONE":
+                    break
 
             # Track agent text messages and their streaming updates
             if message.content and message.content.type == "text" and message.content.author == "agent":
@@ -118,9 +121,12 @@ class TestNonStreamingEvents:
                 content_length = len(str(agent_text))
                 final_message = message
 
-                # Stop when we get DONE status
+                # Stop when we get DONE with content, but only if tool_response
+                # is already visible. The DONE text can be persisted before the
+                # lifecycle activity persists tool_response to the message list.
                 if message.streaming_status == "DONE" and content_length > 0:
-                    break
+                    if not seen_tool_request or seen_tool_response:
+                        break
 
         # Verify we got all the expected pieces
         assert seen_tool_request, "Expected to see tool_request message (agent calling get_weather)"

--- a/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py
+++ b/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py
@@ -143,15 +143,21 @@ class TestNonStreamingEvents:
             # Track tool_response messages (child workflow completion)
             if message.content and message.content.type == "tool_response":
                 seen_tool_response = True
+                # If we already saw DONE but were waiting for tool_response, exit now
+                if found_final_response:
+                    break
 
             # Track agent text messages and their streaming updates
             if message.content and message.content.type == "text" and message.content.author == "agent":
                 content_length = len(message.content.content) if message.content.content else 0
 
-                # Stop when we get DONE status with actual content
+                # Stop when we get DONE with content, but only if tool_response
+                # is already visible. The DONE text can be persisted before the
+                # lifecycle activity persists tool_response to the message list.
                 if message.streaming_status == "DONE" and content_length > 0:
                     found_final_response = True
-                    break
+                    if not seen_tool_request or seen_tool_response:
+                        break
 
         # Verify that we saw the complete flow: tool_request -> human approval -> tool_response -> final answer
         assert seen_tool_request, "Expected to see tool_request message (agent calling wait_for_confirmation)"

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/hooks/activities.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/hooks/activities.py
@@ -4,7 +4,7 @@ This module provides reusable Temporal activities for streaming content
 to the AgentEx UI, designed to work with TemporalStreamingHooks.
 """
 
-from typing import Union
+from typing import Any, Dict
 
 from temporalio import activity
 
@@ -12,16 +12,32 @@ from agentex.lib import adk
 from agentex.types.text_content import TextContent
 from agentex.types.task_message_update import StreamTaskMessageFull
 from agentex.types.task_message_content import (
-    TaskMessageContent,
     ToolRequestContent,
     ToolResponseContent,
 )
 
 
+def _deserialize_content(data: Dict[str, Any]):
+    """Reconstruct the correct content type from a dict using the 'type' discriminator.
+
+    Temporal's payload converter deserializes Union types by trying each variant
+    in order, which causes ToolResponseContent to be misdeserialized as TextContent
+    (both have 'author' and 'content' fields). This function uses the 'type' field
+    to pick the correct Pydantic model.
+    """
+    content_type = data.get("type")
+    if content_type == "tool_request":
+        return ToolRequestContent.model_validate(data)
+    elif content_type == "tool_response":
+        return ToolResponseContent.model_validate(data)
+    else:
+        return TextContent.model_validate(data)
+
+
 @activity.defn(name="stream_lifecycle_content")
 async def stream_lifecycle_content(
     task_id: str,
-    content: Union[TextContent, ToolRequestContent, ToolResponseContent, TaskMessageContent],
+    content: Dict[str, Any],
 ) -> None:
     """Stream agent lifecycle content to the AgentEx UI.
 
@@ -32,28 +48,16 @@ async def stream_lifecycle_content(
     Designed to work seamlessly with TemporalStreamingHooks. The hooks class
     will call this activity automatically when lifecycle events occur.
 
+    Note: The content parameter is a dict (not a typed Union) because Temporal's
+    payload converter misdeserializes Union types with overlapping fields.
+    The correct Pydantic model is reconstructed using the 'type' discriminator.
+
     Args:
         task_id: The AgentEx task ID for routing the content to the correct UI session
-        content: The content to stream - can be any of:
-            - TextContent: Plain text messages (e.g., handoff notifications)
-            - ToolRequestContent: Tool invocation requests with call_id and name
-            - ToolResponseContent: Tool execution results with call_id and output
-            - TaskMessageContent: Generic task message content
-
-    Example:
-        Register this activity with your Temporal worker::
-
-            from agentex.lib.core.temporal.plugins.openai_agents import (
-                TemporalStreamingHooks,
-                stream_lifecycle_content,
-            )
-
-            # In your workflow
-            hooks = TemporalStreamingHooks(
-                task_id=params.task.id,
-                stream_activity=stream_lifecycle_content
-            )
-            result = await Runner.run(agent, input, hooks=hooks)
+        content: Dict with a 'type' field that determines the content model:
+            - type="text": TextContent (plain text messages, handoff notifications)
+            - type="tool_request": ToolRequestContent (tool invocation with call_id)
+            - type="tool_response": ToolResponseContent (tool result with call_id)
 
     Note:
         This activity is non-blocking and will not throw exceptions to the workflow.
@@ -61,18 +65,17 @@ async def stream_lifecycle_content(
         that streaming failures don't break the agent execution.
     """
     try:
+        typed_content = _deserialize_content(content)
         async with adk.streaming.streaming_task_message_context(
             task_id=task_id,
-            initial_content=content,
+            initial_content=typed_content,
         ) as streaming_context:
-            # Send the content as a full message update
             await streaming_context.stream_update(
                 StreamTaskMessageFull(
                     parent_task_message=streaming_context.task_message,
-                    content=content,
+                    content=typed_content,
                     type="full",
                 )
             )
     except Exception as e:
-        # Log error but don't fail the activity - streaming failures shouldn't break execution
         activity.logger.warning(f"Failed to stream content to task {task_id}: {e}")

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/hooks/hooks.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/hooks/hooks.py
@@ -139,8 +139,8 @@ class TemporalStreamingHooks(RunHooks):
                     author="agent",
                     tool_call_id=tool_call_id,
                     name=tool.name,
-                    arguments=tool_arguments,  # Now properly extracted from context
-                ),
+                    arguments=tool_arguments,
+                ).model_dump(),
             ],
             start_to_close_timeout=self.timeout,
         )
@@ -176,7 +176,7 @@ class TemporalStreamingHooks(RunHooks):
                     tool_call_id=tool_call_id,
                     name=tool.name,
                     content=result,
-                ),
+                ).model_dump(),
             ],
             start_to_close_timeout=self.timeout,
         )
@@ -203,7 +203,7 @@ class TemporalStreamingHooks(RunHooks):
                     author="agent",
                     content=f"Handoff from {from_agent.name} to {to_agent.name}",
                     type="text",
-                ),
+                ).model_dump(),
             ],
             start_to_close_timeout=self.timeout,
         )


### PR DESCRIPTION
## Summary

- Temporal's payload converter deserializes `Union` types by trying each variant in order
- `ToolResponseContent` was silently misdeserialized as `TextContent` (both share `author` and `content` fields), so the activity created `text` messages instead of `tool_response` messages
- Hooks now pass `.model_dump()` dicts to the activity, and the activity reconstructs the correct Pydantic model using the `type` discriminator
- Test polling also fixed to handle the DONE/tool_response ordering race condition

## Root cause

`stream_lifecycle_content` activity accepts `Union[TextContent, ToolRequestContent, ToolResponseContent, TaskMessageContent]`. When Temporal deserializes the JSON payload into this Union, it tries `TextContent` first — which succeeds because `TextContent` and `ToolResponseContent` both have `author` and `content` fields. The `type` discriminator is ignored by Temporal's converter.

This started failing when `temporalio 1.24.0` (Mar 23) changed its Pydantic integration for Union type handling.

## Test plan
- [x] CI tutorial tests 070 and 080 pass
- [x] All other tutorial tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Temporal Union deserialization bug introduced in `temporalio 1.24.0` where `ToolResponseContent` was silently coerced into `TextContent` at activity boundaries (both share `author` and `content` fields). The fix serializes content to dicts with `.model_dump()` in the hooks before passing them to the activity, which then reconstructs the correct Pydantic model using the `type` discriminator. Test polling is also hardened to tolerate the race between DONE status and `tool_response` persistence ordering.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — the fix is targeted, well-documented, and all remaining findings are P2 style suggestions.
- The root-cause fix (dict passthrough + discriminator-based deserialization) is correct and addresses the Temporal 1.24.0 regression precisely. The test hardening correctly handles both DONE-before-tool_response and tool_response-before-DONE orderings. No P0 or P1 issues were found.
- No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/temporal/plugins/openai_agents/hooks/activities.py | Core fix: activity signature changed from Union to Dict[str, Any], with a discriminator-based _deserialize_content helper that correctly reconstructs the typed Pydantic model. Logic and docstrings are correct. |
| src/agentex/lib/core/temporal/plugins/openai_agents/hooks/hooks.py | All three hooks now call .model_dump() before passing content to the activity, consistent with the updated activity signature. No issues found. |
| examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py | Polling loop updated to handle DONE/tool_response ordering race. Logic is correct for single-tool agents; see comment on loop exit condition. |
| examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests/test_agent.py | Same polling race condition fix applied. Logic mirrors tutorial 070 and handles both orderings correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Hook as TemporalStreamingHooks
    participant Temporal as Temporal Workflow Engine
    participant Activity as stream_lifecycle_content
    participant Deserializer as _deserialize_content
    participant ADK as adk.streaming

    Note over Hook,ADK: BEFORE this PR (broken with temporalio ≥ 1.24.0)
    Hook->>Temporal: execute_activity(ToolResponseContent(...))
    Temporal-->>Activity: deserializes Union → picks TextContent (wrong!)
    Activity->>ADK: "stream TextContent (type="text" instead of "tool_response")"

    Note over Hook,ADK: AFTER this PR (fixed)
    Hook->>Hook: ToolResponseContent(...).model_dump()
    Hook->>Temporal: "execute_activity({"type":"tool_response", ...})"
    Temporal-->>Activity: passes Dict[str, Any] as-is (no Union ambiguity)
    Activity->>Deserializer: _deserialize_content(data)
    Deserializer->>Deserializer: "data["type"] == "tool_response""
    Deserializer-->>Activity: ToolResponseContent (correct!)
    Activity->>ADK: "stream ToolResponseContent (type="tool_response" ✓)"
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Fhooks%2Factivities.py%3A20-34%0A**Unhandled%20content%20types%20fall%20back%20to%20TextContent%20silently**%0A%0A%60ReasoningContent%60%20and%20%60DataContent%60%20%28both%20valid%20%60TaskMessageContent%60%20variants%20per%20%60task_message_content.py%60%29%20will%20fall%20through%20to%20%60TextContent.model_validate%28data%29%60.%20Those%20models%20don't%20have%20an%20%60author%60%20%2F%20%60content%60%20structure%2C%20so%20validation%20will%20raise%20a%20%60ValidationError%60%20that%20is%20swallowed%20by%20the%20outer%20%60try%2Fexcept%60%2C%20silently%20dropping%20the%20message.%20A%20brief%20comment%20on%20this%20intentional%20limitation%20%E2%80%94%20and%20why%20those%20types%20are%20not%20expected%20here%20%E2%80%94%20would%20help%20future%20maintainers%20avoid%20confusion%2C%20per%20the%20project's%20policy%20on%20explaining%20non-obvious%20logic.%0A%0A%60%60%60suggestion%0Adef%20_deserialize_content%28data%3A%20Dict%5Bstr%2C%20Any%5D%29%20-%3E%20Union%5BTextContent%2C%20ToolRequestContent%2C%20ToolResponseContent%5D%3A%0A%20%20%20%20%22%22%22Reconstruct%20the%20correct%20content%20type%20from%20a%20dict%20using%20the%20'type'%20discriminator.%0A%0A%20%20%20%20Temporal's%20payload%20converter%20deserializes%20Union%20types%20by%20trying%20each%20variant%0A%20%20%20%20in%20order%2C%20which%20causes%20ToolResponseContent%20to%20be%20misdeserialized%20as%20TextContent%0A%20%20%20%20%28both%20have%20'author'%20and%20'content'%20fields%29.%20This%20function%20uses%20the%20'type'%20field%0A%20%20%20%20to%20pick%20the%20correct%20Pydantic%20model.%0A%0A%20%20%20%20Only%20the%20three%20content%20types%20emitted%20by%20TemporalStreamingHooks%20are%20handled%20here%0A%20%20%20%20%28text%2C%20tool_request%2C%20tool_response%29.%20Other%20TaskMessageContent%20variants%0A%20%20%20%20%28ReasoningContent%2C%20DataContent%29%20are%20never%20passed%20by%20the%20hooks%20and%20are%20not%0A%20%20%20%20supported%3B%20unknown%20types%20fall%20back%20to%20TextContent%20and%20will%20raise%20a%0A%20%20%20%20ValidationError%20that%20is%20caught%20and%20logged%20by%20the%20caller.%0A%20%20%20%20%22%22%22%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learnt%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A%23%23%23%20Issue%202%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F070_open_ai_agents_sdk_tools%2Ftests%2Ftest_agent.py%3A127-129%0A**Break%20condition%20is%20correct%20but%20deserves%20a%20comment**%0A%0A%60not%20seen_tool_request%20or%20seen_tool_response%60%20evaluates%20to%20%60True%60%20%28break%29%20when%20either%20no%20tool%20was%20ever%20called%2C%20or%20the%20full%20request%E2%86%92response%20cycle%20is%20complete.%20The%20logic%20is%20correct%20for%20this%20single-tool%20agent%2C%20but%20the%20De%20Morgan's%20negation%20isn't%20immediately%20obvious%20to%20a%20reader%20%E2%80%94%20a%20brief%20inline%20comment%20explaining%20the%20intent%20would%20make%20it%20clearer%20and%20align%20with%20the%20project's%20guidance%20on%20non-obvious%20logic.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Break%20if%20no%20tool%20was%20invoked%20%28pure%20text%20response%29%20OR%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20if%20we've%20observed%20both%20the%20request%20and%20response%20phases.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Without%20this%20guard%2C%20the%20loop%20would%20exit%20before%20tool_response%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20is%20persisted%20when%20DONE%20arrives%20first.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20seen_tool_request%20or%20seen_tool_response%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learnt%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Fhooks%2Factivities.py%3A20-34%0A**Unhandled%20content%20types%20fall%20back%20to%20TextContent%20silently**%0A%0A%60ReasoningContent%60%20and%20%60DataContent%60%20%28both%20valid%20%60TaskMessageContent%60%20variants%20per%20%60task_message_content.py%60%29%20will%20fall%20through%20to%20%60TextContent.model_validate%28data%29%60.%20Those%20models%20don't%20have%20an%20%60author%60%20%2F%20%60content%60%20structure%2C%20so%20validation%20will%20raise%20a%20%60ValidationError%60%20that%20is%20swallowed%20by%20the%20outer%20%60try%2Fexcept%60%2C%20silently%20dropping%20the%20message.%20A%20brief%20comment%20on%20this%20intentional%20limitation%20%E2%80%94%20and%20why%20those%20types%20are%20not%20expected%20here%20%E2%80%94%20would%20help%20future%20maintainers%20avoid%20confusion%2C%20per%20the%20project's%20policy%20on%20explaining%20non-obvious%20logic.%0A%0A%60%60%60suggestion%0Adef%20_deserialize_content%28data%3A%20Dict%5Bstr%2C%20Any%5D%29%20-%3E%20Union%5BTextContent%2C%20ToolRequestContent%2C%20ToolResponseContent%5D%3A%0A%20%20%20%20%22%22%22Reconstruct%20the%20correct%20content%20type%20from%20a%20dict%20using%20the%20'type'%20discriminator.%0A%0A%20%20%20%20Temporal's%20payload%20converter%20deserializes%20Union%20types%20by%20trying%20each%20variant%0A%20%20%20%20in%20order%2C%20which%20causes%20ToolResponseContent%20to%20be%20misdeserialized%20as%20TextContent%0A%20%20%20%20%28both%20have%20'author'%20and%20'content'%20fields%29.%20This%20function%20uses%20the%20'type'%20field%0A%20%20%20%20to%20pick%20the%20correct%20Pydantic%20model.%0A%0A%20%20%20%20Only%20the%20three%20content%20types%20emitted%20by%20TemporalStreamingHooks%20are%20handled%20here%0A%20%20%20%20%28text%2C%20tool_request%2C%20tool_response%29.%20Other%20TaskMessageContent%20variants%0A%20%20%20%20%28ReasoningContent%2C%20DataContent%29%20are%20never%20passed%20by%20the%20hooks%20and%20are%20not%0A%20%20%20%20supported%3B%20unknown%20types%20fall%20back%20to%20TextContent%20and%20will%20raise%20a%0A%20%20%20%20ValidationError%20that%20is%20caught%20and%20logged%20by%20the%20caller.%0A%20%20%20%20%22%22%22%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learnt%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A%23%23%23%20Issue%202%20of%202%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F070_open_ai_agents_sdk_tools%2Ftests%2Ftest_agent.py%3A127-129%0A**Break%20condition%20is%20correct%20but%20deserves%20a%20comment**%0A%0A%60not%20seen_tool_request%20or%20seen_tool_response%60%20evaluates%20to%20%60True%60%20%28break%29%20when%20either%20no%20tool%20was%20ever%20called%2C%20or%20the%20full%20request%E2%86%92response%20cycle%20is%20complete.%20The%20logic%20is%20correct%20for%20this%20single-tool%20agent%2C%20but%20the%20De%20Morgan's%20negation%20isn't%20immediately%20obvious%20to%20a%20reader%20%E2%80%94%20a%20brief%20inline%20comment%20explaining%20the%20intent%20would%20make%20it%20clearer%20and%20align%20with%20the%20project's%20guidance%20on%20non-obvious%20logic.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Break%20if%20no%20tool%20was%20invoked%20%28pure%20text%20response%29%20OR%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20if%20we've%20observed%20both%20the%20request%20and%20response%20phases.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Without%20this%20guard%2C%20the%20loop%20would%20exit%20before%20tool_response%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20is%20persisted%20when%20DONE%20arrives%20first.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20seen_tool_request%20or%20seen_tool_response%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learnt%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A&repo=scaleapi%2Fscale-agentex-python"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/agentex/lib/core/temporal/plugins/openai_agents/hooks/activities.py
Line: 20-34

Comment:
**Unhandled content types fall back to TextContent silently**

`ReasoningContent` and `DataContent` (both valid `TaskMessageContent` variants per `task_message_content.py`) will fall through to `TextContent.model_validate(data)`. Those models don't have an `author` / `content` structure, so validation will raise a `ValidationError` that is swallowed by the outer `try/except`, silently dropping the message. A brief comment on this intentional limitation — and why those types are not expected here — would help future maintainers avoid confusion, per the project's policy on explaining non-obvious logic.

```suggestion
def _deserialize_content(data: Dict[str, Any]) -> Union[TextContent, ToolRequestContent, ToolResponseContent]:
    """Reconstruct the correct content type from a dict using the 'type' discriminator.

    Temporal's payload converter deserializes Union types by trying each variant
    in order, which causes ToolResponseContent to be misdeserialized as TextContent
    (both have 'author' and 'content' fields). This function uses the 'type' field
    to pick the correct Pydantic model.

    Only the three content types emitted by TemporalStreamingHooks are handled here
    (text, tool_request, tool_response). Other TaskMessageContent variants
    (ReasoningContent, DataContent) are never passed by the hooks and are not
    supported; unknown types fall back to TextContent and will raise a
    ValidationError that is caught and logged by the caller.
    """
```

**Rule Used:** Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learnt From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/tests/test_agent.py
Line: 127-129

Comment:
**Break condition is correct but deserves a comment**

`not seen_tool_request or seen_tool_response` evaluates to `True` (break) when either no tool was ever called, or the full request→response cycle is complete. The logic is correct for this single-tool agent, but the De Morgan's negation isn't immediately obvious to a reader — a brief inline comment explaining the intent would make it clearer and align with the project's guidance on non-obvious logic.

```suggestion
                # Break if no tool was invoked (pure text response) OR
                # if we've observed both the request and response phases.
                # Without this guard, the loop would exit before tool_response
                # is persisted when DONE arrives first.
                if not seen_tool_request or seen_tool_response:
                    break
```

**Rule Used:** Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learnt From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (10): Last reviewed commit: ["fix: Temporal Union deserialization caus..."](https://github.com/scaleapi/scale-agentex-python/commit/79ef4dd7a0ab1b8bb1151f5e16124ec5a947dfd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28357919)</sub>

<!-- /greptile_comment -->