### PR TITLE
add support for Temporal PayloadCodec

### DIFF
--- a/src/agentex/lib/core/clients/temporal/temporal_client.py
+++ b/src/agentex/lib/core/clients/temporal/temporal_client.py
@@ -76,9 +76,10 @@ DUPLICATE_POLICY_TO_ID_REUSE_POLICY = {
 
 
 class TemporalClient:
-    def __init__(self, temporal_client: Client | None = None, plugins: list[Any] = []):
+    def __init__(self, temporal_client: Client | None = None, plugins: list[Any] = [], payload_codec: Any | None = None):
         self._client: Client | None = temporal_client
         self._plugins = plugins
+        self._payload_codec = payload_codec
 
     @property
     def client(self) -> Client:
@@ -88,7 +89,7 @@ class TemporalClient:
         return self._client
 
     @classmethod
-    async def create(cls, temporal_address: str, plugins: list[Any] = []):
+    async def create(cls, temporal_address: str, plugins: list[Any] = [], payload_codec: Any | None = None):
         if temporal_address in [
             "false",
             "False",
@@ -101,8 +102,8 @@ class TemporalClient:
         ]:
             _client = None
         else:
-            _client = await get_temporal_client(temporal_address, plugins=plugins)
-        return cls(_client, plugins)
+            _client = await get_temporal_client(temporal_address, plugins=plugins, payload_codec=payload_codec)
+        return cls(_client, plugins, payload_codec)
 
     async def setup(self, temporal_address: str):
         self._client = await self._get_temporal_client(temporal_address=temporal_address)
@@ -120,7 +121,7 @@ class TemporalClient:
         ]:
             return None
         else:
-            return await get_temporal_client(temporal_address, plugins=self._plugins)
+            return await get_temporal_client(temporal_address, plugins=self._plugins, payload_codec=self._payload_codec)
 
     async def start_workflow(
         self,

--- a/src/agentex/lib/core/clients/temporal/temporal_client.py
+++ b/src/agentex/lib/core/clients/temporal/temporal_client.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from temporalio.client import Client, WorkflowExecutionStatus
 from temporalio.common import RetryPolicy as TemporalRetryPolicy, WorkflowIDReusePolicy
 from temporalio.service import RPCError, RPCStatusCode
+from temporalio.converter import PayloadCodec
 
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.utils.model_utils import BaseModel
@@ -76,7 +77,7 @@ DUPLICATE_POLICY_TO_ID_REUSE_POLICY = {
 
 
 class TemporalClient:
-    def __init__(self, temporal_client: Client | None = None, plugins: list[Any] = [], payload_codec: Any | None = None):
+    def __init__(self, temporal_client: Client | None = None, plugins: list[Any] = [], payload_codec: PayloadCodec | None = None):
         self._client: Client | None = temporal_client
         self._plugins = plugins
         self._payload_codec = payload_codec
@@ -89,7 +90,7 @@ class TemporalClient:
         return self._client
 
     @classmethod
-    async def create(cls, temporal_address: str, plugins: list[Any] = [], payload_codec: Any | None = None):
+    async def create(cls, temporal_address: str, plugins: list[Any] = [], payload_codec: PayloadCodec | None = None):
         if temporal_address in [
             "false",
             "False",

--- a/src/agentex/lib/core/clients/temporal/temporal_client.py
+++ b/src/agentex/lib/core/clients/temporal/temporal_client.py
@@ -77,7 +77,9 @@ DUPLICATE_POLICY_TO_ID_REUSE_POLICY = {
 
 
 class TemporalClient:
-    def __init__(self, temporal_client: Client | None = None, plugins: list[Any] = [], payload_codec: PayloadCodec | None = None):
+    def __init__(
+        self, temporal_client: Client | None = None, plugins: list[Any] = [], payload_codec: PayloadCodec | None = None
+    ):
         self._client: Client | None = temporal_client
         self._plugins = plugins
         self._payload_codec = payload_codec

--- a/src/agentex/lib/core/clients/temporal/utils.py
+++ b/src/agentex/lib/core/clients/temporal/utils.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
+import dataclasses
 from typing import Any
 
-import dataclasses
-
 from temporalio.client import Client, Plugin as ClientPlugin
-from temporalio.converter import PayloadCodec
 from temporalio.worker import Interceptor
 from temporalio.runtime import Runtime, TelemetryConfig, OpenTelemetryConfig
+from temporalio.converter import PayloadCodec
 from temporalio.contrib.pydantic import pydantic_data_converter
 
 # class DateTimeJSONEncoder(AdvancedJSONEncoder):
@@ -107,9 +106,8 @@ async def get_temporal_client(
     # Check if OpenAI plugin is present - it needs to configure its own data converter
     # Lazy import to avoid pulling in opentelemetry.sdk for non-Temporal agents
     from temporalio.contrib.openai_agents import OpenAIAgentsPlugin
-    has_openai_plugin = any(
-        isinstance(p, OpenAIAgentsPlugin) for p in (plugins or [])
-    )
+
+    has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
     # Only set data_converter if OpenAI plugin is not present
     connect_kwargs = {

--- a/src/agentex/lib/core/clients/temporal/utils.py
+++ b/src/agentex/lib/core/clients/temporal/utils.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
+import dataclasses
+
 from temporalio.client import Client, Plugin as ClientPlugin
+from temporalio.converter import PayloadCodec
 from temporalio.worker import Interceptor
 from temporalio.runtime import Runtime, TelemetryConfig, OpenTelemetryConfig
 from temporalio.contrib.pydantic import pydantic_data_converter
@@ -79,7 +82,12 @@ def validate_worker_interceptors(interceptors: list[Any]) -> None:
             )
 
 
-async def get_temporal_client(temporal_address: str, metrics_url: str | None = None, plugins: list[Any] = []) -> Client:
+async def get_temporal_client(
+    temporal_address: str,
+    metrics_url: str | None = None,
+    plugins: list[Any] = [],
+    payload_codec: PayloadCodec | None = None,
+) -> Client:
     """
     Create a Temporal client with plugin integration.
 
@@ -87,6 +95,7 @@ async def get_temporal_client(temporal_address: str, metrics_url: str | None = N
         temporal_address: Temporal server address
         metrics_url: Optional metrics endpoint URL
         plugins: List of Temporal plugins to include
+        payload_codec: Optional payload codec for encoding/decoding payloads (e.g. encryption, compression)
 
     Returns:
         Configured Temporal client
@@ -109,7 +118,10 @@ async def get_temporal_client(temporal_address: str, metrics_url: str | None = N
     }
 
     if not has_openai_plugin:
-        connect_kwargs["data_converter"] = pydantic_data_converter
+        data_converter = pydantic_data_converter
+        if payload_codec:
+            data_converter = dataclasses.replace(data_converter, payload_codec=payload_codec)
+        connect_kwargs["data_converter"] = data_converter
 
     if not metrics_url:
         client = await Client.connect(**connect_kwargs)

--- a/src/agentex/lib/core/clients/temporal/utils.py
+++ b/src/agentex/lib/core/clients/temporal/utils.py
@@ -109,7 +109,13 @@ async def get_temporal_client(
 
     has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
-    # Only set data_converter if OpenAI plugin is not present
+    if has_openai_plugin and payload_codec is not None:
+        raise ValueError(
+            "payload_codec is not supported alongside OpenAIAgentsPlugin: the plugin "
+            "installs its own data converter and the codec would be silently ignored, "
+            "leaving payloads unencoded. Remove one or the other."
+        )
+
     connect_kwargs = {
         "target_host": temporal_address,
         "plugins": plugins,

--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -19,6 +19,7 @@ from temporalio.worker import (
 from temporalio.runtime import Runtime, TelemetryConfig, OpenTelemetryConfig
 from temporalio.converter import (
     DataConverter,
+    PayloadCodec,
     JSONTypeConverter,
     AdvancedJSONEncoder,
     DefaultPayloadConverter,
@@ -89,7 +90,12 @@ def _validate_interceptors(interceptors: list) -> None:
             )
 
 
-async def get_temporal_client(temporal_address: str, metrics_url: str | None = None, plugins: list = []) -> Client:
+async def get_temporal_client(
+    temporal_address: str,
+    metrics_url: str | None = None,
+    plugins: list = [],
+    payload_codec: PayloadCodec | None = None,
+) -> Client:
     if plugins != []:  # We don't need to validate the plugins if they are empty
         _validate_plugins(plugins)
 
@@ -108,7 +114,10 @@ async def get_temporal_client(temporal_address: str, metrics_url: str | None = N
 
     # Only set data_converter if OpenAI plugin is not present
     if not has_openai_plugin:
-        connect_kwargs["data_converter"] = custom_data_converter
+        data_converter = custom_data_converter
+        if payload_codec:
+            data_converter = dataclasses.replace(data_converter, payload_codec=payload_codec)
+        connect_kwargs["data_converter"] = data_converter
 
     if not metrics_url:
         client = await Client.connect(**connect_kwargs)
@@ -129,6 +138,7 @@ class AgentexWorker:
         plugins: list = [],
         interceptors: list = [],
         metrics_url: str | None = None,
+        payload_codec: PayloadCodec | None = None,
     ):
         self.task_queue = task_queue
         self.activity_handles = []
@@ -140,6 +150,7 @@ class AgentexWorker:
         self.plugins = plugins
         self.interceptors = interceptors
         self.metrics_url = metrics_url
+        self.payload_codec = payload_codec
 
     @overload
     async def run(
@@ -175,6 +186,7 @@ class AgentexWorker:
             temporal_address=os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"),
             plugins=self.plugins,
             metrics_url=self.metrics_url,
+            payload_codec=self.payload_codec,
         )
 
         # Enable debug mode if AgentEx debug is enabled (disables deadlock detection)

--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -105,6 +105,13 @@ async def get_temporal_client(
 
     has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
+    if has_openai_plugin and payload_codec is not None:
+        raise ValueError(
+            "payload_codec is not supported alongside OpenAIAgentsPlugin: the plugin "
+            "installs its own data converter and the codec would be silently ignored, "
+            "leaving payloads unencoded. Remove one or the other."
+        )
+
     # Build connection kwargs
     connect_kwargs = {
         "target_host": temporal_address,

--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -18,8 +18,8 @@ from temporalio.worker import (
 )
 from temporalio.runtime import Runtime, TelemetryConfig, OpenTelemetryConfig
 from temporalio.converter import (
-    DataConverter,
     PayloadCodec,
+    DataConverter,
     JSONTypeConverter,
     AdvancedJSONEncoder,
     DefaultPayloadConverter,
@@ -102,9 +102,8 @@ async def get_temporal_client(
     # Check if OpenAI plugin is present - it needs to configure its own data converter
     # Lazy import to avoid pulling in opentelemetry.sdk for non-Temporal agents
     from temporalio.contrib.openai_agents import OpenAIAgentsPlugin
-    has_openai_plugin = any(
-        isinstance(p, OpenAIAgentsPlugin) for p in (plugins or [])
-    )
+
+    has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
     # Build connection kwargs
     connect_kwargs = {
@@ -146,7 +145,9 @@ class AgentexWorker:
         self.max_concurrent_activities = max_concurrent_activities
         self.health_check_server_running = False
         self.healthy = False
-        self.health_check_port = health_check_port if health_check_port is not None else EnvironmentVariables.refresh().HEALTH_CHECK_PORT
+        self.health_check_port = (
+            health_check_port if health_check_port is not None else EnvironmentVariables.refresh().HEALTH_CHECK_PORT
+        )
         self.plugins = plugins
         self.interceptors = interceptors
         self.metrics_url = metrics_url

--- a/src/agentex/lib/sdk/fastacp/fastacp.py
+++ b/src/agentex/lib/sdk/fastacp/fastacp.py
@@ -63,6 +63,8 @@ class FastACP:
                 temporal_config["plugins"] = config.plugins  # type: ignore[attr-defined]
             if hasattr(config, "interceptors"):
                 temporal_config["interceptors"] = config.interceptors  # type: ignore[attr-defined]
+            if hasattr(config, "payload_codec"):
+                temporal_config["payload_codec"] = config.payload_codec  # type: ignore[attr-defined]
             return implementation_class.create(**temporal_config)
         else:
             return implementation_class.create(**kwargs)

--- a/src/agentex/lib/sdk/fastacp/fastacp.py
+++ b/src/agentex/lib/sdk/fastacp/fastacp.py
@@ -34,7 +34,7 @@ class FastACP:
     Supports three main ACP types:
     - "sync": Simple synchronous ACP implementation
     - "async": Advanced ACP with sub-types "base" or "temporal" (requires config)
-    - "agentic": (Deprecated, use "async") Identical to "async" 
+    - "agentic": (Deprecated, use "async") Identical to "async"
     """
 
     @staticmethod

--- a/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
+++ b/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
@@ -31,20 +31,22 @@ class TemporalACP(BaseACPServer):
         temporal_task_service: TemporalTaskService | None = None,
         plugins: list[Any] | None = None,
         interceptors: list[Any] | None = None,
+        payload_codec: Any | None = None,
     ):
         super().__init__()
         self._temporal_task_service = temporal_task_service
         self._temporal_address = temporal_address
         self._plugins = plugins or []
         self._interceptors = interceptors or []
+        self._payload_codec = payload_codec
 
     @classmethod
     @override
-    def create(cls, temporal_address: str, plugins: list[Any] | None = None, interceptors: list[Any] | None = None) -> "TemporalACP":
+    def create(cls, temporal_address: str, plugins: list[Any] | None = None, interceptors: list[Any] | None = None, payload_codec: Any | None = None) -> "TemporalACP":
         logger.info("Initializing TemporalACP instance")
 
         # Create instance without temporal client initially
-        temporal_acp = cls(temporal_address=temporal_address, plugins=plugins, interceptors=interceptors)
+        temporal_acp = cls(temporal_address=temporal_address, plugins=plugins, interceptors=interceptors, payload_codec=payload_codec)
         temporal_acp._setup_handlers()
         logger.info("TemporalACP instance initialized now")
         return temporal_acp
@@ -60,7 +62,7 @@ class TemporalACP(BaseACPServer):
             if self._temporal_task_service is None:
                 env_vars = EnvironmentVariables.refresh()
                 temporal_client = await TemporalClient.create(
-                    temporal_address=self._temporal_address, plugins=self._plugins
+                    temporal_address=self._temporal_address, plugins=self._plugins, payload_codec=self._payload_codec
                 )
                 self._temporal_task_service = TemporalTaskService(
                     temporal_client=temporal_client,

--- a/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
+++ b/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, AsyncGenerator, override
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from temporalio.converter import PayloadCodec
 
 from agentex.lib.types.acp import (
     SendEventParams,
@@ -31,7 +32,7 @@ class TemporalACP(BaseACPServer):
         temporal_task_service: TemporalTaskService | None = None,
         plugins: list[Any] | None = None,
         interceptors: list[Any] | None = None,
-        payload_codec: Any | None = None,
+        payload_codec: PayloadCodec | None = None,
     ):
         super().__init__()
         self._temporal_task_service = temporal_task_service
@@ -42,7 +43,7 @@ class TemporalACP(BaseACPServer):
 
     @classmethod
     @override
-    def create(cls, temporal_address: str, plugins: list[Any] | None = None, interceptors: list[Any] | None = None, payload_codec: Any | None = None) -> "TemporalACP":
+    def create(cls, temporal_address: str, plugins: list[Any] | None = None, interceptors: list[Any] | None = None, payload_codec: PayloadCodec | None = None) -> "TemporalACP":
         logger.info("Initializing TemporalACP instance")
 
         # Create instance without temporal client initially

--- a/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
+++ b/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
@@ -43,11 +43,19 @@ class TemporalACP(BaseACPServer):
 
     @classmethod
     @override
-    def create(cls, temporal_address: str, plugins: list[Any] | None = None, interceptors: list[Any] | None = None, payload_codec: PayloadCodec | None = None) -> "TemporalACP":
+    def create(
+        cls,
+        temporal_address: str,
+        plugins: list[Any] | None = None,
+        interceptors: list[Any] | None = None,
+        payload_codec: PayloadCodec | None = None,
+    ) -> "TemporalACP":
         logger.info("Initializing TemporalACP instance")
 
         # Create instance without temporal client initially
-        temporal_acp = cls(temporal_address=temporal_address, plugins=plugins, interceptors=interceptors, payload_codec=payload_codec)
+        temporal_acp = cls(
+            temporal_address=temporal_address, plugins=plugins, interceptors=interceptors, payload_codec=payload_codec
+        )
         temporal_acp._setup_handlers()
         logger.info("TemporalACP instance initialized now")
         return temporal_acp

--- a/src/agentex/lib/types/fastacp.py
+++ b/src/agentex/lib/types/fastacp.py
@@ -56,6 +56,7 @@ class TemporalACPConfig(AsyncACPConfig):
     temporal_address: str = Field(default="temporal-frontend.temporal.svc.cluster.local:7233", frozen=True)
     plugins: list[Any] = Field(default=[], frozen=True)
     interceptors: list[Any] = Field(default=[], frozen=True)
+    payload_codec: Any = Field(default=None, frozen=True)
 
     @field_validator("plugins")
     @classmethod

--- a/src/agentex/lib/types/fastacp.py
+++ b/src/agentex/lib/types/fastacp.py
@@ -39,7 +39,9 @@ class AsyncACPConfig(BaseACPConfig):
 
     type: Literal["temporal", "base"] = Field(..., frozen=True)
 
+
 AgenticACPConfig = AsyncACPConfig
+
 
 class TemporalACPConfig(AsyncACPConfig):
     """
@@ -86,5 +88,6 @@ class AsyncBaseACPConfig(AsyncACPConfig):
     """
 
     type: Literal["base"] = Field(default="base", frozen=True)
+
 
 AgenticBaseACPConfig = AsyncBaseACPConfig

--- a/src/agentex/lib/types/fastacp.py
+++ b/src/agentex/lib/types/fastacp.py
@@ -50,6 +50,11 @@ class TemporalACPConfig(AsyncACPConfig):
         temporal_address: The address of the temporal server
         plugins: List of Temporal client plugins
         interceptors: List of Temporal worker interceptors
+        payload_codec: Optional ``temporalio.converter.PayloadCodec`` for
+            encoding/decoding payloads (e.g. encryption, compression). NOTE:
+            this only configures the ACP (client) side. The worker side must
+            be configured separately via ``AgentexWorker(payload_codec=...)``
+            with the SAME codec, or decode will fail at runtime.
     """
 
     type: Literal["temporal"] = Field(default="temporal", frozen=True)

--- a/tests/lib/test_payload_codec.py
+++ b/tests/lib/test_payload_codec.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio.client import Client, Plugin as ClientPlugin
+from temporalio.converter import PayloadCodec
+from temporalio.contrib.pydantic import pydantic_data_converter
+
+
+class _NoopCodec(PayloadCodec):
+    async def encode(self, payloads):
+        return list(payloads)
+
+    async def decode(self, payloads):
+        return list(payloads)
+
+
+class _FakeOpenAIPlugin(ClientPlugin):
+    def configure_client(self, config):
+        return config
+
+    async def connect_service_client(self, config, next):
+        return await next(config)
+
+
+def _mock_connect():
+    return patch.object(Client, "connect", new=AsyncMock(return_value=object()))
+
+
+def _patch_openai_plugin():
+    return patch("temporalio.contrib.openai_agents.OpenAIAgentsPlugin", _FakeOpenAIPlugin)
+
+
+class TestTemporalClient:
+    def test_init_stores_payload_codec(self):
+        from agentex.lib.core.clients.temporal.temporal_client import TemporalClient
+
+        codec = _NoopCodec()
+        client = TemporalClient(payload_codec=codec)
+        assert client._payload_codec is codec
+
+    def test_init_default_payload_codec_is_none(self):
+        from agentex.lib.core.clients.temporal.temporal_client import TemporalClient
+
+        assert TemporalClient()._payload_codec is None
+
+    async def test_create_with_disabled_address_stores_codec(self):
+        from agentex.lib.core.clients.temporal.temporal_client import TemporalClient
+
+        codec = _NoopCodec()
+        client = await TemporalClient.create(temporal_address="false", payload_codec=codec)
+        assert client._client is None
+        assert client._payload_codec is codec
+
+    async def test_create_propagates_codec_to_get_temporal_client(self):
+        import agentex.lib.core.clients.temporal.temporal_client as module
+
+        codec = _NoopCodec()
+        with patch.object(module, "get_temporal_client", new=AsyncMock(return_value=object())) as mock_get:
+            await module.TemporalClient.create(temporal_address="localhost:7233", plugins=[], payload_codec=codec)
+
+        mock_get.assert_awaited_once()
+        assert mock_get.await_args.kwargs["payload_codec"] is codec
+
+
+class TestGetTemporalClientUtils:
+    async def test_no_codec_uses_pydantic_data_converter_unchanged(self):
+        from agentex.lib.core.clients.temporal.utils import get_temporal_client
+
+        with _mock_connect() as mock_connect:
+            await get_temporal_client(temporal_address="localhost:7233")
+
+        kwargs = mock_connect.await_args.kwargs
+        assert kwargs["data_converter"] is pydantic_data_converter
+        assert kwargs["data_converter"].payload_codec is None
+
+    async def test_codec_is_attached_to_pydantic_data_converter(self):
+        from agentex.lib.core.clients.temporal.utils import get_temporal_client
+
+        codec = _NoopCodec()
+        with _mock_connect() as mock_connect:
+            await get_temporal_client(temporal_address="localhost:7233", payload_codec=codec)
+
+        data_converter = mock_connect.await_args.kwargs["data_converter"]
+        assert data_converter.payload_codec is codec
+        assert data_converter.payload_converter_class is pydantic_data_converter.payload_converter_class
+
+    async def test_codec_with_openai_plugin_raises(self):
+        from agentex.lib.core.clients.temporal.utils import get_temporal_client
+
+        codec = _NoopCodec()
+        with _patch_openai_plugin(), _mock_connect() as mock_connect:
+            with pytest.raises(ValueError, match="payload_codec is not supported alongside OpenAIAgentsPlugin"):
+                await get_temporal_client(
+                    temporal_address="localhost:7233",
+                    plugins=[_FakeOpenAIPlugin()],
+                    payload_codec=codec,
+                )
+            mock_connect.assert_not_awaited()
+
+    async def test_openai_plugin_without_codec_omits_data_converter(self):
+        from agentex.lib.core.clients.temporal.utils import get_temporal_client
+
+        with _patch_openai_plugin(), _mock_connect() as mock_connect:
+            await get_temporal_client(temporal_address="localhost:7233", plugins=[_FakeOpenAIPlugin()])
+
+        assert "data_converter" not in mock_connect.await_args.kwargs
+
+
+class TestGetTemporalClientWorker:
+    async def test_no_codec_uses_custom_data_converter_unchanged(self):
+        from agentex.lib.core.temporal.workers.worker import get_temporal_client, custom_data_converter
+
+        with _mock_connect() as mock_connect:
+            await get_temporal_client(temporal_address="localhost:7233")
+
+        kwargs = mock_connect.await_args.kwargs
+        assert kwargs["data_converter"] is custom_data_converter
+        assert kwargs["data_converter"].payload_codec is None
+
+    async def test_codec_is_attached_to_custom_data_converter(self):
+        from agentex.lib.core.temporal.workers.worker import get_temporal_client, custom_data_converter
+
+        codec = _NoopCodec()
+        with _mock_connect() as mock_connect:
+            await get_temporal_client(temporal_address="localhost:7233", payload_codec=codec)
+
+        data_converter = mock_connect.await_args.kwargs["data_converter"]
+        assert data_converter.payload_codec is codec
+        assert data_converter.payload_converter_class is custom_data_converter.payload_converter_class
+
+    async def test_codec_with_openai_plugin_raises(self):
+        from agentex.lib.core.temporal.workers.worker import get_temporal_client
+
+        codec = _NoopCodec()
+        with _patch_openai_plugin(), _mock_connect() as mock_connect:
+            with pytest.raises(ValueError, match="payload_codec is not supported alongside OpenAIAgentsPlugin"):
+                await get_temporal_client(
+                    temporal_address="localhost:7233",
+                    plugins=[_FakeOpenAIPlugin()],
+                    payload_codec=codec,
+                )
+            mock_connect.assert_not_awaited()
+
+    async def test_openai_plugin_without_codec_omits_data_converter(self):
+        from agentex.lib.core.temporal.workers.worker import get_temporal_client
+
+        with _patch_openai_plugin(), _mock_connect() as mock_connect:
+            await get_temporal_client(temporal_address="localhost:7233", plugins=[_FakeOpenAIPlugin()])
+
+        assert "data_converter" not in mock_connect.await_args.kwargs
+
+
+class TestAgentexWorkerCodec:
+    def test_worker_stores_payload_codec(self):
+        from agentex.lib.core.temporal.workers.worker import AgentexWorker
+
+        codec = _NoopCodec()
+        worker = AgentexWorker(task_queue="test-queue", health_check_port=80, payload_codec=codec)
+        assert worker.payload_codec is codec
+
+    def test_worker_default_payload_codec_is_none(self):
+        from agentex.lib.core.temporal.workers.worker import AgentexWorker
+
+        worker = AgentexWorker(task_queue="test-queue", health_check_port=80)
+        assert worker.payload_codec is None
+
+
+class TestTemporalACPCodec:
+    def test_create_stores_payload_codec(self):
+        from agentex.lib.sdk.fastacp.impl.temporal_acp import TemporalACP
+
+        codec = _NoopCodec()
+        acp = TemporalACP.create(temporal_address="localhost:7233", payload_codec=codec)
+        assert acp._payload_codec is codec
+
+    def test_create_default_payload_codec_is_none(self):
+        from agentex.lib.sdk.fastacp.impl.temporal_acp import TemporalACP
+
+        acp = TemporalACP.create(temporal_address="localhost:7233")
+        assert acp._payload_codec is None
+
+
+class TestFastACPConfigCodec:
+    def test_config_default_codec_is_none(self):
+        from agentex.lib.types.fastacp import TemporalACPConfig
+
+        assert TemporalACPConfig().payload_codec is None
+
+    def test_config_accepts_codec(self):
+        from agentex.lib.types.fastacp import TemporalACPConfig
+
+        codec = _NoopCodec()
+        assert TemporalACPConfig(payload_codec=codec).payload_codec is codec
+
+    def test_fastacp_forwards_codec_from_config(self):
+        from agentex.lib.types.fastacp import TemporalACPConfig
+        from agentex.lib.sdk.fastacp.fastacp import FastACP
+
+        codec = _NoopCodec()
+        config = TemporalACPConfig(payload_codec=codec)
+        captured: dict[str, Any] = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+        with patch(
+            "agentex.lib.sdk.fastacp.impl.temporal_acp.TemporalACP.create",
+            side_effect=fake_create,
+        ):
+            FastACP.create("async", config=config)
+
+        assert captured.get("payload_codec") is codec

--- a/tests/lib/test_payload_codec.py
+++ b/tests/lib/test_payload_codec.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -10,17 +10,21 @@ from temporalio.contrib.pydantic import pydantic_data_converter
 
 
 class _NoopCodec(PayloadCodec):
+    @override
     async def encode(self, payloads):
         return list(payloads)
 
+    @override
     async def decode(self, payloads):
         return list(payloads)
 
 
 class _FakeOpenAIPlugin(ClientPlugin):
+    @override
     def configure_client(self, config):
         return config
 
+    @override
     async def connect_service_client(self, config, next):
         return await next(config)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in `PayloadCodec` support throughout the Temporal integration layer — from `TemporalACPConfig` and `FastACP.create` down to `TemporalClient`, `TemporalACP`, and `AgentexWorker` — so callers can plug in encryption or compression codecs at both the ACP (client) and worker sides. The previous concern about silent codec dropping when `OpenAIAgentsPlugin` is present is resolved by promoting it to an explicit `ValueError` on both paths.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 style suggestions.

The core behavioral change (explicit ValueError instead of silent drop) directly addresses the previous review concern. Codec propagation is consistent across client and worker paths and is well-covered by the new test suite. The only open item is a P2 inconsistency in TemporalACPConfig where payload_codec lacks the same @field_validator guard applied to plugins and interceptors.

src/agentex/lib/types/fastacp.py — `payload_codec` field lacks runtime type validation.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/clients/temporal/temporal_client.py | Added `payload_codec` parameter to `__init__`, `create`, and `_get_temporal_client`; correctly stored and propagated to `get_temporal_client`. |
| src/agentex/lib/core/clients/temporal/utils.py | Added `payload_codec` to `get_temporal_client`; raises `ValueError` when both OpenAI plugin and codec are present; attaches codec via `dataclasses.replace` when provided. |
| src/agentex/lib/core/temporal/workers/worker.py | Added `payload_codec` to `AgentexWorker` and its `get_temporal_client` helper; same guard against OpenAI plugin conflict as the client-side utility. |
| src/agentex/lib/sdk/fastacp/impl/temporal_acp.py | Added `payload_codec` field to `TemporalACP.__init__` and `create`; forwarded to `TemporalClient.create` in the lifespan function. |
| src/agentex/lib/sdk/fastacp/fastacp.py | Added `payload_codec` forwarding from `TemporalACPConfig` to `TemporalACP.create` via the `hasattr` pattern consistent with other fields. |
| src/agentex/lib/types/fastacp.py | Added `payload_codec: Any` field to `TemporalACPConfig` with documentation, but lacks a `@field_validator` unlike `plugins` and `interceptors`. |
| tests/lib/test_payload_codec.py | Comprehensive test coverage for all new codec paths across client utils, worker utils, `AgentexWorker`, `TemporalACP`, and `FastACP` config forwarding. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant FastACP
    participant TemporalACP
    participant TemporalClient
    participant get_temporal_client
    participant Temporal

    User->>FastACP: create("async", config=TemporalACPConfig(payload_codec=codec))
    FastACP->>TemporalACP: create(temporal_address, plugins, interceptors, payload_codec)
    Note over TemporalACP: stores _payload_codec

    Note over TemporalACP: lifespan startup
    TemporalACP->>TemporalClient: create(temporal_address, plugins, payload_codec)
    TemporalClient->>get_temporal_client: get_temporal_client(..., payload_codec)
    alt has_openai_plugin AND payload_codec is not None
        get_temporal_client-->>User: raise ValueError
    else no conflict
        get_temporal_client->>get_temporal_client: dataclasses.replace(data_converter, payload_codec=codec)
        get_temporal_client->>Temporal: Client.connect(data_converter=patched_converter)
        Temporal-->>get_temporal_client: client
    end
    get_temporal_client-->>TemporalClient: client
    TemporalClient-->>TemporalACP: TemporalClient instance

    User->>AgentexWorker: AgentexWorker(payload_codec=codec)
    AgentexWorker->>get_temporal_client: get_temporal_client(..., payload_codec)
    get_temporal_client->>Temporal: Client.connect(data_converter=patched_converter)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Ftypes%2Ffastacp.py%3A66%0A**%60payload_codec%60%20accepts%20any%20value%20without%20type-checking**%0A%0A%60plugins%60%20and%20%60interceptors%60%20both%20have%20%60%40field_validator%60%20methods%20that%20call%20runtime%20validators%20%28%60validate_client_plugins%60%20%2F%20%60validate_worker_interceptors%60%29.%20%60payload_codec%60%20is%20typed%20as%20%60Any%60%20and%20has%20no%20validator%2C%20so%20an%20object%20that%20doesn't%20implement%20%60PayloadCodec%60%20will%20pass%20Pydantic%20validation%20and%20only%20fail%20deep%20inside%20Temporal's%20encode%2Fdecode%20path%20at%20runtime.%0A%0AConsider%20either%20adding%20a%20%60%40field_validator%60%20%28e.g.%2C%20checking%20%60isinstance%28v%2C%20PayloadCodec%29%60%29%20or%20configuring%20%60model_config%20%3D%20ConfigDict%28arbitrary_types_allowed%3DTrue%29%60%20and%20narrowing%20the%20annotation%20to%20%60PayloadCodec%20%7C%20None%60%3A%0A%0A%60%60%60python%0Afrom%20pydantic%20import%20ConfigDict%0A%0Aclass%20TemporalACPConfig%28AsyncACPConfig%29%3A%0A%20%20%20%20model_config%20%3D%20ConfigDict%28arbitrary_types_allowed%3DTrue%29%0A%20%20%20%20...%0A%20%20%20%20payload_codec%3A%20PayloadCodec%20%7C%20None%20%3D%20Field%28default%3DNone%2C%20frozen%3DTrue%29%0A%60%60%60%0A%0A&pr=328&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Ftypes%2Ffastacp.py%3A66%0A**%60payload_codec%60%20accepts%20any%20value%20without%20type-checking**%0A%0A%60plugins%60%20and%20%60interceptors%60%20both%20have%20%60%40field_validator%60%20methods%20that%20call%20runtime%20validators%20%28%60validate_client_plugins%60%20%2F%20%60validate_worker_interceptors%60%29.%20%60payload_codec%60%20is%20typed%20as%20%60Any%60%20and%20has%20no%20validator%2C%20so%20an%20object%20that%20doesn't%20implement%20%60PayloadCodec%60%20will%20pass%20Pydantic%20validation%20and%20only%20fail%20deep%20inside%20Temporal's%20encode%2Fdecode%20path%20at%20runtime.%0A%0AConsider%20either%20adding%20a%20%60%40field_validator%60%20%28e.g.%2C%20checking%20%60isinstance%28v%2C%20PayloadCodec%29%60%29%20or%20configuring%20%60model_config%20%3D%20ConfigDict%28arbitrary_types_allowed%3DTrue%29%60%20and%20narrowing%20the%20annotation%20to%20%60PayloadCodec%20%7C%20None%60%3A%0A%0A%60%60%60python%0Afrom%20pydantic%20import%20ConfigDict%0A%0Aclass%20TemporalACPConfig%28AsyncACPConfig%29%3A%0A%20%20%20%20model_config%20%3D%20ConfigDict%28arbitrary_types_allowed%3DTrue%29%0A%20%20%20%20...%0A%20%20%20%20payload_codec%3A%20PayloadCodec%20%7C%20None%20%3D%20Field%28default%3DNone%2C%20frozen%3DTrue%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=328&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/agentex/lib/types/fastacp.py
Line: 66

Comment:
**`payload_codec` accepts any value without type-checking**

`plugins` and `interceptors` both have `@field_validator` methods that call runtime validators (`validate_client_plugins` / `validate_worker_interceptors`). `payload_codec` is typed as `Any` and has no validator, so an object that doesn't implement `PayloadCodec` will pass Pydantic validation and only fail deep inside Temporal's encode/decode path at runtime.

Consider either adding a `@field_validator` (e.g., checking `isinstance(v, PayloadCodec)`) or configuring `model_config = ConfigDict(arbitrary_types_allowed=True)` and narrowing the annotation to `PayloadCodec | None`:

```python
from pydantic import ConfigDict

class TemporalACPConfig(AsyncACPConfig):
    model_config = ConfigDict(arbitrary_types_allowed=True)
    ...
    payload_codec: PayloadCodec | None = Field(default=None, frozen=True)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["add override annotations to codec and pl..."](https://github.com/scaleapi/scale-agentex-python/commit/cc103efa24518bef602850c06c7aae8ebb33ca73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29016325)</sub>

<!-- /greptile_comment -->