### PR TITLE
feat(adk): support task_id on span creation

### DIFF
--- a/src/agentex/lib/adk/_modules/tracing.py
+++ b/src/agentex/lib/adk/_modules/tracing.py
@@ -64,9 +64,7 @@ class TracingModule:
         # Re-create the underlying httpx client when the event loop changes
         # (e.g. between HTTP requests in a sync ASGI server) to avoid
         # "Event loop is closed" / "bound to a different event loop" errors.
-        if self._tracing_service_lazy is None or (
-            loop_id is not None and loop_id != self._bound_loop_id
-        ):
+        if self._tracing_service_lazy is None or (loop_id is not None and loop_id != self._bound_loop_id):
             import httpx
 
             # Disable keepalive so each span HTTP call gets a fresh TCP
@@ -93,6 +91,7 @@ class TracingModule:
         input: list[Any] | dict[str, Any] | BaseModel | None = None,
         data: list[Any] | dict[str, Any] | BaseModel | None = None,
         parent_id: str | None = None,
+        task_id: str | None = None,
         start_to_close_timeout: timedelta = timedelta(seconds=5),
         heartbeat_timeout: timedelta = timedelta(seconds=5),
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
@@ -109,6 +108,7 @@ class TracingModule:
             input (Union[List, Dict, BaseModel]): The input for the span.
             parent_id (Optional[str]): The parent span ID for the span.
             data (Optional[Union[List, Dict, BaseModel]]): The data for the span.
+            task_id (Optional[str]): The task ID this span belongs to.
             start_to_close_timeout (timedelta): The start to close timeout for the span.
             heartbeat_timeout (timedelta): The heartbeat timeout for the span.
             retry_policy (RetryPolicy): The retry policy for the span.
@@ -126,6 +126,7 @@ class TracingModule:
             input=input,
             parent_id=parent_id,
             data=data,
+            task_id=task_id,
             start_to_close_timeout=start_to_close_timeout,
             heartbeat_timeout=heartbeat_timeout,
             retry_policy=retry_policy,
@@ -149,6 +150,7 @@ class TracingModule:
         input: list[Any] | dict[str, Any] | BaseModel | None = None,
         parent_id: str | None = None,
         data: list[Any] | dict[str, Any] | BaseModel | None = None,
+        task_id: str | None = None,
         start_to_close_timeout: timedelta = timedelta(seconds=5),
         heartbeat_timeout: timedelta = timedelta(seconds=1),
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
@@ -162,6 +164,7 @@ class TracingModule:
             input (Union[List, Dict, BaseModel]): The input for the span.
             parent_id (Optional[str]): The parent span ID for the span.
             data (Optional[Union[List, Dict, BaseModel]]): The data for the span.
+            task_id (Optional[str]): The task ID this span belongs to.
             start_to_close_timeout (timedelta): The start to close timeout for the span.
             heartbeat_timeout (timedelta): The heartbeat timeout for the span.
             retry_policy (RetryPolicy): The retry policy for the span.
@@ -175,6 +178,7 @@ class TracingModule:
             name=name,
             input=input,
             data=data,
+            task_id=task_id,
         )
         if in_temporal_workflow():
             return await ActivityHelpers.execute_activity(
@@ -192,6 +196,7 @@ class TracingModule:
                 input=input,
                 parent_id=parent_id,
                 data=data,
+                task_id=task_id,
             )
 
     async def end_span(

--- a/src/agentex/lib/core/services/adk/tracing.py
+++ b/src/agentex/lib/core/services/adk/tracing.py
@@ -22,6 +22,7 @@ class TracingService:
         parent_id: str | None = None,
         input: list[Any] | dict[str, Any] | BaseModel | None = None,
         data: list[Any] | dict[str, Any] | BaseModel | None = None,
+        task_id: str | None = None,
     ) -> Span | None:
         trace = self._tracer.trace(trace_id)
         span = await trace.start_span(
@@ -29,6 +30,7 @@ class TracingService:
             parent_id=parent_id,
             input=input or {},
             data=data,
+            task_id=task_id,
         )
         heartbeat_if_in_workflow("start span")
         return span

--- a/src/agentex/lib/core/temporal/activities/adk/tracing_activities.py
+++ b/src/agentex/lib/core/temporal/activities/adk/tracing_activities.py
@@ -24,6 +24,7 @@ class StartSpanParams(BaseModel):
     name: str
     input: list[Any] | dict[str, Any] | BaseModel | None = None
     data: list[Any] | dict[str, Any] | BaseModel | None = None
+    task_id: str | None = None
 
 
 class EndSpanParams(BaseModel):
@@ -47,6 +48,7 @@ class TracingActivities:
             name=params.name,
             input=params.input,
             data=params.data,
+            task_id=params.task_id,
         )
 
     @activity.defn(name=TracingActivityName.END_SPAN)

--- a/src/agentex/lib/core/tracing/trace.py
+++ b/src/agentex/lib/core/tracing/trace.py
@@ -54,6 +54,7 @@ class Trace:
         parent_id: str | None = None,
         input: dict[str, Any] | list[dict[str, Any]] | BaseModel | None = None,
         data: dict[str, Any] | list[dict[str, Any]] | BaseModel | None = None,
+        task_id: str | None = None,
     ) -> Span:
         """
         Start a new span and register it with the API.
@@ -63,6 +64,7 @@ class Trace:
             parent_id: Optional parent span ID.
             input: Optional input data for the span.
             data: Optional additional data for the span.
+            task_id: Optional ID of the task this span belongs to.
 
         Returns:
             The newly created span.
@@ -86,6 +88,7 @@ class Trace:
             start_time=start_time,
             input=serialized_input,
             data=serialized_data,
+            task_id=task_id,
         )
 
         for processor in self.processors:
@@ -150,6 +153,7 @@ class Trace:
         parent_id: str | None = None,
         input: dict[str, Any] | list[dict[str, Any]] | BaseModel | None = None,
         data: dict[str, Any] | list[dict[str, Any]] | BaseModel | None = None,
+        task_id: str | None = None,
     ):
         """
         Context manager for spans.
@@ -158,7 +162,7 @@ class Trace:
         if not self.trace_id:
             yield None
             return
-        span = self.start_span(name, parent_id, input, data)
+        span = self.start_span(name, parent_id, input, data, task_id=task_id)
         try:
             yield span
         finally:
@@ -198,6 +202,7 @@ class AsyncTrace:
         parent_id: str | None = None,
         input: dict[str, Any] | list[dict[str, Any]] | BaseModel | None = None,
         data: dict[str, Any] | list[dict[str, Any]] | BaseModel | None = None,
+        task_id: str | None = None,
     ) -> Span:
         """
         Start a new span and register it with the API.
@@ -207,6 +212,7 @@ class AsyncTrace:
             parent_id: Optional parent span ID.
             input: Optional input data for the span.
             data: Optional additional data for the span.
+            task_id: Optional ID of the task this span belongs to.
 
         Returns:
             The newly created span.
@@ -229,6 +235,7 @@ class AsyncTrace:
             start_time=start_time,
             input=serialized_input,
             data=serialized_data,
+            task_id=task_id,
         )
 
         if self.processors:
@@ -293,6 +300,7 @@ class AsyncTrace:
         parent_id: str | None = None,
         input: dict[str, Any] | list[dict[str, Any]] | BaseModel | None = None,
         data: dict[str, Any] | list[dict[str, Any]] | BaseModel | None = None,
+        task_id: str | None = None,
     ) -> AsyncGenerator[Span | None, None]:
         """
         Context manager for spans.
@@ -302,6 +310,7 @@ class AsyncTrace:
             parent_id: Optional parent span ID.
             input: Optional input data for the span.
             data: Optional additional data for the span.
+            task_id: Optional ID of the task this span belongs to.
 
         Yields:
             The span object.
@@ -309,7 +318,7 @@ class AsyncTrace:
         if not self.trace_id:
             yield None
             return
-        span = await self.start_span(name, parent_id, input, data)
+        span = await self.start_span(name, parent_id, input, data, task_id=task_id)
         try:
             yield span
         finally:

--- a/tests/lib/adk/test_tracing_activities.py
+++ b/tests/lib/adk/test_tracing_activities.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+from temporalio.testing import ActivityEnvironment
+
+from agentex.types.span import Span
+
+
+def _make_span(**overrides) -> Span:
+    defaults = {
+        "id": "span-123",
+        "name": "test-span",
+        "start_time": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "trace_id": "trace-123",
+    }
+    defaults.update(overrides)
+    return Span(**defaults)
+
+
+def _make_tracing_activities():
+    from agentex.lib.core.services.adk.tracing import TracingService
+    from agentex.lib.core.temporal.activities.adk.tracing_activities import TracingActivities
+
+    mock_service = AsyncMock(spec=TracingService)
+    activities = TracingActivities(tracing_service=mock_service)
+    env = ActivityEnvironment()
+    return mock_service, activities, env
+
+
+class TestStartSpanActivity:
+    async def test_start_span_with_task_id(self):
+        from agentex.lib.core.temporal.activities.adk.tracing_activities import StartSpanParams
+
+        mock_service, activities, env = _make_tracing_activities()
+        expected = _make_span(task_id="task-abc")
+        mock_service.start_span.return_value = expected
+
+        params = StartSpanParams(
+            trace_id="trace-123",
+            name="test-span",
+            task_id="task-abc",
+        )
+        result = await env.run(activities.start_span, params)
+
+        assert result == expected
+        assert result.task_id == "task-abc"
+        mock_service.start_span.assert_called_once_with(
+            trace_id="trace-123",
+            parent_id=None,
+            name="test-span",
+            input=None,
+            data=None,
+            task_id="task-abc",
+        )
+
+    async def test_start_span_without_task_id(self):
+        from agentex.lib.core.temporal.activities.adk.tracing_activities import StartSpanParams
+
+        mock_service, activities, env = _make_tracing_activities()
+        expected = _make_span()
+        mock_service.start_span.return_value = expected
+
+        params = StartSpanParams(trace_id="trace-123", name="test-span")
+        result = await env.run(activities.start_span, params)
+
+        assert result == expected
+        mock_service.start_span.assert_called_once_with(
+            trace_id="trace-123",
+            parent_id=None,
+            name="test-span",
+            input=None,
+            data=None,
+            task_id=None,
+        )
+
+
+class TestEndSpanActivity:
+    async def test_end_span_preserves_task_id(self):
+        from agentex.lib.core.temporal.activities.adk.tracing_activities import EndSpanParams
+
+        mock_service, activities, env = _make_tracing_activities()
+        span = _make_span(task_id="task-abc")
+        expected = _make_span(
+            task_id="task-abc",
+            end_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        mock_service.end_span.return_value = expected
+
+        params = EndSpanParams(trace_id="trace-123", span=span)
+        result = await env.run(activities.end_span, params)
+
+        assert result == expected
+        assert result.task_id == "task-abc"
+        mock_service.end_span.assert_called_once_with(trace_id="trace-123", span=span)

--- a/tests/lib/adk/test_tracing_module.py
+++ b/tests/lib/adk/test_tracing_module.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import agentex.lib.adk._modules.tracing as _tracing_mod
+from agentex.types.span import Span
+from agentex.lib.adk._modules.tracing import TracingModule
+from agentex.lib.core.services.adk.tracing import TracingService
+
+
+def _make_span(**overrides) -> Span:
+    defaults = {
+        "id": "span-123",
+        "name": "test-span",
+        "start_time": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "trace_id": "trace-123",
+    }
+    defaults.update(overrides)
+    return Span(**defaults)
+
+
+def _make_module() -> tuple[AsyncMock, TracingModule]:
+    mock_service = AsyncMock(spec=TracingService)
+    module = TracingModule(tracing_service=mock_service)
+    return mock_service, module
+
+
+class TestStartSpan:
+    async def test_start_span_with_task_id(self):
+        mock_service, module = _make_module()
+        expected = _make_span(task_id="task-abc")
+        mock_service.start_span.return_value = expected
+
+        with patch.object(_tracing_mod, "in_temporal_workflow", return_value=False):
+            result = await module.start_span(
+                trace_id="trace-123",
+                name="test-span",
+                task_id="task-abc",
+            )
+
+        assert result == expected
+        assert result.task_id == "task-abc"
+        mock_service.start_span.assert_called_once_with(
+            trace_id="trace-123",
+            name="test-span",
+            input=None,
+            parent_id=None,
+            data=None,
+            task_id="task-abc",
+        )
+
+    async def test_start_span_without_task_id(self):
+        mock_service, module = _make_module()
+        expected = _make_span()
+        mock_service.start_span.return_value = expected
+
+        with patch.object(_tracing_mod, "in_temporal_workflow", return_value=False):
+            result = await module.start_span(trace_id="trace-123", name="test-span")
+
+        assert result == expected
+        mock_service.start_span.assert_called_once_with(
+            trace_id="trace-123",
+            name="test-span",
+            input=None,
+            parent_id=None,
+            data=None,
+            task_id=None,
+        )
+
+
+class TestEndSpan:
+    async def test_end_span_preserves_task_id(self):
+        mock_service, module = _make_module()
+        span = _make_span(task_id="task-abc")
+        expected = _make_span(
+            task_id="task-abc",
+            end_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        mock_service.end_span.return_value = expected
+
+        with patch.object(_tracing_mod, "in_temporal_workflow", return_value=False):
+            result = await module.end_span(trace_id="trace-123", span=span)
+
+        assert result == expected
+        assert result.task_id == "task-abc"
+        mock_service.end_span.assert_called_once_with(trace_id="trace-123", span=span)
+
+
+class TestSpanContextManager:
+    async def test_span_context_manager_forwards_task_id(self):
+        mock_service, module = _make_module()
+        started = _make_span(task_id="task-abc")
+        mock_service.start_span.return_value = started
+        mock_service.end_span.return_value = started
+
+        with patch.object(_tracing_mod, "in_temporal_workflow", return_value=False):
+            async with module.span(
+                trace_id="trace-123",
+                name="test-span",
+                task_id="task-abc",
+            ) as span:
+                assert span is not None
+                assert span.task_id == "task-abc"
+
+        assert mock_service.start_span.call_args.kwargs["task_id"] == "task-abc"
+        mock_service.end_span.assert_called_once()
+
+    async def test_span_context_manager_noop_when_no_trace_id(self):
+        mock_service, module = _make_module()
+
+        with patch.object(_tracing_mod, "in_temporal_workflow", return_value=False):
+            async with module.span(trace_id="", name="test-span") as span:
+                assert span is None
+
+        mock_service.start_span.assert_not_called()
+        mock_service.end_span.assert_not_called()

--- a/tests/lib/adk/test_tracing_service.py
+++ b/tests/lib/adk/test_tracing_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from agentex.types.span import Span
+from agentex.lib.core.services.adk.tracing import TracingService
+
+
+def _make_span(**overrides) -> Span:
+    defaults = {
+        "id": "span-123",
+        "name": "test-span",
+        "start_time": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "trace_id": "trace-123",
+    }
+    defaults.update(overrides)
+    return Span(**defaults)
+
+
+def _make_service() -> tuple[MagicMock, MagicMock, TracingService]:
+    """Build a TracingService backed by an AsyncTracer whose
+    trace.start_span / trace.end_span are mocked."""
+    mock_trace = MagicMock()
+    mock_trace.start_span = AsyncMock()
+    mock_trace.end_span = AsyncMock()
+
+    mock_tracer = MagicMock()
+    mock_tracer.trace.return_value = mock_trace
+
+    service = TracingService(tracer=mock_tracer)
+    return mock_tracer, mock_trace, service
+
+
+class TestStartSpanService:
+    async def test_start_span_passes_task_id(self):
+        mock_tracer, mock_trace, service = _make_service()
+        expected = _make_span(task_id="task-abc")
+        mock_trace.start_span.return_value = expected
+
+        result = await service.start_span(
+            trace_id="trace-123",
+            name="test-span",
+            task_id="task-abc",
+        )
+
+        assert result == expected
+        mock_tracer.trace.assert_called_once_with("trace-123")
+        mock_trace.start_span.assert_awaited_once_with(
+            name="test-span",
+            parent_id=None,
+            input={},
+            data=None,
+            task_id="task-abc",
+        )
+
+    async def test_start_span_without_task_id(self):
+        _mock_tracer, mock_trace, service = _make_service()
+        expected = _make_span()
+        mock_trace.start_span.return_value = expected
+
+        result = await service.start_span(trace_id="trace-123", name="test-span")
+
+        assert result == expected
+        mock_trace.start_span.assert_awaited_once_with(
+            name="test-span",
+            parent_id=None,
+            input={},
+            data=None,
+            task_id=None,
+        )
+
+
+class TestEndSpanService:
+    async def test_end_span_forwards_span(self):
+        mock_tracer, mock_trace, service = _make_service()
+        span = _make_span(task_id="task-abc")
+        mock_trace.end_span.return_value = span
+
+        result = await service.end_span(trace_id="trace-123", span=span)
+
+        assert result is span
+        mock_tracer.trace.assert_called_once_with("trace-123")
+        mock_trace.end_span.assert_awaited_once_with(span)

--- a/tests/lib/core/tracing/test_trace_task_id.py
+++ b/tests/lib/core/tracing/test_trace_task_id.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from agentex.lib.core.tracing.trace import Trace, AsyncTrace
+
+
+def _make_sync_trace(trace_id: str = "trace-123") -> tuple[MagicMock, Trace]:
+    client = MagicMock()
+    trace = Trace(processors=[], client=client, trace_id=trace_id)
+    return client, trace
+
+
+def _make_async_trace(trace_id: str = "trace-123") -> tuple[MagicMock, AsyncTrace]:
+    client = MagicMock()
+    trace = AsyncTrace(processors=[], client=client, trace_id=trace_id)
+    return client, trace
+
+
+class TestSyncTraceTaskId:
+    def test_start_span_sets_task_id_on_span(self):
+        _client, trace = _make_sync_trace()
+        span = trace.start_span(name="foo", task_id="task-abc")
+        assert span.task_id == "task-abc"
+        assert span.trace_id == "trace-123"
+
+    def test_start_span_defaults_task_id_to_none(self):
+        _client, trace = _make_sync_trace()
+        span = trace.start_span(name="foo")
+        assert span.task_id is None
+
+    def test_end_span_preserves_task_id_from_span(self):
+        _client, trace = _make_sync_trace()
+        span = trace.start_span(name="foo", task_id="task-abc")
+        trace.end_span(span)
+        assert span.task_id == "task-abc"
+
+
+class TestAsyncTraceTaskId:
+    async def test_start_span_sets_task_id_on_span(self):
+        _client, trace = _make_async_trace()
+        span = await trace.start_span(name="foo", task_id="task-abc")
+        assert span.task_id == "task-abc"
+        assert span.trace_id == "trace-123"
+
+    async def test_start_span_defaults_task_id_to_none(self):
+        _client, trace = _make_async_trace()
+        span = await trace.start_span(name="foo")
+        assert span.task_id is None
+
+    async def test_end_span_preserves_task_id_from_span(self):
+        _client, trace = _make_async_trace()
+        span = await trace.start_span(name="foo", task_id="task-abc")
+        await trace.end_span(span)
+        assert span.task_id == "task-abc"


### PR DESCRIPTION
## Summary
- Thread an optional `task_id` through ADK span creation (`TracingModule.start_span` / `span` context manager → `TracingService` → `StartSpanParams` activity → `Trace`/`AsyncTrace.start_span`), so spans can be associated with the task that produced them
- `end_span` intentionally unchanged — it already forwards the existing `Span` object which carries `task_id` from creation, matching how other fields (name, parent_id, input) are handled
- Tests at each layer (core trace, service, activity, ADK module) verify `task_id` is set on the `Span` and plumbed through correctly, and that it's preserved through `end_span`

## Test plan
- [x] `rye run pytest tests/lib/adk/test_tracing_module.py tests/lib/adk/test_tracing_activities.py tests/lib/adk/test_tracing_service.py tests/lib/core/tracing/test_trace_task_id.py` — 17 passed
- [x] `rye run pytest tests/lib/core/tracing/ tests/lib/adk/` — no regressions (86 passed, 2 pre-existing skips)
- [x] `rye run ruff format` + `rye run ruff check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads an optional `task_id` parameter through the full ADK span creation stack — from `TracingModule.start_span` / `span` context manager down through `StartSpanParams`, `TracingActivities`, `TracingService`, and into both `Trace` and `AsyncTrace.start_span` — so spans can be associated with the task that produced them. `end_span` is intentionally left unchanged since the `Span` object already carries `task_id` from creation. Coverage is thorough with 17 new tests across all four layers.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — additive, backward-compatible change with comprehensive test coverage at every layer.

All changed files introduce only an optional parameter with a `None` default, preserving backward compatibility throughout. The `Span` model already had `task_id`. Tests cover all four layers (core trace, service, activity, module). The one P2 finding (`AgentexLangGraphTracingHandler` not yet forwarding `task_id`) is a gap in coverage, not a regression.

No files require special attention. Optionally consider updating `_langgraph_tracing.py` in a follow-up to propagate `task_id` through LLM/tool child spans.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/adk/_modules/tracing.py | Adds `task_id` param to both `start_span` and `span` context manager, threading it through to `StartSpanParams` and direct `TracingService` calls. Clean, backward-compatible addition. |
| src/agentex/lib/core/services/adk/tracing.py | Adds `task_id` parameter and forwards it to `trace.start_span`. Minimal, correct change. |
| src/agentex/lib/core/temporal/activities/adk/tracing_activities.py | Adds `task_id: str | None = None` to `StartSpanParams` and passes it through the activity; `EndSpanParams` and `end_span` correctly left unchanged. |
| src/agentex/lib/core/tracing/trace.py | Adds `task_id` to `Trace.start_span`, `AsyncTrace.start_span`, and both `span` context managers; stored on the `Span` object at creation. |
| tests/lib/adk/test_tracing_module.py | New tests cover `task_id` forwarding at the module level for `start_span`, `end_span`, and the context manager, including the no-op case. |
| tests/lib/adk/test_tracing_activities.py | Activity-level tests verify `task_id` is plumbed through `StartSpanParams` and preserved across `end_span`. |
| tests/lib/adk/test_tracing_service.py | Service-level tests confirm `task_id` is forwarded to `trace.start_span` and that `end_span` correctly passes through the span object. |
| tests/lib/core/tracing/test_trace_task_id.py | Core trace tests verify both `Trace` and `AsyncTrace` set `task_id` on the `Span` and that `end_span` preserves it. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant TracingModule
    participant StartSpanParams
    participant TracingActivities
    participant TracingService
    participant AsyncTrace
    participant Span

    Caller->>TracingModule: start_span(trace_id, name, task_id)
    alt in Temporal workflow
        TracingModule->>StartSpanParams: StartSpanParams(task_id=task_id)
        TracingModule->>TracingActivities: execute_activity(START_SPAN, params)
        TracingActivities->>TracingService: start_span(..., task_id=params.task_id)
    else direct call
        TracingModule->>TracingService: start_span(..., task_id=task_id)
    end
    TracingService->>AsyncTrace: trace.start_span(..., task_id=task_id)
    AsyncTrace->>Span: Span(task_id=task_id, ...)
    Span-->>Caller: span (with task_id set)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fadk%2F_modules%2F_langgraph_tracing.py%3A36-50%0A**%60task_id%60%20not%20forwarded%20in%20LangGraph%20tracing%20handler**%0A%0A%60AgentexLangGraphTracingHandler%60%20creates%20child%20spans%20for%20LLM%20calls%20and%20tool%20executions%20via%20%60TracingModule.start_span%60%2C%20but%20it%20never%20accepts%20or%20forwards%20a%20%60task_id%60.%20Spans%20produced%20by%20this%20handler%20will%20always%20have%20%60task_id%3DNone%60%2C%20even%20when%20the%20caller%20has%20a%20task%20context.%0A%0AIf%20the%20intent%20is%20for%20*all*%20spans%20in%20a%20trace%20to%20carry%20the%20task%20association%2C%20consider%20accepting%20%60task_id%60%20in%20%60__init__%60%20alongside%20%60parent_span_id%60%20and%20threading%20it%20through%20%60on_chat_model_start%60%20%2F%20%60on_tool_start%60.%0A%0A%60%60%60python%0Adef%20__init__%28%0A%20%20%20%20self%2C%0A%20%20%20%20trace_id%3A%20str%2C%0A%20%20%20%20parent_span_id%3A%20str%20%7C%20None%20%3D%20None%2C%0A%20%20%20%20task_id%3A%20str%20%7C%20None%20%3D%20None%2C%0A%20%20%20%20tracing%3A%20TracingModule%20%7C%20None%20%3D%20None%2C%0A%29%20-%3E%20None%3A%0A%20%20%20%20...%0A%20%20%20%20self._task_id%20%3D%20task_id%0A%60%60%60%0A%0A&pr=329&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fadk%2F_modules%2F_langgraph_tracing.py%3A36-50%0A**%60task_id%60%20not%20forwarded%20in%20LangGraph%20tracing%20handler**%0A%0A%60AgentexLangGraphTracingHandler%60%20creates%20child%20spans%20for%20LLM%20calls%20and%20tool%20executions%20via%20%60TracingModule.start_span%60%2C%20but%20it%20never%20accepts%20or%20forwards%20a%20%60task_id%60.%20Spans%20produced%20by%20this%20handler%20will%20always%20have%20%60task_id%3DNone%60%2C%20even%20when%20the%20caller%20has%20a%20task%20context.%0A%0AIf%20the%20intent%20is%20for%20*all*%20spans%20in%20a%20trace%20to%20carry%20the%20task%20association%2C%20consider%20accepting%20%60task_id%60%20in%20%60__init__%60%20alongside%20%60parent_span_id%60%20and%20threading%20it%20through%20%60on_chat_model_start%60%20%2F%20%60on_tool_start%60.%0A%0A%60%60%60python%0Adef%20__init__%28%0A%20%20%20%20self%2C%0A%20%20%20%20trace_id%3A%20str%2C%0A%20%20%20%20parent_span_id%3A%20str%20%7C%20None%20%3D%20None%2C%0A%20%20%20%20task_id%3A%20str%20%7C%20None%20%3D%20None%2C%0A%20%20%20%20tracing%3A%20TracingModule%20%7C%20None%20%3D%20None%2C%0A%29%20-%3E%20None%3A%0A%20%20%20%20...%0A%20%20%20%20self._task_id%20%3D%20task_id%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=329&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/agentex/lib/adk/_modules/_langgraph_tracing.py
Line: 36-50

Comment:
**`task_id` not forwarded in LangGraph tracing handler**

`AgentexLangGraphTracingHandler` creates child spans for LLM calls and tool executions via `TracingModule.start_span`, but it never accepts or forwards a `task_id`. Spans produced by this handler will always have `task_id=None`, even when the caller has a task context.

If the intent is for *all* spans in a trace to carry the task association, consider accepting `task_id` in `__init__` alongside `parent_span_id` and threading it through `on_chat_model_start` / `on_tool_start`.

```python
def __init__(
    self,
    trace_id: str,
    parent_span_id: str | None = None,
    task_id: str | None = None,
    tracing: TracingModule | None = None,
) -> None:
    ...
    self._task_id = task_id
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add task\_id to span creation"](https://github.com/scaleapi/scale-agentex-python/commit/5a1698deef8375d1f4a24f541d7e6d929ecb5862) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29135736)</sub>

<!-- /greptile_comment -->