### PR TITLE
batch SGP span upserts

### DIFF
--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import override
 
 import scale_gp_beta.lib.tracing as tracing

--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -125,48 +125,64 @@ class SGPAsyncTracingProcessor(AsyncTracingProcessor):
 
     @override
     async def on_span_start(self, span: Span) -> None:
-        self._add_source_to_span(span)
-        sgp_span = create_span(
-            name=span.name,
-            span_type=_get_span_type(span),
-            span_id=span.id,
-            parent_id=span.parent_id,
-            trace_id=span.trace_id,
-            input=span.input,
-            output=span.output,
-            metadata=span.data,
-        )
-        sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
+        await self.on_spans_start([span])
+
+    @override
+    async def on_span_end(self, span: Span) -> None:
+        await self.on_spans_end([span])
+
+    @override
+    async def on_spans_start(self, spans: list[Span]) -> None:
+        if not spans:
+            return
+
+        sgp_spans: list[SGPSpan] = []
+        for span in spans:
+            self._add_source_to_span(span)
+            sgp_span = create_span(
+                name=span.name,
+                span_type=_get_span_type(span),
+                span_id=span.id,
+                parent_id=span.parent_id,
+                trace_id=span.trace_id,
+                input=span.input,
+                output=span.output,
+                metadata=span.data,
+            )
+            sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
+            self._spans[span.id] = sgp_span
+            sgp_spans.append(sgp_span)
 
         if self.disabled:
             logger.warning("SGP is disabled, skipping span upsert")
             return
-        # TODO(AGX1-198): Batch multiple spans into a single upsert_batch call
-        # instead of one span per HTTP request.
-        # https://linear.app/scale-epd/issue/AGX1-198/actually-use-sgp-batching-for-spans
         await self.sgp_async_client.spans.upsert_batch(  # type: ignore[union-attr]
-            items=[sgp_span.to_request_params()]
+            items=[s.to_request_params() for s in sgp_spans]
         )
 
-        self._spans[span.id] = sgp_span
-
     @override
-    async def on_span_end(self, span: Span) -> None:
-        sgp_span = self._spans.pop(span.id, None)
-        if sgp_span is None:
-            logger.warning(f"Span {span.id} not found in stored spans, skipping span end")
+    async def on_spans_end(self, spans: list[Span]) -> None:
+        if not spans:
             return
 
-        self._add_source_to_span(span)
-        sgp_span.input = span.input  # type: ignore[assignment]
-        sgp_span.output = span.output  # type: ignore[assignment]
-        sgp_span.metadata = span.data  # type: ignore[assignment]
-        sgp_span.end_time = span.end_time.isoformat()  # type: ignore[union-attr]
+        to_upsert: list[SGPSpan] = []
+        for span in spans:
+            sgp_span = self._spans.pop(span.id, None)
+            if sgp_span is None:
+                logger.warning(f"Span {span.id} not found in stored spans, skipping span end")
+                continue
 
-        if self.disabled:
+            self._add_source_to_span(span)
+            sgp_span.input = span.input  # type: ignore[assignment]
+            sgp_span.output = span.output  # type: ignore[assignment]
+            sgp_span.metadata = span.data  # type: ignore[assignment]
+            sgp_span.end_time = span.end_time.isoformat()  # type: ignore[union-attr]
+            to_upsert.append(sgp_span)
+
+        if self.disabled or not to_upsert:
             return
         await self.sgp_async_client.spans.upsert_batch(  # type: ignore[union-attr]
-            items=[sgp_span.to_request_params()]
+            items=[s.to_request_params() for s in to_upsert]
         )
 
     @override

--- a/src/agentex/lib/core/tracing/processors/tracing_processor_interface.py
+++ b/src/agentex/lib/core/tracing/processors/tracing_processor_interface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from abc import ABC, abstractmethod
 

--- a/src/agentex/lib/core/tracing/processors/tracing_processor_interface.py
+++ b/src/agentex/lib/core/tracing/processors/tracing_processor_interface.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import ABC, abstractmethod
 
 from agentex.types.span import Span
@@ -34,6 +35,20 @@ class AsyncTracingProcessor(ABC):
     @abstractmethod
     async def on_span_end(self, span: Span) -> None:
         pass
+
+    async def on_spans_start(self, spans: list[Span]) -> None:
+        """Batched variant of on_span_start.
+
+        Default fallback fans out to the single-span method in parallel so
+        existing processors keep working unchanged.  Processors that support
+        real batching (e.g. sending all spans in one HTTP call) should
+        override this to avoid the per-span round trip.
+        """
+        await asyncio.gather(*(self.on_span_start(s) for s in spans), return_exceptions=False)
+
+    async def on_spans_end(self, spans: list[Span]) -> None:
+        """Batched variant of on_span_end.  See on_spans_start for details."""
+        await asyncio.gather(*(self.on_span_end(s) for s in spans), return_exceptions=False)
 
     @abstractmethod
     async def shutdown(self) -> None:

--- a/src/agentex/lib/core/tracing/processors/tracing_processor_interface.py
+++ b/src/agentex/lib/core/tracing/processors/tracing_processor_interface.py
@@ -5,6 +5,9 @@ from abc import ABC, abstractmethod
 
 from agentex.types.span import Span
 from agentex.lib.types.tracing import TracingProcessorConfig
+from agentex.lib.utils.logging import make_logger
+
+logger = make_logger(__name__)
 
 
 class SyncTracingProcessor(ABC):
@@ -45,12 +48,35 @@ class AsyncTracingProcessor(ABC):
         existing processors keep working unchanged.  Processors that support
         real batching (e.g. sending all spans in one HTTP call) should
         override this to avoid the per-span round trip.
+
+        Per-span exceptions are captured and logged individually so that one
+        failing span does not prevent the others from being processed.
         """
-        await asyncio.gather(*(self.on_span_start(s) for s in spans), return_exceptions=False)
+        results = await asyncio.gather(
+            *(self.on_span_start(s) for s in spans), return_exceptions=True
+        )
+        for span, result in zip(spans, results):
+            if isinstance(result, Exception):
+                logger.error(
+                    "Tracing processor %s failed on_span_start for span %s",
+                    type(self).__name__,
+                    span.id,
+                    exc_info=result,
+                )
 
     async def on_spans_end(self, spans: list[Span]) -> None:
         """Batched variant of on_span_end.  See on_spans_start for details."""
-        await asyncio.gather(*(self.on_span_end(s) for s in spans), return_exceptions=False)
+        results = await asyncio.gather(
+            *(self.on_span_end(s) for s in spans), return_exceptions=True
+        )
+        for span, result in zip(spans, results):
+            if isinstance(result, Exception):
+                logger.error(
+                    "Tracing processor %s failed on_span_end for span %s",
+                    type(self).__name__,
+                    span.id,
+                    exc_info=result,
+                )
 
     @abstractmethod
     async def shutdown(self) -> None:

--- a/src/agentex/lib/core/tracing/span_queue.py
+++ b/src/agentex/lib/core/tracing/span_queue.py
@@ -105,6 +105,10 @@ class AsyncSpanQueue:
             return
 
         event_type = items[0].event_type
+        assert all(i.event_type == event_type for i in items), (
+            "_process_items requires all items to share the same event_type; "
+            "callers must split START and END batches before dispatching."
+        )
         by_processor: dict[AsyncTracingProcessor, list[Span]] = {}
         for item in items:
             for p in item.processors:

--- a/src/agentex/lib/core/tracing/span_queue.py
+++ b/src/agentex/lib/core/tracing/span_queue.py
@@ -95,29 +95,36 @@ class AsyncSpanQueue:
 
     @staticmethod
     async def _process_items(items: list[_SpanQueueItem]) -> None:
-        """Process a list of span events concurrently."""
+        """Dispatch a batch of same-event-type items to each processor in one call.
 
-        async def _handle(item: _SpanQueueItem) -> None:
+        Groups spans by processor so each processor sees its full slice of the
+        drain batch at once.  Processors that override the batched methods can
+        then send a single HTTP request per drain cycle instead of N.
+        """
+        if not items:
+            return
+
+        event_type = items[0].event_type
+        by_processor: dict[AsyncTracingProcessor, list[Span]] = {}
+        for item in items:
+            for p in item.processors:
+                by_processor.setdefault(p, []).append(item.span)
+
+        async def _handle(p: AsyncTracingProcessor, spans: list[Span]) -> None:
             try:
-                if item.event_type == SpanEventType.START:
-                    coros = [p.on_span_start(item.span) for p in item.processors]
+                if event_type == SpanEventType.START:
+                    await p.on_spans_start(spans)
                 else:
-                    coros = [p.on_span_end(item.span) for p in item.processors]
-                results = await asyncio.gather(*coros, return_exceptions=True)
-                for result in results:
-                    if isinstance(result, Exception):
-                        logger.error(
-                            "Tracing processor error during %s for span %s",
-                            item.event_type.value,
-                            item.span.id,
-                            exc_info=result,
-                        )
+                    await p.on_spans_end(spans)
             except Exception:
                 logger.exception(
-                    "Unexpected error in span queue for span %s", item.span.id
+                    "Tracing processor %s failed handling %d spans during %s",
+                    type(p).__name__,
+                    len(spans),
+                    event_type.value,
                 )
 
-        await asyncio.gather(*[_handle(item) for item in items])
+        await asyncio.gather(*[_handle(p, spans) for p, spans in by_processor.items()])
 
     # ------------------------------------------------------------------
     # Shutdown

--- a/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
@@ -188,3 +188,42 @@ class TestSGPAsyncTracingProcessorMemoryLeak:
         assert len(processor._spans) == 0
         # The end upsert should have been called
         assert processor.sgp_async_client.spans.upsert_batch.call_count == 2  # start + end
+
+    async def test_on_spans_start_sends_single_upsert_for_batch(self):
+        """Given N spans at once, on_spans_start should make ONE upsert_batch HTTP call."""
+        processor, _ = self._make_processor()
+
+        n = 10
+        spans = [_make_span() for _ in range(n)]
+        with patch(f"{MODULE}.create_span", side_effect=lambda **kw: _make_mock_sgp_span()):
+            await processor.on_spans_start(spans)
+
+        assert processor.sgp_async_client.spans.upsert_batch.call_count == 1, (
+            "Batched on_spans_start must make exactly one upsert_batch HTTP call"
+        )
+        items = processor.sgp_async_client.spans.upsert_batch.call_args.kwargs["items"]
+        assert len(items) == n
+        # All spans should be tracked for the subsequent end call
+        assert len(processor._spans) == n
+
+    async def test_on_spans_end_sends_single_upsert_for_batch(self):
+        """Given N spans at once, on_spans_end should make ONE upsert_batch HTTP call."""
+        processor, _ = self._make_processor()
+
+        n = 10
+        spans = [_make_span() for _ in range(n)]
+        with patch(f"{MODULE}.create_span", side_effect=lambda **kw: _make_mock_sgp_span()):
+            await processor.on_spans_start(spans)
+
+        processor.sgp_async_client.spans.upsert_batch.reset_mock()
+
+        for span in spans:
+            span.end_time = datetime.now(UTC)
+        await processor.on_spans_end(spans)
+
+        assert processor.sgp_async_client.spans.upsert_batch.call_count == 1, (
+            "Batched on_spans_end must make exactly one upsert_batch HTTP call"
+        )
+        items = processor.sgp_async_client.spans.upsert_batch.call_args.kwargs["items"]
+        assert len(items) == n
+        assert len(processor._spans) == 0

--- a/tests/lib/core/tracing/processors/test_tracing_processor_interface.py
+++ b/tests/lib/core/tracing/processors/test_tracing_processor_interface.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import uuid
+import logging
+from datetime import UTC, datetime
+from typing import override
+
+from agentex.types.span import Span
+from agentex.lib.types.tracing import TracingProcessorConfig
+from agentex.lib.core.tracing.processors.tracing_processor_interface import (
+    AsyncTracingProcessor,
+)
+
+
+def _make_span(span_id: str | None = None) -> Span:
+    return Span(
+        id=span_id or str(uuid.uuid4()),
+        name="test-span",
+        start_time=datetime.now(UTC),
+        trace_id="trace-1",
+    )
+
+
+class _RecordingProcessor(AsyncTracingProcessor):
+    """Test processor that records every on_span_* call and fails on demand."""
+
+    def __init__(self, fail_ids: set[str] | None = None) -> None:
+        self.started_ids: list[str] = []
+        self.ended_ids: list[str] = []
+        self._fail_ids = fail_ids or set()
+
+    @override
+    async def on_span_start(self, span: Span) -> None:
+        self.started_ids.append(span.id)
+        if span.id in self._fail_ids:
+            raise RuntimeError(f"boom-start-{span.id}")
+
+    @override
+    async def on_span_end(self, span: Span) -> None:
+        self.ended_ids.append(span.id)
+        if span.id in self._fail_ids:
+            raise RuntimeError(f"boom-end-{span.id}")
+
+    @override
+    async def shutdown(self) -> None:
+        pass
+
+
+class TestDefaultBatchedFanout:
+    """The default on_spans_start / on_spans_end in AsyncTracingProcessor must:
+    - dispatch to the single-span method for every span
+    - continue after individual failures (not short-circuit)
+    - log each failure individually
+    - not propagate exceptions to the caller
+    """
+
+    async def test_on_spans_start_runs_every_span_despite_failures(self, caplog):
+        proc = _RecordingProcessor(fail_ids={"span-1"})
+        spans = [_make_span(f"span-{i}") for i in range(3)]
+
+        with caplog.at_level(logging.ERROR):
+            # Must not raise, even though span-1 fails.
+            await proc.on_spans_start(spans)
+
+        # Every span's on_span_start was invoked
+        assert proc.started_ids == ["span-0", "span-1", "span-2"]
+
+    async def test_on_spans_start_logs_each_failure(self, caplog):
+        proc = _RecordingProcessor(fail_ids={"span-0", "span-2"})
+        spans = [_make_span(f"span-{i}") for i in range(3)]
+
+        with caplog.at_level(logging.ERROR):
+            await proc.on_spans_start(spans)
+
+        # Two distinct error log records, one per failing span
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        messages = " ".join(r.getMessage() for r in error_records)
+        assert "span-0" in messages
+        assert "span-2" in messages
+
+    async def test_on_spans_end_runs_every_span_despite_failures(self, caplog):
+        proc = _RecordingProcessor(fail_ids={"span-1"})
+        spans = [_make_span(f"span-{i}") for i in range(3)]
+
+        with caplog.at_level(logging.ERROR):
+            await proc.on_spans_end(spans)
+
+        assert proc.ended_ids == ["span-0", "span-1", "span-2"]
+
+    async def test_dummy_config_construction(self):
+        """AsyncTracingProcessor's __init__ is abstract — verify concrete
+        subclass above satisfies the interface."""
+        _ = TracingProcessorConfig
+        proc = _RecordingProcessor()
+        await proc.on_spans_start([])
+        await proc.on_spans_end([])
+        assert proc.started_ids == []
+        assert proc.ended_ids == []

--- a/tests/lib/core/tracing/processors/test_tracing_processor_interface.py
+++ b/tests/lib/core/tracing/processors/test_tracing_processor_interface.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import uuid
 import logging
-from datetime import UTC, datetime
 from typing import override
+from datetime import UTC, datetime
 
 from agentex.types.span import Span
 from agentex.lib.types.tracing import TracingProcessorConfig

--- a/tests/lib/core/tracing/test_span_queue.py
+++ b/tests/lib/core/tracing/test_span_queue.py
@@ -21,9 +21,25 @@ def _make_span(span_id: str | None = None) -> Span:
 
 
 def _make_processor(**overrides: AsyncMock) -> AsyncMock:
+    """Build a mock processor compatible with the queue's batched dispatch.
+
+    The queue now calls on_spans_start(list) / on_spans_end(list) on each
+    processor.  Mirror the behavior of AsyncTracingProcessor's default fallback
+    by fanning out the list to per-span calls concurrently, so tests that
+    assert on on_span_start / on_span_end continue to observe per-span calls.
+    """
     proc = AsyncMock()
     proc.on_span_start = overrides.get("on_span_start", AsyncMock())
     proc.on_span_end = overrides.get("on_span_end", AsyncMock())
+
+    async def _fanout_start(spans: list[Span]) -> None:
+        await asyncio.gather(*(proc.on_span_start(s) for s in spans), return_exceptions=True)
+
+    async def _fanout_end(spans: list[Span]) -> None:
+        await asyncio.gather(*(proc.on_span_end(s) for s in spans), return_exceptions=True)
+
+    proc.on_spans_start = AsyncMock(side_effect=_fanout_start)
+    proc.on_spans_end = AsyncMock(side_effect=_fanout_end)
     return proc
 
 
@@ -216,6 +232,61 @@ class TestAsyncSpanQueueBatchConcurrency:
             f"Batch drain took {elapsed:.3f}s — serial would be {serial_time:.3f}s. "
             f"Expected at least 2x speedup from concurrency."
         )
+
+
+class TestAsyncSpanQueueBatchedDispatch:
+    """The queue should dispatch a whole drain batch to each processor via the
+    batched methods (on_spans_start / on_spans_end) in one call per processor,
+    so processors that support real HTTP batching can send one request instead
+    of N.
+    """
+
+    async def test_batched_start_dispatch_single_call_per_drain(self):
+        received: list[list[str]] = []
+
+        async def capture_starts(spans: list[Span]) -> None:
+            received.append([s.id for s in spans])
+
+        proc = AsyncMock()
+        proc.on_spans_start = AsyncMock(side_effect=capture_starts)
+        proc.on_spans_end = AsyncMock()
+
+        queue = AsyncSpanQueue()
+
+        # Enqueue several spans synchronously before the drain has a chance to
+        # run — they should all land in a single drain batch.
+        ids = [f"span-{i}" for i in range(5)]
+        for i in ids:
+            queue.enqueue(SpanEventType.START, _make_span(i), [proc])
+
+        await queue.shutdown()
+
+        # on_spans_start must have been called exactly once with all 5 spans.
+        assert proc.on_spans_start.call_count == 1, (
+            f"Expected one batched call, got {proc.on_spans_start.call_count}"
+        )
+        assert received == [ids]
+
+    async def test_batched_end_dispatch_single_call_per_drain(self):
+        received: list[list[str]] = []
+
+        async def capture_ends(spans: list[Span]) -> None:
+            received.append([s.id for s in spans])
+
+        proc = AsyncMock()
+        proc.on_spans_start = AsyncMock()
+        proc.on_spans_end = AsyncMock(side_effect=capture_ends)
+
+        queue = AsyncSpanQueue()
+
+        ids = [f"span-{i}" for i in range(5)]
+        for i in ids:
+            queue.enqueue(SpanEventType.END, _make_span(i), [proc])
+
+        await queue.shutdown()
+
+        assert proc.on_spans_end.call_count == 1
+        assert received == [ids]
 
 
 class TestAsyncSpanQueueIntegration:

--- a/tests/lib/core/tracing/test_span_queue.py
+++ b/tests/lib/core/tracing/test_span_queue.py
@@ -234,6 +234,32 @@ class TestAsyncSpanQueueBatchConcurrency:
         )
 
 
+class TestProcessItemsPreconditions:
+    """_process_items assumes every item in the list has the same event_type.
+    Violating that precondition silently causes END events to be treated as
+    STARTs (or vice versa), which is a silent data-corruption bug.  Guard it
+    with an assertion."""
+
+    async def test_mixed_event_types_raise_assertion(self):
+        from agentex.lib.core.tracing.span_queue import _SpanQueueItem
+
+        proc = AsyncMock()
+        proc.on_spans_start = AsyncMock()
+        proc.on_spans_end = AsyncMock()
+
+        mixed = [
+            _SpanQueueItem(event_type=SpanEventType.START, span=_make_span("a"), processors=[proc]),
+            _SpanQueueItem(event_type=SpanEventType.END, span=_make_span("b"), processors=[proc]),
+        ]
+
+        try:
+            await AsyncSpanQueue._process_items(mixed)
+        except AssertionError:
+            return
+        else:
+            raise AssertionError("Expected AssertionError for mixed event types")
+
+
 class TestAsyncSpanQueueBatchedDispatch:
     """The queue should dispatch a whole drain batch to each processor via the
     batched methods (on_spans_start / on_spans_end) in one call per processor,


### PR DESCRIPTION
https://linear.app/scale-epd/issue/AGX1-198/actually-use-sgp-batching-for-spans

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements true HTTP batching for SGP span upserts: the queue now groups spans by processor and calls `on_spans_start`/`on_spans_end` once per drain cycle per processor, replacing the previous N-calls-per-drain approach. `SGPAsyncTracingProcessor` overrides the new batched methods to issue a single `upsert_batch` HTTP request for all spans in the batch, and the interface provides a safe default fan-out fallback for processors that only implement the single-span methods.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; one minor P2 style suggestion about assert vs raise, no blocking issues.

The batching logic is correct and well-tested, the default fallback properly uses return_exceptions=True with per-failure logging, and the prior concern about return_exceptions has been addressed. The only remaining finding is a P2 suggestion to replace assert with an explicit ValueError in _process_items.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/span_queue.py | Refactored _process_items to group spans per-processor and dispatch via batched on_spans_start/on_spans_end; adds assertion (not raise) to guard same-event-type precondition. |
| src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py | Added on_spans_start/on_spans_end overrides that build all SGP spans first then make a single upsert_batch HTTP call; single-span methods now delegate to the batch variants. |
| src/agentex/lib/core/tracing/processors/tracing_processor_interface.py | Added default on_spans_start/on_spans_end that fan out to per-span methods using asyncio.gather with return_exceptions=True and per-failure logging. |
| tests/lib/core/tracing/processors/test_sgp_tracing_processor.py | Added two batch tests verifying on_spans_start and on_spans_end each produce exactly one upsert_batch call for N spans. |
| tests/lib/core/tracing/processors/test_tracing_processor_interface.py | New test file validating the default fan-out behavior: continues past individual failures, does not propagate exceptions, logs each error. |
| tests/lib/core/tracing/test_span_queue.py | Updated mock processor helper to implement on_spans_start/on_spans_end; added TestProcessItemsPreconditions and TestAsyncSpanQueueBatchedDispatch suites. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant DL as AsyncSpanQueue._drain_loop
    participant PI as _process_items
    participant SGP as SGPAsyncTracingProcessor
    participant API as SGP HTTP API

    DL->>PI: _process_items(starts)
    PI->>PI: group spans by processor
    PI->>SGP: on_spans_start([span1, span2, ...spanN])
    SGP->>SGP: create all SGPSpans, store in _spans
    SGP->>API: upsert_batch(items=[...N items...])
    API-->>SGP: 200 OK

    DL->>PI: _process_items(ends)
    PI->>SGP: on_spans_end([span1, span2, ...spanN])
    SGP->>SGP: pop from _spans, update fields
    SGP->>API: upsert_batch(items=[...N items...])
    API-->>SGP: 200 OK
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftracing%2Fspan_queue.py%3A108-111%0A**%60assert%60%20stripped%20in%20optimized%20builds**%0A%0A%60assert%60%20statements%20are%20silently%20removed%20when%20Python%20is%20run%20with%20the%20%60-O%60%20flag%20%28%60PYTHONOPTIMIZE%60%29%20or%20compiled%20to%20%60.pyo%60%20bytecode.%20If%20this%20guard%20is%20ever%20triggered%20in%20a%20production-optimized%20environment%2C%20mixed%20START%2FEND%20items%20would%20be%20dispatched%20incorrectly%20with%20no%20error%20raised.%20Consider%20raising%20an%20explicit%20%60ValueError%60%20instead%20to%20make%20the%20precondition%20unconditional.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20not%20all%28i.event_type%20%3D%3D%20event_type%20for%20i%20in%20items%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20raise%20ValueError%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22_process_items%20requires%20all%20items%20to%20share%20the%20same%20event_type%3B%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22callers%20must%20split%20START%20and%20END%20batches%20before%20dispatching.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A&pr=331&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftracing%2Fspan_queue.py%3A108-111%0A**%60assert%60%20stripped%20in%20optimized%20builds**%0A%0A%60assert%60%20statements%20are%20silently%20removed%20when%20Python%20is%20run%20with%20the%20%60-O%60%20flag%20%28%60PYTHONOPTIMIZE%60%29%20or%20compiled%20to%20%60.pyo%60%20bytecode.%20If%20this%20guard%20is%20ever%20triggered%20in%20a%20production-optimized%20environment%2C%20mixed%20START%2FEND%20items%20would%20be%20dispatched%20incorrectly%20with%20no%20error%20raised.%20Consider%20raising%20an%20explicit%20%60ValueError%60%20instead%20to%20make%20the%20precondition%20unconditional.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20not%20all%28i.event_type%20%3D%3D%20event_type%20for%20i%20in%20items%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20raise%20ValueError%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22_process_items%20requires%20all%20items%20to%20share%20the%20same%20event_type%3B%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22callers%20must%20split%20START%20and%20END%20batches%20before%20dispatching.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=331&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/agentex/lib/core/tracing/span_queue.py
Line: 108-111

Comment:
**`assert` stripped in optimized builds**

`assert` statements are silently removed when Python is run with the `-O` flag (`PYTHONOPTIMIZE`) or compiled to `.pyo` bytecode. If this guard is ever triggered in a production-optimized environment, mixed START/END items would be dispatched incorrectly with no error raised. Consider raising an explicit `ValueError` instead to make the precondition unconditional.

```suggestion
        if not all(i.event_type == event_type for i in items):
            raise ValueError(
                "_process_items requires all items to share the same event_type; "
                "callers must split START and END batches before dispatching."
            )
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["lint fixes"](https://github.com/scaleapi/scale-agentex-python/commit/21b790f9d0df4a77d760da15a307b3a8d2568f38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29194489)</sub>

<!-- /greptile_comment -->