### PR TITLE
add service account id as option to register agentex agent

### DIFF
--- a/src/agentex/lib/sdk/config/environment_config.py
+++ b/src/agentex/lib/sdk/config/environment_config.py
@@ -165,6 +165,17 @@ class AgentEnvironmentsConfig(UtilsBaseModel):
                 account_id: 6887f093600ecd59bbbd3095
             helm_overrides:
 
+        The principal must contain exactly one of `user_id` or `service_account_id`.
+        Use `service_account_id` to register an agent under a service account
+        instead of a personal user identity:
+        dev:
+            kubernetes:
+            namespace: "sgp-000-hello-acp"
+            auth:
+            principal:
+                service_account_id: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+                account_id: 6887f093600ecd59bbbd3095
+
         if the environment field is not explicitly set, we assume its the same as
         the name of the environment
         Args:

--- a/src/agentex/lib/sdk/config/validation.py
+++ b/src/agentex/lib/sdk/config/validation.py
@@ -236,11 +236,12 @@ def generate_helpful_error_message(error: Exception, context: str = "") -> str:
                 "1. Check file location: should be next to manifest.yaml\n"
                 "2. Verify file permissions"
             )
-    elif "user_id" in base_msg.lower():
+    elif "user_id" in base_msg.lower() or "service_account_id" in base_msg.lower():
         base_msg += (
             "\n\n💡 Auth Principal Tips:\n"
-            "- user_id should be unique per environment\n"
-            "- Include environment name (e.g., 'dev_my_agent')\n"
+            "- Set exactly one of 'user_id' or 'service_account_id'\n"
+            "- The id should be unique per environment\n"
+            "- For user_id, include environment name (e.g., 'dev_my_agent')\n"
             "- Use consistent naming convention across agents"
         )
     elif "namespace" in base_msg.lower():

--- a/src/agentex/lib/sdk/config/validation.py
+++ b/src/agentex/lib/sdk/config/validation.py
@@ -103,11 +103,14 @@ def _validate_single_environment_config(env_name: str, env_config: AgentEnvironm
 
     # Validate auth principal
     principal = env_config.auth.principal
-    if not principal.get("user_id"):
-        raise ValueError("Auth principal must contain non-empty 'user_id'")
+    user_id = principal.get("user_id")
+    service_account_id = principal.get("service_account_id")
+    if not user_id and not service_account_id:
+        raise ValueError("Auth principal must contain non-empty 'user_id' or 'service_account_id'")
+    if user_id and service_account_id:
+        raise ValueError("Auth principal must contain only one of 'user_id' or 'service_account_id', not both")
 
     # Check for environment-specific user_id patterns
-    user_id = principal["user_id"]
     if isinstance(user_id, str):
         if not any(env_name.lower() in user_id.lower() for env_name in ["dev", "prod", "staging", env_name]):
             logger.warning(

--- a/tests/lib/cli/test_validation.py
+++ b/tests/lib/cli/test_validation.py
@@ -1,0 +1,76 @@
+"""Tests for the auth-principal portion of the environments.yaml validator.
+
+Covers the rule that an env config's principal must carry exactly one of
+`user_id` or `service_account_id` — the same shape that downstream services
+(agentex-auth, SGP) expect on the wire.
+"""
+
+import pytest
+
+from agentex.lib.sdk.config.validation import (
+    EnvironmentsValidationError,
+    validate_environments_config,
+)
+from agentex.lib.sdk.config.environment_config import (
+    AgentAuthConfig,
+    AgentKubernetesConfig,
+    AgentEnvironmentConfig,
+    AgentEnvironmentsConfig,
+)
+
+
+def _config_with_principal(principal: dict) -> AgentEnvironmentsConfig:
+    return AgentEnvironmentsConfig(
+        schema_version="v1",
+        environments={
+            "dev": AgentEnvironmentConfig(
+                kubernetes=AgentKubernetesConfig(namespace="dev-ns"),
+                auth=AgentAuthConfig(principal=principal),
+            )
+        },
+    )
+
+
+def test_user_only_principal_passes():
+    """Existing user_id-only configs continue to validate (backwards compat)."""
+    config = _config_with_principal({"user_id": "73d0c8bd-4726-434c-9686-eb627d89f078", "account_id": "acct-1"})
+
+    validate_environments_config(config)
+
+
+def test_service_account_only_principal_passes():
+    """New service_account_id-only configs validate."""
+    config = _config_with_principal(
+        {"service_account_id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d", "account_id": "acct-1"}
+    )
+
+    validate_environments_config(config)
+
+
+def test_principal_with_neither_id_is_rejected():
+    """A principal with no identity id fails fast with a clear error."""
+    config = _config_with_principal({"account_id": "acct-1"})
+
+    with pytest.raises(EnvironmentsValidationError) as exc_info:
+        validate_environments_config(config)
+
+    msg = str(exc_info.value)
+    assert "user_id" in msg
+    assert "service_account_id" in msg
+
+
+def test_principal_with_both_ids_is_rejected():
+    """Setting both ids is a config error — the principal must commit to one identity type."""
+    config = _config_with_principal(
+        {
+            "user_id": "73d0c8bd-4726-434c-9686-eb627d89f078",
+            "service_account_id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+            "account_id": "acct-1",
+        }
+    )
+
+    with pytest.raises(EnvironmentsValidationError) as exc_info:
+        validate_environments_config(config)
+
+    msg = str(exc_info.value)
+    assert "only one of" in msg.lower() or "not both" in msg.lower()


### PR DESCRIPTION
## Summary

Relaxes the `environments.yaml` auth-principal validator so agent developers can register an agent under a service account instead of a user identity.

- `_validate_single_environment_config` now requires **exactly one** of `user_id` or `service_account_id` in the `auth.principal` block (mutually exclusive). The previous validator hard-required `user_id`, which blocked SA registration end-to-end.
- Updates the docstring example in `environment_config.py` to show both shapes.

Backwards compatible: existing configs with only `user_id` continue to validate. Field shape mirrors what `agentex-auth` (`SGPPrincipalContext`) and SGP (`x-user-id` / `x-service-account-id` headers) already use, so no translation layer is needed between yaml and the wire.

## Related PRs (ship together)

- This PR (SDK validator) — `scaleapi/scale-agentex-python#332`
- SGP backend — https://github.com/scaleapi/scaleapi/pull/141104
- agentex-auth — https://github.com/scaleapi/agentex/pull/333
- scale-agentex (auth cache key) — https://github.com/scaleapi/scale-agentex/pull/210

## Test Plan

- 4 new unit tests in `tests/lib/cli/test_validation.py`, all passing via `uv run pytest`:
  - user-only principal validates (backwards-compat)
  - service_account-only principal validates
  - principal with neither id is rejected with a clear error
  - principal with both ids is rejected with a "not both" error
- Existing `test_environment_config.py` (18 tests) still passes.
- `ruff check` + `ruff format` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes the `environments.yaml` auth-principal validator to accept either `user_id` or `service_account_id` (mutually exclusive), enabling agents to be registered under a service account identity. Existing configs using only `user_id` are fully backwards-compatible, and four targeted unit tests cover all four principal combinations.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — change is backwards-compatible, logic is correct, and all four principal scenarios are tested.

The only finding is a P2 style suggestion (missing explanatory comment) that does not affect correctness or runtime behavior. All changed paths are covered by new tests.

No files require special attention.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/sdk/config/validation.py | Core validator updated: replaces hard-required `user_id` with a mutually-exclusive `user_id` XOR `service_account_id` check; error messages and hints updated accordingly. Logic is correct and backwards-compatible. |
| src/agentex/lib/sdk/config/environment_config.py | Docstring-only change: adds a `service_account_id` YAML example to `get_configs_for_env`. No model or validation logic changed. |
| tests/lib/cli/test_validation.py | New test file: 4 unit tests covering the four principal scenarios (user_id only, service_account_id only, neither, both). Coverage is complete for the changed validator path. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_validate_single_environment_config] --> B{principal has user_id?}
    B -- No --> C{principal has service_account_id?}
    C -- No --> D[❌ ValueError: must contain one of user_id or service_account_id]
    C -- Yes --> E[✅ SA path — skip env-name warning]
    B -- Yes --> F{also has service_account_id?}
    F -- Yes --> G[❌ ValueError: not both]
    F -- No --> H{user_id is a string?}
    H -- Yes --> I{contains env indicator?}
    I -- No --> J[⚠️ logger.warning: missing env indicator in user_id]
    I -- Yes --> K[✅ user_id path OK]
    J --> K
    E --> L[validate helm overrides if present]
    K --> L
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agentex/lib/sdk/config/validation.py`, line 239-245 ([link](https://github.com/scaleapi/scale-agentex-python/blob/6aae53f903c7b0edb82e2158bc5c625966bbc8b5/src/agentex/lib/sdk/config/validation.py#L239-L245)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Helpful error hint omits `service_account_id`**

   The hint block is triggered whenever `"user_id"` appears in the error message. Both new error messages (`"must contain non-empty 'user_id' or 'service_account_id'"` and `"must contain only one of 'user_id' or 'service_account_id', not both"`) contain the string `"user_id"`, so this block fires for `service_account_id`-related failures too — but the tips text mentions only `user_id`, which will mislead users configuring a service account principal.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/sdk/config/validation.py
   Line: 239-245

   Comment:
   **Helpful error hint omits `service_account_id`**

   The hint block is triggered whenever `"user_id"` appears in the error message. Both new error messages (`"must contain non-empty 'user_id' or 'service_account_id'"` and `"must contain only one of 'user_id' or 'service_account_id', not both"`) contain the string `"user_id"`, so this block fires for `service_account_id`-related failures too — but the tips text mentions only `user_id`, which will mislead users configuring a service account principal.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fsdk%2Fconfig%2Fvalidation.py%0ALine%3A%20239-245%0A%0AComment%3A%0A**Helpful%20error%20hint%20omits%20%60service_account_id%60**%0A%0AThe%20hint%20block%20is%20triggered%20whenever%20%60%22user_id%22%60%20appears%20in%20the%20error%20message.%20Both%20new%20error%20messages%20%28%60%22must%20contain%20non-empty%20'user_id'%20or%20'service_account_id'%22%60%20and%20%60%22must%20contain%20only%20one%20of%20'user_id'%20or%20'service_account_id'%2C%20not%20both%22%60%29%20contain%20the%20string%20%60%22user_id%22%60%2C%20so%20this%20block%20fires%20for%20%60service_account_id%60-related%20failures%20too%20%E2%80%94%20but%20the%20tips%20text%20mentions%20only%20%60user_id%60%2C%20which%20will%20mislead%20users%20configuring%20a%20service%20account%20principal.%0A%0A%60%60%60suggestion%0A%20%20%20%20elif%20%22user_id%22%20in%20base_msg.lower%28%29%20or%20%22service_account_id%22%20in%20base_msg.lower%28%29%3A%0A%20%20%20%20%20%20%20%20base_msg%20%2B%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22%5Cn%5Cn%F0%9F%92%A1%20Auth%20Principal%20Tips%3A%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%22-%20user_id%20or%20service_account_id%20should%20be%20unique%20per%20environment%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%22-%20For%20user_id%2C%20include%20environment%20name%20%28e.g.%2C%20'dev_my_agent'%29%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%22-%20Use%20consistent%20naming%20convention%20across%20agents%22%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fsdk%2Fconfig%2Fvalidation.py%0ALine%3A%20239-245%0A%0AComment%3A%0A**Helpful%20error%20hint%20omits%20%60service_account_id%60**%0A%0AThe%20hint%20block%20is%20triggered%20whenever%20%60%22user_id%22%60%20appears%20in%20the%20error%20message.%20Both%20new%20error%20messages%20%28%60%22must%20contain%20non-empty%20'user_id'%20or%20'service_account_id'%22%60%20and%20%60%22must%20contain%20only%20one%20of%20'user_id'%20or%20'service_account_id'%2C%20not%20both%22%60%29%20contain%20the%20string%20%60%22user_id%22%60%2C%20so%20this%20block%20fires%20for%20%60service_account_id%60-related%20failures%20too%20%E2%80%94%20but%20the%20tips%20text%20mentions%20only%20%60user_id%60%2C%20which%20will%20mislead%20users%20configuring%20a%20service%20account%20principal.%0A%0A%60%60%60suggestion%0A%20%20%20%20elif%20%22user_id%22%20in%20base_msg.lower%28%29%20or%20%22service_account_id%22%20in%20base_msg.lower%28%29%3A%0A%20%20%20%20%20%20%20%20base_msg%20%2B%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22%5Cn%5Cn%F0%9F%92%A1%20Auth%20Principal%20Tips%3A%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%22-%20user_id%20or%20service_account_id%20should%20be%20unique%20per%20environment%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%22-%20For%20user_id%2C%20include%20environment%20name%20%28e.g.%2C%20'dev_my_agent'%29%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%22-%20Use%20consistent%20naming%20convention%20across%20agents%22%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fsdk%2Fconfig%2Fvalidation.py%3A113-119%0A**Missing%20comment%20on%20intentional%20skip%20of%20env-indicator%20warning**%0A%0AThe%20%60if%20isinstance%28user_id%2C%20str%29%3A%60%20block%20silently%20skips%20the%20environment-name%20warning%20when%20%60service_account_id%60%20is%20used%20instead.%20This%20is%20the%20right%20call%20%28SA%20IDs%20are%20pre-created%20UUIDs%2C%20not%20free-form%20strings%29%2C%20but%20it%20is%20non-obvious%20to%20a%20future%20maintainer%20who%20sees%20a%20codepath%20with%20no%20validation%20at%20all%20for%20%60service_account_id%60.%20A%20short%20inline%20comment%20would%20make%20the%20intent%20clear.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20Check%20for%20environment-specific%20user_id%20patterns.%0A%20%20%20%20%23%20This%20warning%20is%20intentionally%20skipped%20for%20service_account_id%3A%20SA%20identifiers%0A%20%20%20%20%23%20are%20pre-created%20UUIDs%20whose%20names%20are%20not%20expected%20to%20encode%20environment%20info.%0A%20%20%20%20if%20isinstance%28user_id%2C%20str%29%3A%0A%20%20%20%20%20%20%20%20if%20not%20any%28env_name.lower%28%29%20in%20user_id.lower%28%29%20for%20env_name%20in%20%5B%22dev%22%2C%20%22prod%22%2C%20%22staging%22%2C%20env_name%5D%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22User%20ID%20'%7Buser_id%7D'%20doesn't%20contain%20environment%20indicator.%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22Consider%20including%20'%7Benv_name%7D'%20in%20the%20user_id%20for%20clarity.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learned%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A&pr=332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fsdk%2Fconfig%2Fvalidation.py%3A113-119%0A**Missing%20comment%20on%20intentional%20skip%20of%20env-indicator%20warning**%0A%0AThe%20%60if%20isinstance%28user_id%2C%20str%29%3A%60%20block%20silently%20skips%20the%20environment-name%20warning%20when%20%60service_account_id%60%20is%20used%20instead.%20This%20is%20the%20right%20call%20%28SA%20IDs%20are%20pre-created%20UUIDs%2C%20not%20free-form%20strings%29%2C%20but%20it%20is%20non-obvious%20to%20a%20future%20maintainer%20who%20sees%20a%20codepath%20with%20no%20validation%20at%20all%20for%20%60service_account_id%60.%20A%20short%20inline%20comment%20would%20make%20the%20intent%20clear.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20Check%20for%20environment-specific%20user_id%20patterns.%0A%20%20%20%20%23%20This%20warning%20is%20intentionally%20skipped%20for%20service_account_id%3A%20SA%20identifiers%0A%20%20%20%20%23%20are%20pre-created%20UUIDs%20whose%20names%20are%20not%20expected%20to%20encode%20environment%20info.%0A%20%20%20%20if%20isinstance%28user_id%2C%20str%29%3A%0A%20%20%20%20%20%20%20%20if%20not%20any%28env_name.lower%28%29%20in%20user_id.lower%28%29%20for%20env_name%20in%20%5B%22dev%22%2C%20%22prod%22%2C%20%22staging%22%2C%20env_name%5D%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22User%20ID%20'%7Buser_id%7D'%20doesn't%20contain%20environment%20indicator.%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22Consider%20including%20'%7Benv_name%7D'%20in%20the%20user_id%20for%20clarity.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learned%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/agentex/lib/sdk/config/validation.py
Line: 113-119

Comment:
**Missing comment on intentional skip of env-indicator warning**

The `if isinstance(user_id, str):` block silently skips the environment-name warning when `service_account_id` is used instead. This is the right call (SA IDs are pre-created UUIDs, not free-form strings), but it is non-obvious to a future maintainer who sees a codepath with no validation at all for `service_account_id`. A short inline comment would make the intent clear.

```suggestion
    # Check for environment-specific user_id patterns.
    # This warning is intentionally skipped for service_account_id: SA identifiers
    # are pre-created UUIDs whose names are not expected to encode environment info.
    if isinstance(user_id, str):
        if not any(env_name.lower() in user_id.lower() for env_name in ["dev", "prod", "staging", env_name]):
            logger.warning(
                f"User ID '{user_id}' doesn't contain environment indicator. "
                f"Consider including '{env_name}' in the user_id for clarity."
            )
```

**Rule Used:** Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learned From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["better error message"](https://github.com/scaleapi/scale-agentex-python/commit/1e0156a9dbd40558d2409b6b8a3e99da39ce308d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29899608)</sub>

**Context used:**

- Rule used - Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learned From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

<!-- /greptile_comment -->