### PR TITLE
perf(streaming): coalesce per-token publishes to Redis (50ms / 128-char window)

### DIFF
--- a/src/agentex/lib/adk/_modules/streaming.py
+++ b/src/agentex/lib/adk/_modules/streaming.py
@@ -7,6 +7,7 @@ from agentex import AsyncAgentex  # noqa: F401
 from agentex.lib.adk.utils._modules.client import create_async_agentex_client
 from agentex.lib.core.adapters.streams.adapter_redis import RedisStreamRepository
 from agentex.lib.core.services.adk.streaming import (
+    StreamingMode,
     StreamingService,
     StreamingTaskMessageContext,
 )
@@ -50,6 +51,7 @@ class StreamingModule:
         self,
         task_id: str,
         initial_content: TaskMessageContent,
+        streaming_mode: StreamingMode = "coalesced",
     ) -> StreamingTaskMessageContext:
         """
         Create a streaming context for managing TaskMessage lifecycle.
@@ -60,7 +62,11 @@ class StreamingModule:
         Args:
             task_id: The ID of the task
             initial_content: The initial content for the TaskMessage
-            agentex_client: The agentex client for creating/updating messages
+            streaming_mode: How per-delta updates are published. Defaults to
+                "coalesced" (50ms / 128-char windowed batches with an immediate
+                first-delta flush). Pass "per_token" for the legacy publish-every-
+                delta behavior, or "off" to suppress per-delta publishes entirely
+                while still recording the full message body on close.
 
         Returns:
             StreamingTaskMessageContext: Context manager for streaming operations
@@ -76,4 +82,5 @@ class StreamingModule:
         return self._streaming_service.streaming_task_message_context(
             task_id=task_id,
             initial_content=initial_content,
+            streaming_mode=streaming_mode,
         )

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
-from typing import Literal
+from typing import Awaitable, Callable, Literal
 
 from agentex import AsyncAgentex
 from agentex.lib.utils.logging import make_logger
@@ -37,6 +39,187 @@ logger = make_logger(__name__)
 
 def _get_stream_topic(task_id: str) -> str:
     return f"task:{task_id}"
+
+
+StreamingMode = Literal["off", "per_token", "coalesced"]
+"""Controls how a StreamingTaskMessageContext publishes deltas.
+
+- "off":        Feed the accumulator (so the persisted message body is correct)
+                but never publish per-delta events. Consumers see start + done
+                only. Lowest latency.
+- "per_token":  Publish every delta immediately. Highest UX fidelity for
+                token-by-token rendering, highest Redis cost, and re-introduces
+                head-of-line blocking on the producer's event loop.
+- "coalesced":  Buffer deltas in a small time/size window and publish them as
+                merged batches. The first delta flushes immediately for fast
+                perceived responsiveness; subsequent deltas flush every 50ms or
+                whenever 128 buffered chars accumulate, whichever comes first.
+                Order within each (delta type, index) channel is preserved
+                exactly; only granularity changes.
+"""
+
+
+def _delta_char_len(delta: TaskMessageDelta | None) -> int:
+    if delta is None:
+        return 0
+    if isinstance(delta, TextDelta):
+        return len(delta.text_delta or "")
+    if isinstance(delta, DataDelta):
+        return len(delta.data_delta or "")
+    if isinstance(delta, ReasoningSummaryDelta):
+        return len(delta.summary_delta or "")
+    if isinstance(delta, ReasoningContentDelta):
+        return len(delta.content_delta or "")
+    if isinstance(delta, ToolRequestDelta):
+        return len(delta.arguments_delta or "")
+    if isinstance(delta, ToolResponseDelta):
+        return len(delta.content_delta or "")
+    return 0
+
+
+def _can_merge(a: TaskMessageDelta, b: TaskMessageDelta) -> bool:
+    if type(a) is not type(b):
+        return False
+    if isinstance(a, ReasoningSummaryDelta) and isinstance(b, ReasoningSummaryDelta):
+        return a.summary_index == b.summary_index
+    if isinstance(a, ReasoningContentDelta) and isinstance(b, ReasoningContentDelta):
+        return a.content_index == b.content_index
+    if isinstance(a, ToolRequestDelta) and isinstance(b, ToolRequestDelta):
+        return a.tool_call_id == b.tool_call_id
+    if isinstance(a, ToolResponseDelta) and isinstance(b, ToolResponseDelta):
+        return a.tool_call_id == b.tool_call_id
+    return True
+
+
+def _merge_pair(a: TaskMessageDelta, b: TaskMessageDelta) -> TaskMessageDelta:
+    if isinstance(a, TextDelta) and isinstance(b, TextDelta):
+        return TextDelta(type="text", text_delta=(a.text_delta or "") + (b.text_delta or ""))
+    if isinstance(a, DataDelta) and isinstance(b, DataDelta):
+        return DataDelta(type="data", data_delta=(a.data_delta or "") + (b.data_delta or ""))
+    if isinstance(a, ReasoningSummaryDelta) and isinstance(b, ReasoningSummaryDelta):
+        return ReasoningSummaryDelta(
+            type="reasoning_summary",
+            summary_index=a.summary_index,
+            summary_delta=(a.summary_delta or "") + (b.summary_delta or ""),
+        )
+    if isinstance(a, ReasoningContentDelta) and isinstance(b, ReasoningContentDelta):
+        return ReasoningContentDelta(
+            type="reasoning_content",
+            content_index=a.content_index,
+            content_delta=(a.content_delta or "") + (b.content_delta or ""),
+        )
+    if isinstance(a, ToolRequestDelta) and isinstance(b, ToolRequestDelta):
+        return ToolRequestDelta(
+            type="tool_request",
+            tool_call_id=a.tool_call_id,
+            name=a.name,
+            arguments_delta=(a.arguments_delta or "") + (b.arguments_delta or ""),
+        )
+    if isinstance(a, ToolResponseDelta) and isinstance(b, ToolResponseDelta):
+        return ToolResponseDelta(
+            type="tool_response",
+            tool_call_id=a.tool_call_id,
+            name=a.name,
+            content_delta=(a.content_delta or "") + (b.content_delta or ""),
+        )
+    return b
+
+
+def _merge_consecutive(updates: list[StreamTaskMessageDelta]) -> list[StreamTaskMessageDelta]:
+    """Merge consecutive same-channel deltas. Order across channels is preserved exactly."""
+    result: list[StreamTaskMessageDelta] = []
+    for u in updates:
+        if u.delta is None or not result:
+            result.append(u)
+            continue
+        last = result[-1]
+        if last.delta is not None and _can_merge(last.delta, u.delta):
+            result[-1] = StreamTaskMessageDelta(
+                parent_task_message=last.parent_task_message,
+                delta=_merge_pair(last.delta, u.delta),
+                type="delta",
+            )
+        else:
+            result.append(u)
+    return result
+
+
+class CoalescingBuffer:
+    """Time-and-size-windowed buffer that merges consecutive same-channel deltas.
+
+    Decouples the producer (model event loop) from the publisher (Redis): ``add``
+    only enqueues and may signal an early flush; the actual publish always runs
+    on a background ticker, so the producer never awaits on a Redis round-trip.
+    """
+
+    FLUSH_INTERVAL_S = 0.050
+    MAX_BUFFERED_CHARS = 128
+
+    def __init__(self, on_flush: Callable[[StreamTaskMessageDelta], Awaitable[object]]):
+        self._on_flush = on_flush
+        self._buf: list[StreamTaskMessageDelta] = []
+        self._buf_chars = 0
+        self._first_flushed = False
+        self._closed = False
+        self._lock = asyncio.Lock()
+        self._flush_signal = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run(), name="coalescing-buffer")
+
+    async def add(self, update: StreamTaskMessageDelta) -> None:
+        if self._closed:
+            return
+        async with self._lock:
+            self._buf.append(update)
+            self._buf_chars += _delta_char_len(update.delta)
+            if not self._first_flushed or self._buf_chars >= self.MAX_BUFFERED_CHARS:
+                self._first_flushed = True
+                self._flush_signal.set()
+
+    async def _run(self) -> None:
+        try:
+            while not self._closed:
+                try:
+                    await asyncio.wait_for(self._flush_signal.wait(), timeout=self.FLUSH_INTERVAL_S)
+                except asyncio.TimeoutError:
+                    pass
+                async with self._lock:
+                    self._flush_signal.clear()
+                    drained = self._drain_locked()
+                for u in drained:
+                    try:
+                        await self._on_flush(u)
+                    except Exception as e:
+                        logger.exception(f"CoalescingBuffer flush failed: {e}")
+        except asyncio.CancelledError:
+            pass
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._task is not None:
+            self._flush_signal.set()
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        async with self._lock:
+            drained = self._drain_locked()
+        for u in drained:
+            try:
+                await self._on_flush(u)
+            except Exception as e:
+                logger.exception(f"CoalescingBuffer final flush failed: {e}")
+
+    def _drain_locked(self) -> list[StreamTaskMessageDelta]:
+        if not self._buf:
+            return []
+        merged = _merge_consecutive(self._buf)
+        self._buf = []
+        self._buf_chars = 0
+        return merged
 
 
 class DeltaAccumulator:
@@ -176,6 +359,7 @@ class StreamingTaskMessageContext:
         initial_content: TaskMessageContent,
         agentex_client: AsyncAgentex,
         streaming_service: "StreamingService",
+        streaming_mode: StreamingMode = "coalesced",
     ):
         self.task_id = task_id
         self.initial_content = initial_content
@@ -184,6 +368,8 @@ class StreamingTaskMessageContext:
         self._streaming_service = streaming_service
         self._is_closed = False
         self._delta_accumulator = DeltaAccumulator()
+        self._streaming_mode: StreamingMode = streaming_mode
+        self._buffer: CoalescingBuffer | None = None
 
     async def __aenter__(self) -> "StreamingTaskMessageContext":
         return await self.open()
@@ -208,6 +394,10 @@ class StreamingTaskMessageContext:
         )
         await self._streaming_service.stream_update(start_event)
 
+        if self._streaming_mode == "coalesced":
+            self._buffer = CoalescingBuffer(on_flush=self._streaming_service.stream_update)
+            self._buffer.start()
+
         return self
 
     async def close(self) -> TaskMessage:
@@ -218,6 +408,12 @@ class StreamingTaskMessageContext:
         if self._is_closed:
             return self.task_message  # Already done
 
+        # Drain any buffered deltas before announcing DONE so consumers see the
+        # full sequence in order.
+        if self._buffer is not None:
+            await self._buffer.close()
+            self._buffer = None
+
         # Send the DONE event
         done_event = StreamTaskMessageDone(
             parent_task_message=self.task_message,
@@ -227,8 +423,8 @@ class StreamingTaskMessageContext:
 
         # Update the task message with the final content
         has_deltas = (
-            self._delta_accumulator._accumulated_deltas or 
-            self._delta_accumulator._reasoning_summaries or 
+            self._delta_accumulator._accumulated_deltas or
+            self._delta_accumulator._reasoning_summaries or
             self._delta_accumulator._reasoning_contents
         )
         if has_deltas:
@@ -248,7 +444,20 @@ class StreamingTaskMessageContext:
     async def stream_update(
         self, update: TaskMessageUpdate
     ) -> TaskMessageUpdate | None:
-        """Stream an update to the repository."""
+        """Stream an update to the repository.
+
+        Behavior depends on the context's ``streaming_mode``:
+        - "off": delta updates feed the accumulator (so the persisted message
+          body is correct) but are never published.
+        - "per_token": delta updates are published immediately.
+        - "coalesced": delta updates are queued in a 50ms / 128-char window and
+          flushed as merged batches on a background ticker; the first delta
+          flushes immediately for fast perceived responsiveness.
+
+        ``StreamTaskMessageDone`` and ``StreamTaskMessageFull`` updates always
+        publish synchronously regardless of mode so consumers and persistence
+        stay in sync.
+        """
         if self._is_closed:
             raise ValueError("Context is already done")
 
@@ -258,6 +467,11 @@ class StreamingTaskMessageContext:
         if isinstance(update, StreamTaskMessageDelta):
             if update.delta is not None:
                 self._delta_accumulator.add_delta(update.delta)
+            if self._streaming_mode == "off":
+                return update
+            if self._streaming_mode == "coalesced" and self._buffer is not None:
+                await self._buffer.add(update)
+                return update
 
         result = await self._streaming_service.stream_update(update)
 
@@ -288,12 +502,14 @@ class StreamingService:
         self,
         task_id: str,
         initial_content: TaskMessageContent,
+        streaming_mode: StreamingMode = "coalesced",
     ) -> StreamingTaskMessageContext:
         return StreamingTaskMessageContext(
             task_id=task_id,
             initial_content=initial_content,
             agentex_client=self._agentex_client,
             streaming_service=self,
+            streaming_mode=streaming_mode,
         )
 
     async def stream_update(

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -122,7 +122,10 @@ def _merge_pair(a: TaskMessageDelta, b: TaskMessageDelta) -> TaskMessageDelta:
             name=a.name,
             content_delta=(a.content_delta or "") + (b.content_delta or ""),
         )
-    return b
+    raise AssertionError(
+        f"_can_merge approved {type(a).__name__} pair but _merge_pair has no handler — "
+        "a new TaskMessageDelta variant was added without updating both functions"
+    )
 
 
 def _merge_consecutive(updates: list[StreamTaskMessageDelta]) -> list[StreamTaskMessageDelta]:
@@ -189,9 +192,17 @@ class CoalescingBuffer:
                 async with self._lock:
                     self._flush_signal.clear()
                     drained = self._drain_locked()
-                for u in drained:
+                for idx, u in enumerate(drained):
                     try:
                         await self._on_flush(u)
+                    except asyncio.CancelledError:
+                        # Re-enqueue the item being flushed plus any remaining so
+                        # close()'s final drain can recover them. May cause a
+                        # duplicate publish of the in-flight item, which is
+                        # preferable to silent loss for a streaming UX.
+                        async with self._lock:
+                            self._buf = drained[idx:] + self._buf
+                        raise
                     except Exception as e:
                         logger.exception(f"CoalescingBuffer flush failed: {e}")
         except asyncio.CancelledError:

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import json
 import asyncio
 import contextlib
-import json
-from typing import Awaitable, Callable, Literal
+from typing import Literal, Callable, Awaitable
 
 from agentex import AsyncAgentex
 from agentex.lib.utils.logging import make_logger

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
@@ -5,10 +5,6 @@ import uuid
 import logging
 from typing import Any, List, Union, Optional, override
 
-# Re-export the canonical StreamingMode literal from the streaming service so
-# all layers share a single definition.
-from agentex.lib.core.services.adk.streaming import StreamingMode as StreamingMode
-
 from agents import (
     Tool,
     Model,
@@ -32,6 +28,10 @@ from agents.tool import (
     ImageGenerationTool,
 )
 from agents.computer import Computer, AsyncComputer
+
+# Re-export the canonical StreamingMode literal from the streaming service so
+# all layers share a single definition.
+from agentex.lib.core.services.adk.streaming import StreamingMode as StreamingMode
 
 try:
     from agents.tool import ShellTool  # type: ignore[attr-defined]

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import uuid
-import logging
 from typing import Any, List, Union, Optional, override
 
 from agents import (
@@ -58,6 +57,7 @@ from openai.types.responses import (
 
 # AgentEx SDK imports
 from agentex.lib import adk
+from agentex.lib.utils.logging import make_logger
 from agentex.lib.core.tracing.tracer import AsyncTracer
 from agentex.types.task_message_delta import TextDelta, ReasoningContentDelta, ReasoningSummaryDelta
 from agentex.types.task_message_update import StreamTaskMessageFull, StreamTaskMessageDelta
@@ -69,8 +69,12 @@ from agentex.lib.core.temporal.plugins.openai_agents.interceptors.context_interc
     streaming_parent_span_id,
 )
 
-# Create logger for this module
-logger = logging.getLogger("agentex.temporal.streaming")
+# Use the SDK's make_logger so this module's INFO/DEBUG output is actually
+# visible (raw ``logging.getLogger`` returns a logger with no handler/level
+# configured, which silently drops anything below WARNING). Keep the explicit
+# name "agentex.temporal.streaming" so any external logging config targeting
+# that name keeps working.
+logger = make_logger("agentex.temporal.streaming")
 
 
 def _serialize_item(item: Any) -> dict[str, Any]:

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
@@ -5,6 +5,10 @@ import uuid
 import logging
 from typing import Any, List, Union, Optional, override
 
+# Re-export the canonical StreamingMode literal from the streaming service so
+# all layers share a single definition.
+from agentex.lib.core.services.adk.streaming import StreamingMode as StreamingMode
+
 from agents import (
     Tool,
     Model,
@@ -113,6 +117,7 @@ class TemporalStreamingModel(Model):
         model_name: str = "gpt-4o",
         _use_responses_api: bool = True,
         openai_client: Optional[AsyncOpenAI] = None,
+        streaming_mode: StreamingMode = "coalesced",
     ):
         """Initialize the streaming model with OpenAI client and model name.
 
@@ -121,18 +126,25 @@ class TemporalStreamingModel(Model):
             _use_responses_api: Internal flag for responses API (deprecated, always True)
             openai_client: Optional custom AsyncOpenAI client. If not provided, a default
                           client with max_retries=0 will be created (since Temporal handles retries)
+            streaming_mode: How per-delta updates flow to consumers. Defaults to
+                          "coalesced" (50ms / 128-char windowed batches with an
+                          immediate first-delta flush) for low latency without
+                          giving up streaming UX. Use "per_token" for legacy
+                          publish-every-delta behavior, or "off" to suppress
+                          per-delta publishes entirely.
         """
         # Use provided client or create default (Temporal handles retries)
         self.client = openai_client if openai_client is not None else AsyncOpenAI(max_retries=0)
         self.model_name = model_name
         # Always use Responses API for all models
         self.use_responses_api = True
+        self.streaming_mode: StreamingMode = streaming_mode
 
         # Initialize tracer as a class variable
         agentex_client = create_async_agentex_client()
         self.tracer = AsyncTracer(agentex_client)
 
-        logger.info(f"[TemporalStreamingModel] Initialized model={self.model_name}, use_responses_api={self.use_responses_api}, custom_client={openai_client is not None}, tracer=initialized")
+        logger.info(f"[TemporalStreamingModel] Initialized model={self.model_name}, use_responses_api={self.use_responses_api}, custom_client={openai_client is not None}, streaming_mode={self.streaming_mode}, tracer=initialized")
 
     def _non_null_or_not_given(self, value: Any) -> Any:
         """Convert None to NOT_GIVEN sentinel, matching OpenAI SDK pattern."""
@@ -634,6 +646,7 @@ class TemporalStreamingModel(Model):
                                         type="reasoning",
                                         style="active",
                                     ),
+                                    streaming_mode=self.streaming_mode,
                                 ).__aenter__()
                         elif item and getattr(item, 'type', None) == 'function_call':
                             # Track the function call being streamed
@@ -654,6 +667,7 @@ class TemporalStreamingModel(Model):
                                     content="",
                                     format="markdown",
                                 ),
+                                streaming_mode=self.streaming_mode,
                             ).__aenter__()
 
                     elif isinstance(event, ResponseFunctionCallArgumentsDeltaEvent):
@@ -732,7 +746,8 @@ class TemporalStreamingModel(Model):
                                     delta=delta_obj,
                                     type="delta",
                                 )
-                                await streaming_context.stream_update(update) if streaming_context else None
+                                if streaming_context:
+                                    await streaming_context.stream_update(update)
                             except Exception as e:
                                 logger.warning(f"Failed to send text delta: {e}")
 
@@ -935,16 +950,24 @@ class TemporalStreamingModel(Model):
 class TemporalStreamingModelProvider(ModelProvider):
     """Custom model provider that returns a streaming-capable model."""
 
-    def __init__(self, openai_client: Optional[AsyncOpenAI] = None):
+    def __init__(
+        self,
+        openai_client: Optional[AsyncOpenAI] = None,
+        streaming_mode: StreamingMode = "coalesced",
+    ):
         """Initialize the provider.
 
         Args:
             openai_client: Optional custom AsyncOpenAI client to use for all models.
                           If not provided, each model will create its own default client.
+            streaming_mode: Default streaming mode applied to every model returned by
+                          this provider. See ``StreamingMode`` for the meaning of
+                          each value. Defaults to "coalesced" — fast but still streamy.
         """
         super().__init__()
         self.openai_client = openai_client
-        logger.info(f"[TemporalStreamingModelProvider] Initialized, custom_client={openai_client is not None}")
+        self.streaming_mode: StreamingMode = streaming_mode
+        logger.info(f"[TemporalStreamingModelProvider] Initialized, custom_client={openai_client is not None}, streaming_mode={self.streaming_mode}")
 
     @override
     def get_model(self, model_name: Union[str, None]) -> Model:
@@ -959,5 +982,9 @@ class TemporalStreamingModelProvider(ModelProvider):
         # Use the provided model_name or default to gpt-4o
         actual_model = model_name if model_name else "gpt-4o"
         logger.info(f"[TemporalStreamingModelProvider] Creating TemporalStreamingModel for model_name: {actual_model}")
-        model = TemporalStreamingModel(model_name=actual_model, openai_client=self.openai_client)
+        model = TemporalStreamingModel(
+            model_name=actual_model,
+            openai_client=self.openai_client,
+            streaming_mode=self.streaming_mode,
+        )
         return model

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/tests/conftest.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/tests/conftest.py
@@ -21,6 +21,7 @@ from agents.tool import (
     CodeInterpreterTool,
     ImageGenerationTool,
 )
+from agents.computer import Computer
 from agents.model_settings import Reasoning  # type: ignore[attr-defined]
 from openai.types.responses import (
     ResponseCompletedEvent,
@@ -45,6 +46,34 @@ def mock_openai_client():
 def sample_task_id():
     """Generate a sample task ID"""
     return f"task_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def _streaming_context_vars(sample_task_id):
+    """Populate the streaming ContextVars that ContextInterceptor sets from
+    request headers in real Temporal flows. TemporalStreamingModel.get_response()
+    validates that all three are set before doing any work, so any test that
+    calls get_response() must request this fixture.
+
+    Named with a leading underscore so tests can request it purely for its
+    setup/teardown side effects without ruff flagging it as an unused argument
+    (ARG002). The yielded value is the task_id set on the ContextVar, available
+    for tests that need to assert against it.
+    """
+    from agentex.lib.core.temporal.plugins.openai_agents.interceptors.context_interceptor import (
+        streaming_task_id,
+        streaming_trace_id,
+        streaming_parent_span_id,
+    )
+    task_token = streaming_task_id.set(sample_task_id)
+    trace_token = streaming_trace_id.set("test-trace-id")
+    span_token = streaming_parent_span_id.set("test-parent-span-id")
+    try:
+        yield sample_task_id
+    finally:
+        streaming_task_id.reset(task_token)
+        streaming_trace_id.reset(trace_token)
+        streaming_parent_span_id.reset(span_token)
 
 
 @pytest.fixture
@@ -115,8 +144,13 @@ def sample_file_search_tool():
 
 @pytest.fixture
 def sample_computer_tool():
-    """Sample ComputerTool for testing"""
-    computer = MagicMock()
+    """Sample ComputerTool for testing.
+
+    Production validates ``isinstance(computer, (Computer, AsyncComputer))`` for
+    Responses API serialization, so the mock must be ``spec``-bound to
+    ``Computer`` for the isinstance check to pass.
+    """
+    computer = MagicMock(spec=Computer)
     computer.environment = "desktop"
     computer.dimensions = [1920, 1080]
     return ComputerTool(computer=computer)

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
@@ -8,13 +8,19 @@ import pytest
 from agents import ModelSettings
 from openai import NOT_GIVEN
 from agents.model_settings import Reasoning, MCPToolChoice  # type: ignore[attr-defined]
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseTextDeltaEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseReasoningSummaryTextDeltaEvent,
+)
 
 
 class TestStreamingModelSettings:
     """Test that all ModelSettings parameters work with Responses API"""
 
     @pytest.mark.asyncio
-    async def test_temperature_setting(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_temperature_setting(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test that temperature parameter is properly passed to Responses API"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -45,7 +51,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['temperature'] == temp
 
     @pytest.mark.asyncio
-    async def test_top_p_setting(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_top_p_setting(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test that top_p parameter is properly passed to Responses API"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -75,7 +81,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['top_p'] == expected
 
     @pytest.mark.asyncio
-    async def test_max_tokens_setting(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_max_tokens_setting(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test that max_tokens is properly mapped to max_output_tokens"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -102,7 +108,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['max_output_tokens'] == 2000
 
     @pytest.mark.asyncio
-    async def test_reasoning_effort_settings(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_reasoning_effort_settings(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test reasoning effort levels (low/medium/high)"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -132,7 +138,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['reasoning'] == {"effort": effort}
 
     @pytest.mark.asyncio
-    async def test_reasoning_summary_settings(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_reasoning_summary_settings(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test reasoning summary settings (auto/none)"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -162,7 +168,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['reasoning'] == {"effort": "medium", "summary": summary}
 
     @pytest.mark.asyncio
-    async def test_tool_choice_variations(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_function_tool):
+    async def test_tool_choice_variations(self, streaming_model, _streaming_context_vars, sample_task_id, sample_function_tool):
         """Test various tool_choice settings"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -200,7 +206,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['tool_choice'] == expected
 
     @pytest.mark.asyncio
-    async def test_parallel_tool_calls(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_function_tool):
+    async def test_parallel_tool_calls(self, streaming_model, _streaming_context_vars, sample_task_id, sample_function_tool):
         """Test parallel tool calls setting"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -228,7 +234,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['parallel_tool_calls'] == parallel
 
     @pytest.mark.asyncio
-    async def test_truncation_strategy(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_truncation_strategy(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test truncation parameter"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -256,7 +262,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['truncation'] == "auto"
 
     @pytest.mark.asyncio
-    async def test_response_include(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_file_search_tool):
+    async def test_response_include(self, streaming_model, _streaming_context_vars, sample_task_id, sample_file_search_tool):
         """Test response include parameter"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -288,7 +294,7 @@ class TestStreamingModelSettings:
         assert "file_search_call.results" in include_list  # Added by file search tool
 
     @pytest.mark.asyncio
-    async def test_verbosity(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_verbosity(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test verbosity settings"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -315,7 +321,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['text'] == {"verbosity": "high"}
 
     @pytest.mark.asyncio
-    async def test_metadata_and_store(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_metadata_and_store(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test metadata and store parameters"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -349,7 +355,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['store'] == store
 
     @pytest.mark.asyncio
-    async def test_extra_headers_and_body(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_extra_headers_and_body(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test extra customization parameters"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -386,7 +392,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['extra_query'] == extra_query
 
     @pytest.mark.asyncio
-    async def test_top_logprobs(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_top_logprobs(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test top_logprobs parameter"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -421,7 +427,7 @@ class TestStreamingModelTools:
     """Test that all tool types work with streaming"""
 
     @pytest.mark.asyncio
-    async def test_function_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_function_tool):
+    async def test_function_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_function_tool):
         """Test FunctionTool conversion and streaming"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -451,7 +457,7 @@ class TestStreamingModelTools:
         assert 'parameters' in tools[0]
 
     @pytest.mark.asyncio
-    async def test_web_search_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_web_search_tool):
+    async def test_web_search_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_web_search_tool):
         """Test WebSearchTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -478,7 +484,7 @@ class TestStreamingModelTools:
         assert tools[0]['type'] == 'web_search'
 
     @pytest.mark.asyncio
-    async def test_file_search_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_file_search_tool):
+    async def test_file_search_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_file_search_tool):
         """Test FileSearchTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -507,7 +513,7 @@ class TestStreamingModelTools:
         assert tools[0]['max_num_results'] == 10
 
     @pytest.mark.asyncio
-    async def test_computer_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_computer_tool):
+    async def test_computer_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_computer_tool):
         """Test ComputerTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -537,7 +543,7 @@ class TestStreamingModelTools:
         assert tools[0]['display_height'] == 1080
 
     @pytest.mark.asyncio
-    async def test_multiple_computer_tools_error(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_computer_tool):
+    async def test_multiple_computer_tools_error(self, streaming_model, _streaming_context_vars, sample_task_id, sample_computer_tool):
         """Test that multiple computer tools raise an error"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -561,7 +567,7 @@ class TestStreamingModelTools:
             )
 
     @pytest.mark.asyncio
-    async def test_hosted_mcp_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_hosted_mcp_tool):
+    async def test_hosted_mcp_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_hosted_mcp_tool):
         """Test HostedMCPTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -589,7 +595,7 @@ class TestStreamingModelTools:
         assert tools[0]['server_label'] == 'test_server'
 
     @pytest.mark.asyncio
-    async def test_image_generation_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_image_generation_tool):
+    async def test_image_generation_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_image_generation_tool):
         """Test ImageGenerationTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -616,7 +622,7 @@ class TestStreamingModelTools:
         assert tools[0]['type'] == 'image_generation'
 
     @pytest.mark.asyncio
-    async def test_code_interpreter_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_code_interpreter_tool):
+    async def test_code_interpreter_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_code_interpreter_tool):
         """Test CodeInterpreterTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -643,7 +649,7 @@ class TestStreamingModelTools:
         assert tools[0]['type'] == 'code_interpreter'
 
     @pytest.mark.asyncio
-    async def test_local_shell_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_local_shell_tool):
+    async def test_local_shell_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_local_shell_tool):
         """Test LocalShellTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -671,7 +677,7 @@ class TestStreamingModelTools:
         # working_directory no longer in API - LocalShellTool uses executor internally
 
     @pytest.mark.asyncio
-    async def test_handoffs(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_handoff):
+    async def test_handoffs(self, streaming_model, _streaming_context_vars, sample_task_id, sample_handoff):
         """Test Handoff conversion to function tools"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -700,7 +706,7 @@ class TestStreamingModelTools:
         assert tools[0]['description'] == 'Transfer to support agent'
 
     @pytest.mark.asyncio
-    async def test_mixed_tools(self, streaming_model, _mock_adk_streaming, sample_task_id,
+    async def test_mixed_tools(self, streaming_model, _streaming_context_vars, sample_task_id,
                               sample_function_tool, sample_web_search_tool, sample_handoff):
         """Test multiple tools together"""
         streaming_model.client.responses.create = AsyncMock()
@@ -736,19 +742,24 @@ class TestStreamingModelBasics:
     """Test core streaming functionality"""
 
     @pytest.mark.asyncio
-    async def test_responses_api_streaming(self, streaming_model, mock_adk_streaming, sample_task_id):
+    async def test_responses_api_streaming(self, streaming_model, mock_adk_streaming, _streaming_context_vars, sample_task_id):
         """Test basic Responses API streaming flow"""
         streaming_model.client.responses.create = AsyncMock()
 
-        # Create a mock stream with text deltas
+        # Production uses ``isinstance(event, ...)`` against the OpenAI Responses
+        # event types to dispatch. ``spec=...`` makes isinstance pass without
+        # triggering pydantic validation on partially-constructed events.
+        item_added = MagicMock(spec=ResponseOutputItemAddedEvent)
+        item_added.item = MagicMock(type="message")
+        item_added.output_index = 0
+        text_delta_1 = MagicMock(spec=ResponseTextDeltaEvent)
+        text_delta_1.delta = "Hello "
+        text_delta_2 = MagicMock(spec=ResponseTextDeltaEvent)
+        text_delta_2.delta = "world!"
+        completed = MagicMock(spec=ResponseCompletedEvent)
+        completed.response = MagicMock(output=[], usage=MagicMock())
         mock_stream = AsyncMock()
-        events = [
-            MagicMock(type="response.output_item.added", item=MagicMock(type="message")),
-            MagicMock(type="response.text.delta", delta="Hello "),
-            MagicMock(type="response.text.delta", delta="world!"),
-            MagicMock(type="response.completed", response=MagicMock(output=[]))
-        ]
-        mock_stream.__aiter__.return_value = iter(events)
+        mock_stream.__aiter__.return_value = iter([item_added, text_delta_1, text_delta_2, completed])
         streaming_model.client.responses.create.return_value = mock_stream
 
         result = await streaming_model.get_response(
@@ -773,17 +784,24 @@ class TestStreamingModelBasics:
         assert isinstance(result, ModelResponse)
 
     @pytest.mark.asyncio
-    async def test_task_id_threading(self, streaming_model, mock_adk_streaming):
-        """Test that task_id is properly threaded through to streaming context"""
+    async def test_task_id_threading(self, streaming_model, mock_adk_streaming, _streaming_context_vars):
+        """Test that task_id from the streaming ContextVar is threaded through to
+        the streaming context. ``_streaming_context_vars`` yields the task_id that
+        was set on the ContextVar, which is what production reads (the kwarg
+        ``task_id=...`` to ``get_response`` is swallowed by ``**kwargs`` and ignored).
+        """
         streaming_model.client.responses.create = AsyncMock()
 
+        item_added = MagicMock(spec=ResponseOutputItemAddedEvent)
+        item_added.item = MagicMock(type="message")
+        item_added.output_index = 0
+        completed = MagicMock(spec=ResponseCompletedEvent)
+        completed.response = MagicMock(output=[], usage=MagicMock())
         mock_stream = AsyncMock()
-        mock_stream.__aiter__.return_value = iter([
-            MagicMock(type="response.completed", response=MagicMock(output=[]))
-        ])
+        mock_stream.__aiter__.return_value = iter([item_added, completed])
         streaming_model.client.responses.create.return_value = mock_stream
 
-        task_id = "test_task_12345"
+        expected_task_id = _streaming_context_vars
 
         await streaming_model.get_response(
             system_instructions="Test",
@@ -793,27 +811,30 @@ class TestStreamingModelBasics:
             output_schema=None,
             handoffs=[],
             tracing=None,
-            task_id=task_id
         )
 
-        # Verify task_id was passed to streaming context
+        # Verify the ContextVar's task_id was threaded through to the streaming context
         mock_adk_streaming.streaming_task_message_context.assert_called()
         call_args = mock_adk_streaming.streaming_task_message_context.call_args
-        assert call_args.kwargs['task_id'] == task_id
+        assert call_args.kwargs['task_id'] == expected_task_id
 
     @pytest.mark.asyncio
-    async def test_redis_context_creation(self, streaming_model, mock_adk_streaming, sample_task_id):
+    async def test_redis_context_creation(self, streaming_model, mock_adk_streaming, _streaming_context_vars, sample_task_id):
         """Test that Redis streaming contexts are created properly"""
         streaming_model.client.responses.create = AsyncMock()
 
-        # Mock stream with reasoning
+        # Production uses ``isinstance`` against OpenAI Responses event types;
+        # ``spec=...`` makes isinstance pass without triggering pydantic validation.
+        item_added = MagicMock(spec=ResponseOutputItemAddedEvent)
+        item_added.item = MagicMock(type="reasoning")
+        item_added.output_index = 0
+        reasoning_delta = MagicMock(spec=ResponseReasoningSummaryTextDeltaEvent)
+        reasoning_delta.delta = "Thinking..."
+        reasoning_delta.summary_index = 0
+        completed = MagicMock(spec=ResponseCompletedEvent)
+        completed.response = MagicMock(output=[], usage=MagicMock())
         mock_stream = AsyncMock()
-        events = [
-            MagicMock(type="response.output_item.added", item=MagicMock(type="reasoning")),
-            MagicMock(type="response.reasoning_summary_text.delta", delta="Thinking...", summary_index=0),
-            MagicMock(type="response.completed", response=MagicMock(output=[]))
-        ]
-        mock_stream.__aiter__.return_value = iter(events)
+        mock_stream.__aiter__.return_value = iter([item_added, reasoning_delta, completed])
         streaming_model.client.responses.create.return_value = mock_stream
 
         await streaming_model.get_response(
@@ -832,10 +853,16 @@ class TestStreamingModelBasics:
 
     @pytest.mark.asyncio
     async def test_missing_task_id_error(self, streaming_model):
-        """Test that missing task_id raises appropriate error"""
+        """Test that missing streaming ContextVars raise an appropriate error.
+
+        Production reads task_id, trace_id, and parent_span_id from ContextVars
+        populated by ContextInterceptor. Without ``_streaming_context_vars``
+        requested, all three are at their defaults — empty strings — and
+        ``get_response`` raises before doing any work.
+        """
         streaming_model.client.responses.create = AsyncMock()
 
-        with pytest.raises(ValueError, match="task_id is required"):
+        with pytest.raises(ValueError, match=r"task_id.*required"):
             await streaming_model.get_response(
                 system_instructions="Test",
                 input="Hello",
@@ -844,5 +871,4 @@ class TestStreamingModelBasics:
                 output_schema=None,
                 handoffs=[],
                 tracing=None,
-                task_id=None  # Missing task_id
             )

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
@@ -773,11 +773,13 @@ class TestStreamingModelBasics:
             task_id=sample_task_id
         )
 
-        # Verify streaming context was created
-        mock_adk_streaming.streaming_task_message_context.assert_called_with(
-            task_id=sample_task_id,
-            initial_content=mock_adk_streaming.streaming_task_message_context.call_args.kwargs['initial_content']
-        )
+        # Verify streaming context was created with the right task_id. We
+        # don't strict-match the full kwargs because production also passes
+        # ``streaming_mode``, which is an implementation detail this test
+        # doesn't care about.
+        mock_adk_streaming.streaming_task_message_context.assert_called()
+        call_kwargs = mock_adk_streaming.streaming_task_message_context.call_args.kwargs
+        assert call_kwargs['task_id'] == sample_task_id
 
         # Verify result is returned as ModelResponse
         from agents import ModelResponse

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -1,0 +1,497 @@
+"""Tests for the streaming service: ``CoalescingBuffer``, merge helpers, and
+``StreamingTaskMessageContext`` mode dispatch.
+
+These exercise the in-process behavior of the streaming layer without hitting
+Redis or any AgentEx HTTP endpoints — everything below the
+``StreamingService.stream_update`` boundary is mocked.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentex.types.task_message import TaskMessage
+from agentex.types.text_content import TextContent
+from agentex.types.task_message_delta import (
+    DataDelta,
+    TextDelta,
+    ToolRequestDelta,
+    ToolResponseDelta,
+    ReasoningSummaryDelta,
+)
+from agentex.types.task_message_update import StreamTaskMessageDelta
+from agentex.lib.core.services.adk.streaming import (
+    CoalescingBuffer,
+    StreamingTaskMessageContext,
+    _can_merge,
+    _merge_pair,
+    _delta_char_len,
+    _merge_consecutive,
+)
+
+
+@pytest.fixture
+def task_message() -> TaskMessage:
+    return TaskMessage(
+        id="m1",
+        task_id="t1",
+        content=TextContent(author="agent", content="", format="markdown"),
+        streaming_status="IN_PROGRESS",
+    )
+
+
+def _text(tm: TaskMessage, s: str) -> StreamTaskMessageDelta:
+    return StreamTaskMessageDelta(
+        parent_task_message=tm,
+        delta=TextDelta(type="text", text_delta=s),
+        type="delta",
+    )
+
+
+def _reasoning_summary(tm: TaskMessage, idx: int, s: str) -> StreamTaskMessageDelta:
+    return StreamTaskMessageDelta(
+        parent_task_message=tm,
+        delta=ReasoningSummaryDelta(
+            type="reasoning_summary", summary_index=idx, summary_delta=s
+        ),
+        type="delta",
+    )
+
+
+async def _make_context(streaming_mode: str) -> tuple[StreamingTaskMessageContext, MagicMock, TaskMessage]:
+    tm = TaskMessage(
+        id="m1",
+        task_id="t1",
+        content=TextContent(author="agent", content="", format="markdown"),
+        streaming_status="IN_PROGRESS",
+    )
+    svc = MagicMock()
+    svc.stream_update = AsyncMock()
+    client = MagicMock()
+    client.messages.create = AsyncMock(return_value=tm)
+    client.messages.update = AsyncMock()
+    ctx = StreamingTaskMessageContext(
+        task_id="t1",
+        initial_content=TextContent(author="agent", content="", format="markdown"),
+        agentex_client=client,
+        streaming_service=svc,
+        streaming_mode=streaming_mode,  # type: ignore[arg-type]
+    )
+    await ctx.open()
+    return ctx, svc, tm
+
+
+class TestDeltaCharLen:
+    def test_text_delta(self) -> None:
+        assert _delta_char_len(TextDelta(type="text", text_delta="hello")) == 5
+
+    def test_reasoning_summary_delta(self) -> None:
+        assert (
+            _delta_char_len(
+                ReasoningSummaryDelta(
+                    type="reasoning_summary", summary_index=0, summary_delta="abc"
+                )
+            )
+            == 3
+        )
+
+    def test_none_delta_is_zero(self) -> None:
+        assert _delta_char_len(None) == 0
+
+    def test_empty_string_delta(self) -> None:
+        assert _delta_char_len(TextDelta(type="text", text_delta="")) == 0
+
+
+class TestCanMerge:
+    def test_same_text_type(self) -> None:
+        a = TextDelta(type="text", text_delta="a")
+        b = TextDelta(type="text", text_delta="b")
+        assert _can_merge(a, b) is True
+
+    def test_different_types_never_merge(self) -> None:
+        text = TextDelta(type="text", text_delta="a")
+        data = DataDelta(type="data", data_delta="b")
+        assert _can_merge(text, data) is False
+
+    def test_reasoning_summary_same_index_merges(self) -> None:
+        a = ReasoningSummaryDelta(type="reasoning_summary", summary_index=0, summary_delta="x")
+        b = ReasoningSummaryDelta(type="reasoning_summary", summary_index=0, summary_delta="y")
+        assert _can_merge(a, b) is True
+
+    def test_reasoning_summary_different_index_blocks_merge(self) -> None:
+        a = ReasoningSummaryDelta(type="reasoning_summary", summary_index=0, summary_delta="x")
+        b = ReasoningSummaryDelta(type="reasoning_summary", summary_index=1, summary_delta="y")
+        assert _can_merge(a, b) is False
+
+    def test_tool_request_same_call_id_merges(self) -> None:
+        a = ToolRequestDelta(type="tool_request", tool_call_id="c1", name="t", arguments_delta="{")
+        b = ToolRequestDelta(type="tool_request", tool_call_id="c1", name="t", arguments_delta="}")
+        assert _can_merge(a, b) is True
+
+    def test_tool_request_different_call_id_blocks_merge(self) -> None:
+        a = ToolRequestDelta(type="tool_request", tool_call_id="c1", name="t", arguments_delta="{")
+        b = ToolRequestDelta(type="tool_request", tool_call_id="c2", name="t", arguments_delta="}")
+        assert _can_merge(a, b) is False
+
+
+class TestMergePair:
+    def test_text_concatenates(self) -> None:
+        merged = _merge_pair(
+            TextDelta(type="text", text_delta="Hello "),
+            TextDelta(type="text", text_delta="world"),
+        )
+        assert isinstance(merged, TextDelta)
+        assert merged.text_delta == "Hello world"
+
+    def test_reasoning_summary_concatenates_and_keeps_index(self) -> None:
+        merged = _merge_pair(
+            ReasoningSummaryDelta(
+                type="reasoning_summary", summary_index=2, summary_delta="hello "
+            ),
+            ReasoningSummaryDelta(
+                type="reasoning_summary", summary_index=2, summary_delta="world"
+            ),
+        )
+        assert isinstance(merged, ReasoningSummaryDelta)
+        assert merged.summary_index == 2
+        assert merged.summary_delta == "hello world"
+
+    def test_tool_response_concatenates_and_keeps_call_id(self) -> None:
+        merged = _merge_pair(
+            ToolResponseDelta(
+                type="tool_response", tool_call_id="c1", name="t", content_delta="part1 "
+            ),
+            ToolResponseDelta(
+                type="tool_response", tool_call_id="c1", name="t", content_delta="part2"
+            ),
+        )
+        assert isinstance(merged, ToolResponseDelta)
+        assert merged.tool_call_id == "c1"
+        assert merged.content_delta == "part1 part2"
+
+    def test_handles_none_string_fields(self) -> None:
+        """Pydantic allows the *_delta fields to be None; merge must coerce to empty."""
+        merged = _merge_pair(
+            TextDelta(type="text", text_delta=None),
+            TextDelta(type="text", text_delta="late"),
+        )
+        assert isinstance(merged, TextDelta)
+        assert merged.text_delta == "late"
+
+
+class TestMergeConsecutive:
+    def test_pure_text_collapses_to_one(self, task_message: TaskMessage) -> None:
+        deltas = [_text(task_message, s) for s in ["Hello", " ", "world", "!"]]
+        merged = _merge_consecutive(deltas)
+        assert len(merged) == 1
+        assert merged[0].delta is not None
+        assert isinstance(merged[0].delta, TextDelta)
+        assert merged[0].delta.text_delta == "Hello world!"
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert _merge_consecutive([]) == []
+
+    def test_single_delta_passes_through(self, task_message: TaskMessage) -> None:
+        deltas = [_text(task_message, "lone")]
+        merged = _merge_consecutive(deltas)
+        assert len(merged) == 1
+        assert merged[0] is deltas[0]  # same object, no merge happened
+
+    def test_cross_channel_order_preserved_for_reasoning(
+        self, task_message: TaskMessage
+    ) -> None:
+        """Consecutive same-(type, index) merges; distinct channels never reorder."""
+        deltas = [
+            _reasoning_summary(task_message, 0, "Let me "),
+            _reasoning_summary(task_message, 0, "think..."),
+            _reasoning_summary(task_message, 1, "Maybe "),
+            _reasoning_summary(task_message, 0, " Actually,"),
+            _reasoning_summary(task_message, 0, " yes."),
+        ]
+        merged = _merge_consecutive(deltas)
+        # Three groups: idx=0 run, idx=1 single, idx=0 run again — order preserved.
+        assert len(merged) == 3
+        assert merged[0].delta is not None and isinstance(
+            merged[0].delta, ReasoningSummaryDelta
+        )
+        assert merged[1].delta is not None and isinstance(
+            merged[1].delta, ReasoningSummaryDelta
+        )
+        assert merged[2].delta is not None and isinstance(
+            merged[2].delta, ReasoningSummaryDelta
+        )
+        assert merged[0].delta.summary_index == 0
+        assert merged[0].delta.summary_delta == "Let me think..."
+        assert merged[1].delta.summary_index == 1
+        assert merged[1].delta.summary_delta == "Maybe "
+        assert merged[2].delta.summary_index == 0
+        assert merged[2].delta.summary_delta == " Actually, yes."
+
+    def test_per_channel_concat_matches_per_token_semantics(
+        self, task_message: TaskMessage
+    ) -> None:
+        """Reconstructing per-channel content from the merged stream must match
+        what a per-token consumer would have seen."""
+        deltas = [
+            _reasoning_summary(task_message, 0, "Hel"),
+            _reasoning_summary(task_message, 0, "lo"),
+            _reasoning_summary(task_message, 1, "World"),
+            _reasoning_summary(task_message, 0, "!"),
+        ]
+        merged = _merge_consecutive(deltas)
+
+        per_index: dict[int, str] = {}
+        for u in merged:
+            d = u.delta
+            assert isinstance(d, ReasoningSummaryDelta)
+            per_index[d.summary_index] = per_index.get(d.summary_index, "") + (
+                d.summary_delta or ""
+            )
+
+        assert per_index == {0: "Hello!", 1: "World"}
+
+
+class TestCoalescingBufferTimeWindow:
+    @pytest.mark.asyncio
+    async def test_first_delta_flushes_immediately(
+        self, task_message: TaskMessage
+    ) -> None:
+        """The first-delta-immediate optimization should trip a flush in <=20ms,
+        well below the 50ms time window, so consumers see ``something started``."""
+        flushed: list[StreamTaskMessageDelta] = []
+
+        async def on_flush(u: StreamTaskMessageDelta) -> None:
+            flushed.append(u)
+
+        buf = CoalescingBuffer(on_flush=on_flush)
+        buf.start()
+        try:
+            await buf.add(_text(task_message, "hi"))
+            # Give the ticker a single tick to drain the signal.
+            await asyncio.sleep(0.020)
+            assert len(flushed) == 1
+            assert flushed[0].delta is not None and isinstance(
+                flushed[0].delta, TextDelta
+            )
+            assert flushed[0].delta.text_delta == "hi"
+        finally:
+            await buf.close()
+
+    @pytest.mark.asyncio
+    async def test_size_threshold_triggers_early_flush(
+        self, task_message: TaskMessage
+    ) -> None:
+        """Adding more than MAX_BUFFERED_CHARS in one shot should flush within
+        a single asyncio tick, well before the 50ms timer would fire."""
+        flushed: list[StreamTaskMessageDelta] = []
+
+        async def on_flush(u: StreamTaskMessageDelta) -> None:
+            flushed.append(u)
+
+        buf = CoalescingBuffer(on_flush=on_flush)
+        buf.start()
+        try:
+            # Burn the first-delta-immediate slot so we're on the steady-state path.
+            await buf.add(_text(task_message, "x"))
+            await asyncio.sleep(0.020)
+            flushed.clear()
+
+            # Now add 200 chars in one delta — well over MAX_BUFFERED_CHARS=128.
+            await buf.add(_text(task_message, "A" * 200))
+            await asyncio.sleep(0.010)  # half the timer interval; only size can fire here
+            assert len(flushed) == 1
+            assert flushed[0].delta is not None and isinstance(
+                flushed[0].delta, TextDelta
+            )
+            assert flushed[0].delta.text_delta == "A" * 200
+        finally:
+            await buf.close()
+
+    @pytest.mark.asyncio
+    async def test_subsequent_deltas_coalesce_within_window(
+        self, task_message: TaskMessage
+    ) -> None:
+        """Three small deltas added inside one timer window should publish as
+        one merged delta (after the initial first-flush burns)."""
+        flushed: list[StreamTaskMessageDelta] = []
+
+        async def on_flush(u: StreamTaskMessageDelta) -> None:
+            flushed.append(u)
+
+        buf = CoalescingBuffer(on_flush=on_flush)
+        buf.start()
+        try:
+            await buf.add(_text(task_message, "first"))  # immediate flush
+            await asyncio.sleep(0.020)
+            flushed.clear()
+
+            for chunk in ("ab", "cd", "ef"):
+                await buf.add(_text(task_message, chunk))
+            # Wait past the 50ms window so the timer fires.
+            await asyncio.sleep(0.080)
+            # All three small deltas merge into a single publish.
+            assert len(flushed) == 1
+            assert flushed[0].delta is not None and isinstance(
+                flushed[0].delta, TextDelta
+            )
+            assert flushed[0].delta.text_delta == "abcdef"
+        finally:
+            await buf.close()
+
+
+class TestCoalescingBufferClose:
+    @pytest.mark.asyncio
+    async def test_close_drains_remaining_buffered_items(
+        self, task_message: TaskMessage
+    ) -> None:
+        """Items added after the last timer tick must still flush before close()
+        completes — the persisted message body and the stream contract both
+        require it."""
+        flushed: list[StreamTaskMessageDelta] = []
+
+        async def on_flush(u: StreamTaskMessageDelta) -> None:
+            flushed.append(u)
+
+        buf = CoalescingBuffer(on_flush=on_flush)
+        buf.start()
+        await buf.add(_text(task_message, "first"))  # immediate
+        await asyncio.sleep(0.020)
+        flushed.clear()
+
+        # Add an item and immediately close — too fast for the 50ms timer.
+        await buf.add(_text(task_message, "last"))
+        await buf.close()
+
+        assert len(flushed) == 1
+        assert flushed[0].delta is not None and isinstance(flushed[0].delta, TextDelta)
+        assert flushed[0].delta.text_delta == "last"
+
+    @pytest.mark.asyncio
+    async def test_close_when_idle_is_safe(self, task_message: TaskMessage) -> None:
+        """``close()`` with no buffered items must not raise."""
+        buf = CoalescingBuffer(on_flush=AsyncMock())
+        buf.start()
+        await buf.close()  # no items, no signal, just exit cleanly
+
+    @pytest.mark.asyncio
+    async def test_add_after_close_is_noop(self, task_message: TaskMessage) -> None:
+        """Defensive: ``add`` after ``close`` must silently do nothing rather
+        than raise. Real flows shouldn't hit this but tests racing close()
+        should not blow up."""
+        flushed: list[StreamTaskMessageDelta] = []
+
+        async def on_flush(u: StreamTaskMessageDelta) -> None:
+            flushed.append(u)
+
+        buf = CoalescingBuffer(on_flush=on_flush)
+        buf.start()
+        await buf.close()
+        # Fully drained and closed; this should silently no-op.
+        await buf.add(_text(task_message, "after"))
+        assert flushed == []
+
+
+class TestCoalescingBufferCancelDuringFlush:
+    @pytest.mark.asyncio
+    async def test_cancel_during_flush_recovers_remaining_items(
+        self, task_message: TaskMessage
+    ) -> None:
+        """Regression: when ``close()`` cancels the ticker mid-flush, items in
+        the local ``drained`` list must be re-enqueued so the final drain in
+        ``close()`` can recover them. Otherwise the last coalesced batch is
+        silently dropped — visible to consumers as a truncated stream.
+        """
+        flushed: list[StreamTaskMessageDelta] = []
+        first_started = asyncio.Event()
+        first_continue = asyncio.Event()
+
+        async def slow_flush(u: StreamTaskMessageDelta) -> None:
+            flushed.append(u)
+            if len(flushed) == 1:
+                first_started.set()
+                # Block the first publish until the test releases it. This
+                # guarantees the cancellation lands inside the flush loop.
+                await first_continue.wait()
+
+        buf = CoalescingBuffer(on_flush=slow_flush)
+        buf.start()
+        # Add five items quickly; they all land in self._buf and the ticker
+        # will drain them as one merged batch.
+        for i in range(5):
+            await buf.add(_text(task_message, f"chunk{i}"))
+
+        await asyncio.wait_for(first_started.wait(), timeout=2.0)
+        # Trigger close() while the first flush is blocked, then release it.
+        close_task = asyncio.create_task(buf.close())
+        first_continue.set()
+        await close_task
+
+        # All five chunks must appear at least once across all publishes.
+        # (The first-flushed item may duplicate; that's the documented
+        # trade-off — duplicate > silent loss.)
+        full = "".join(
+            u.delta.text_delta or ""
+            for u in flushed
+            if isinstance(u.delta, TextDelta)
+        )
+        for i in range(5):
+            assert f"chunk{i}" in full, (
+                f"chunk{i} missing — silent data loss across cancel-during-flush boundary. "
+                f"flushed payloads: {[u.delta.text_delta for u in flushed if isinstance(u.delta, TextDelta)]}"
+            )
+
+
+class TestStreamingTaskMessageContextModes:
+    @pytest.mark.asyncio
+    async def test_off_mode_skips_publishes_but_persists_full_content(self) -> None:
+        ctx, svc, tm = await _make_context("off")
+        svc.stream_update.reset_mock()
+        for chunk in ("Hello", " ", "world"):
+            await ctx.stream_update(_text(tm, chunk))
+        # Plenty of time for any background ticker — none should exist.
+        await asyncio.sleep(0.080)
+        assert svc.stream_update.call_count == 0, (
+            "off mode must publish zero per-delta updates"
+        )
+
+        await ctx.close()
+        # The persisted message body must still contain the full assembled text,
+        # because the accumulator was fed even when publishing was suppressed.
+        update_kwargs = ctx._agentex_client.messages.update.call_args.kwargs
+        assert update_kwargs["content"]["content"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_per_token_mode_publishes_each_delta_immediately(self) -> None:
+        ctx, svc, tm = await _make_context("per_token")
+        svc.stream_update.reset_mock()
+        for chunk in ("a", "b", "c"):
+            await ctx.stream_update(_text(tm, chunk))
+        # Per-token mode must publish synchronously, no waiting required.
+        assert svc.stream_update.call_count == 3
+        await ctx.close()
+
+    @pytest.mark.asyncio
+    async def test_coalesced_mode_batches_and_persists_full_content(self) -> None:
+        ctx, svc, tm = await _make_context("coalesced")
+        svc.stream_update.reset_mock()
+        for chunk in ("Hello", " ", "world", "!"):
+            await ctx.stream_update(_text(tm, chunk))
+        await ctx.close()
+
+        # Assembled content is the union of all per-delta text.
+        update_kwargs = ctx._agentex_client.messages.update.call_args.kwargs
+        assert update_kwargs["content"]["content"] == "Hello world!"
+
+        # Coalesced mode produces fewer publishes than per_token (4) but at
+        # least the start + at least one delta + done.
+        delta_publishes = [
+            call
+            for call in svc.stream_update.call_args_list
+            if isinstance(call.args[0] if call.args else None, StreamTaskMessageDelta)
+        ]
+        assert len(delta_publishes) >= 1, "coalesced mode should publish at least one delta"
+        assert len(delta_publishes) < 4, (
+            "coalesced mode should batch at least some of the four chunks"
+        )


### PR DESCRIPTION
## Summary

Per-token Redis publishes from `TemporalStreamingModel` were adding **~45s (56-62%)** overhead to agent response latency. Root cause: each `await streaming_context.stream_update(...)` inside the OpenAI stream `async for` blocked token consumption until the Redis publish round-trip completed (head-of-line blocking via TCP backpressure on the SSE connection).

This PR replaces per-token publishes with a coalescing buffer that runs on a background ticker driven by `asyncio.Event` — so the producer's event loop never awaits on Redis, even on size-threshold flushes.

## Performance context (from the original report)

| Metric | No-Streaming Baseline | With Per-Token Streaming | Overhead |
|---|---|---|---|
| First Callback P50 | 56.2s | 103.1s | +47s (+84%) |
| Final Response P50 | 73.1s | 118.4s | +45s (+62%) |
| Final Response P95 | 121.9s | 178.4s | +56s (+46%) |

Cost model with 1000 tokens at the chosen thresholds:
- ~10–22 Redis publishes per response (down from ~1000)
- ~50–110ms total Redis time, **off the critical path**
- Expected to land within ~5–10% of the no-streaming P50 (~73s)

## Design

### `StreamingMode = Literal["off", "per_token", "coalesced"]`

Single source of truth in `streaming.py`. Every layer takes it as a parameter (model, provider, service, adk module, context).

| Mode | Semantics |
|---|---|
| `off` | Feed accumulator (so persisted message body is correct), no per-delta publishes. Consumers see `start → done` only. |
| `per_token` | Publish every delta immediately. Legacy behavior. |
| `coalesced` (**default**) | Buffer 50ms / 128-char windowed batches, flush first delta immediately for perceived responsiveness. |

### `CoalescingBuffer`

- 50ms time window (timer-driven)
- 128-char size threshold (signal-driven via `asyncio.Event`)
- First-delta-immediate optimization (~1 extra publish per stream, big perceived-latency win)
- Background ticker decoupled from `add()` — producer never awaits on Redis
- **Consecutive-only merge**: only merges adjacent same-channel deltas, so character order within every `(type, index)` channel is preserved exactly. Cross-channel order is preserved too.
- `close()` drains remaining buffer before `StreamTaskMessageDone` so consumers see the full sequence.

### Default flip

The default for `streaming_mode` is `"coalesced"` at every layer. All 13+ existing callers of `streaming_task_message_context()` (claude_agents, langgraph, litellm provider, openai sync provider, etc.) benefit automatically without code changes.

## Risks / caveats

1. **Behavior change for non-OpenAI streaming consumers.** claude_agents, langgraph, litellm provider, and the openai sync provider all flip from per-token to coalesced silently. Downstream UIs that animate per-delta will animate per-50ms-chunk instead. At human reading speeds for prose, this should be indistinguishable, but it's a contract change worth flagging.
2. **First-delta-immediate adds one extra publish per stream.** Tiny absolute cost, big UX win (response appears \"alive\" within ~20ms). Always on.
3. **Granularity, not order, changes.** Coalescing never reorders characters within a channel — it only emits fewer events with bigger payloads. Consumers that assume \"each delta == one OpenAI token\" or use inter-delta timing as a signal will see different timing characteristics; consumers that just concatenate (the standard pattern) see identical final output.
4. **Opt-out is one line.** Anyone needing strict per-token streaming sets `streaming_mode=\"per_token\"` on the model/provider/context constructor — no other code changes required.

## Test plan

- [x] pyright clean on all 3 modified files
- [x] Top-level `tests/test_streaming.py` (20/20 pass)
- [x] End-to-end smoke tests for the 6 key invariants:
  - [x] Pure-text consecutive merge collapses to single delta with full content
  - [x] Cross-channel reasoning deltas preserve order; per-channel content matches per-token semantics
  - [x] First delta flushes within ~20ms (well under the 50ms window)
  - [x] 200-char delta triggers size-flush before the timer fires
  - [x] `close()` drains buffer; persisted message body is the full assembled content
  - [x] `\"off\"` mode produces zero per-delta publishes but still persists complete content
- [ ] Re-run the original benchmark on a representative workload to confirm P50 final-response landed within ~5–10% of the no-streaming baseline (~73s)
- [ ] Manual smoke: deploy to a dev environment, exercise an OpenAI agent end-to-end, verify chat UI still renders streamingly (just chunkier)
- [ ] Manual smoke: exercise a claude_agents and a langgraph path to verify the silent default-flip doesn't break anything

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces per-token Redis publishes in `TemporalStreamingModel` with a `CoalescingBuffer` that merges consecutive same-channel deltas in 50ms / 128-char windows on a background `asyncio.Task`, eliminating the head-of-line blocking that was adding ~45s to agent response latency. A new `StreamingMode` literal (`"off"` / `"per_token"` / `"coalesced"`) threads through every layer; the default flips to `"coalesced"` at all 13+ call sites automatically.

The previously-flagged silent data-loss on `CancelledError` mid-flush has been addressed: items are now re-enqueued before re-raising so `close()`'s final drain recovers them. Two minor style points remain (see inline comments) but neither affects correctness.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the core correctness concern from the prior review thread is resolved, and all remaining findings are P2 style suggestions.

The critical silent-drop bug (CancelledError during flush leaving items unrecovered) is fixed with the re-enqueue pattern. The two remaining comments are defensive coding suggestions — a TOCTOU on _closed that only matters for concurrent callers (not the sequential streaming model), and a _buf_chars accounting gap that is benign given _closed=True gates any threshold checks. Neither affects observable behavior. Test coverage is thorough (20 unit tests across helpers, buffer windowing, cancellation recovery, and mode dispatch).

src/agentex/lib/core/services/adk/streaming.py — the two P2 style items in CoalescingBuffer._run and add()
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/services/adk/streaming.py | Core of the PR: adds StreamingMode type alias, CoalescingBuffer class, and mode-dispatch in StreamingTaskMessageContext. The CancelledError re-enqueue fix from the previous review thread is applied; one minor race on the _closed guard and a _buf_chars accounting gap after re-enqueue remain. |
| src/agentex/lib/adk/_modules/streaming.py | Thin pass-through: adds streaming_mode parameter to StreamingModule.streaming_task_message_context() and forwards it to the service. No logic here. |
| src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py | Adds streaming_mode parameter to TemporalStreamingModel and TemporalStreamingModelProvider, switches logger from raw logging.getLogger to make_logger, and passes streaming_mode through to context construction at both reasoning and text streaming sites. |
| tests/lib/core/services/adk/test_streaming.py | New 497-line test file covering CoalescingBuffer time/size windows, close drain, cancel-during-flush recovery, merge helpers, and StreamingTaskMessageContext mode dispatch. Comprehensive coverage of all three modes. |
| src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py | Loosened one assertion to not strict-match full kwargs (since streaming_mode is now passed), keeping task_id check. Minor test hygiene improvement. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Producer (OpenAI stream)
    participant C as StreamingTaskMessageContext
    participant B as CoalescingBuffer
    participant R as Redis (StreamingService)

    P->>C: stream_update(delta1) [first]
    C->>B: add(delta1)
    Note over B: _first_flushed=False → set _flush_signal
    B-->>R: on_flush(delta1) [immediate via ticker]

    P->>C: stream_update(delta2)
    P->>C: stream_update(delta3)
    Note over B: buffering in _buf...

    loop Every 50ms or 128 chars
        B->>B: _drain_locked() → _merge_consecutive()
        B-->>R: on_flush(merged delta2+delta3)
    end

    P->>C: close()
    C->>B: close()
    B->>B: cancel background ticker
    B->>B: final _drain_locked()
    B-->>R: on_flush(remaining merged)
    C-->>R: stream_update(StreamTaskMessageDone)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%3A175-183%0A**%60_closed%60%20guard%20is%20outside%20the%20lock%20%E2%80%94%20concurrent%20%60close%28%29%60%20can%20silently%20drop%20items**%0A%0A%60_closed%60%20is%20read%20before%20acquiring%20the%20lock%2C%20so%20a%20concurrent%20coroutine%20calling%20%60close%28%29%60%20can%20interleave%20as%20follows%3A%0A%0A1.%20%60add%28%29%60%20reads%20%60self._closed%60%20%E2%86%92%20%60False%60%2C%20passes%20the%20guard%0A2.%20%60close%28%29%60%20sets%20%60self._closed%20%3D%20True%60%2C%20drains%20and%20flushes%20the%20buffer%2C%20exits%0A3.%20%60add%28%29%60%20acquires%20the%20lock%20and%20appends%20to%20%60self._buf%60%20%E2%80%94%20item%20is%20never%20drained%0A%0AIn%20asyncio%20this%20requires%20two%20coroutines%20concurrently%20calling%20%60add%28%29%60%20and%20%60close%28%29%60%2C%20which%20the%20current%20streaming%20model%20doesn't%20do%20%28tokens%20are%20produced%20sequentially%20before%20%60close%28%29%60%20is%20called%29.%20Still%2C%20moving%20the%20check%20inside%20the%20lock%20makes%20the%20invariant%20obvious%20and%20prevents%20silent%20loss%20for%20any%20future%20concurrent%20caller%3A%0A%0A%60%60%60python%0Aasync%20def%20add%28self%2C%20update%3A%20StreamTaskMessageDelta%29%20-%3E%20None%3A%0A%20%20%20%20async%20with%20self._lock%3A%0A%20%20%20%20%20%20%20%20if%20self._closed%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20self._buf.append%28update%29%0A%20%20%20%20%20%20%20%20self._buf_chars%20%2B%3D%20_delta_char_len%28update.delta%29%0A%20%20%20%20%20%20%20%20if%20not%20self._first_flushed%20or%20self._buf_chars%20%3E%3D%20self.MAX_BUFFERED_CHARS%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20self._first_flushed%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20self._flush_signal.set%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%3A198-204%0A**%60_buf_chars%60%20not%20restored%20after%20re-enqueue%20on%20%60CancelledError%60**%0A%0A%60_drain_locked%28%29%60%20resets%20%60self._buf_chars%20%3D%200%60.%20When%20the%20cancel%20handler%20re-enqueues%20%60drained%5Bidx%3A%5D%60%20back%20into%20%60self._buf%60%2C%20the%20char%20counter%20stays%20at%200%20even%20though%20%60self._buf%60%20is%20no%20longer%20empty.%20This%20is%20benign%20today%20%E2%80%94%20%60self._closed%20%3D%20True%60%20prevents%20any%20new%20%60add%28%29%60%20calls%20that%20rely%20on%20the%20threshold%20check%2C%20and%20the%20final%20drain%20in%20%60close%28%29%60%20reads%20%60self._buf%60%20directly%20%E2%80%94%20but%20it%20leaves%20the%20object%20in%20an%20internally%20inconsistent%20state%20that%20could%20confuse%20future%20readers%20or%20be%20misused%20if%20the%20buffer%20were%20ever%20reused.%0A%0AConsider%20updating%20the%20counter%20alongside%20the%20re-enqueue%3A%0A%60%60%60python%0Aasync%20with%20self._lock%3A%0A%20%20%20%20self._buf%20%3D%20drained%5Bidx%3A%5D%20%2B%20self._buf%0A%20%20%20%20self._buf_chars%20%3D%20sum%28_delta_char_len%28u.delta%29%20for%20u%20in%20self._buf%29%0A%60%60%60%0A%0A&pr=333&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%3A175-183%0A**%60_closed%60%20guard%20is%20outside%20the%20lock%20%E2%80%94%20concurrent%20%60close%28%29%60%20can%20silently%20drop%20items**%0A%0A%60_closed%60%20is%20read%20before%20acquiring%20the%20lock%2C%20so%20a%20concurrent%20coroutine%20calling%20%60close%28%29%60%20can%20interleave%20as%20follows%3A%0A%0A1.%20%60add%28%29%60%20reads%20%60self._closed%60%20%E2%86%92%20%60False%60%2C%20passes%20the%20guard%0A2.%20%60close%28%29%60%20sets%20%60self._closed%20%3D%20True%60%2C%20drains%20and%20flushes%20the%20buffer%2C%20exits%0A3.%20%60add%28%29%60%20acquires%20the%20lock%20and%20appends%20to%20%60self._buf%60%20%E2%80%94%20item%20is%20never%20drained%0A%0AIn%20asyncio%20this%20requires%20two%20coroutines%20concurrently%20calling%20%60add%28%29%60%20and%20%60close%28%29%60%2C%20which%20the%20current%20streaming%20model%20doesn't%20do%20%28tokens%20are%20produced%20sequentially%20before%20%60close%28%29%60%20is%20called%29.%20Still%2C%20moving%20the%20check%20inside%20the%20lock%20makes%20the%20invariant%20obvious%20and%20prevents%20silent%20loss%20for%20any%20future%20concurrent%20caller%3A%0A%0A%60%60%60python%0Aasync%20def%20add%28self%2C%20update%3A%20StreamTaskMessageDelta%29%20-%3E%20None%3A%0A%20%20%20%20async%20with%20self._lock%3A%0A%20%20%20%20%20%20%20%20if%20self._closed%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20self._buf.append%28update%29%0A%20%20%20%20%20%20%20%20self._buf_chars%20%2B%3D%20_delta_char_len%28update.delta%29%0A%20%20%20%20%20%20%20%20if%20not%20self._first_flushed%20or%20self._buf_chars%20%3E%3D%20self.MAX_BUFFERED_CHARS%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20self._first_flushed%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20self._flush_signal.set%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%3A198-204%0A**%60_buf_chars%60%20not%20restored%20after%20re-enqueue%20on%20%60CancelledError%60**%0A%0A%60_drain_locked%28%29%60%20resets%20%60self._buf_chars%20%3D%200%60.%20When%20the%20cancel%20handler%20re-enqueues%20%60drained%5Bidx%3A%5D%60%20back%20into%20%60self._buf%60%2C%20the%20char%20counter%20stays%20at%200%20even%20though%20%60self._buf%60%20is%20no%20longer%20empty.%20This%20is%20benign%20today%20%E2%80%94%20%60self._closed%20%3D%20True%60%20prevents%20any%20new%20%60add%28%29%60%20calls%20that%20rely%20on%20the%20threshold%20check%2C%20and%20the%20final%20drain%20in%20%60close%28%29%60%20reads%20%60self._buf%60%20directly%20%E2%80%94%20but%20it%20leaves%20the%20object%20in%20an%20internally%20inconsistent%20state%20that%20could%20confuse%20future%20readers%20or%20be%20misused%20if%20the%20buffer%20were%20ever%20reused.%0A%0AConsider%20updating%20the%20counter%20alongside%20the%20re-enqueue%3A%0A%60%60%60python%0Aasync%20with%20self._lock%3A%0A%20%20%20%20self._buf%20%3D%20drained%5Bidx%3A%5D%20%2B%20self._buf%0A%20%20%20%20self._buf_chars%20%3D%20sum%28_delta_char_len%28u.delta%29%20for%20u%20in%20self._buf%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=333&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22perf%2Fstreaming-coalesce%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Fstreaming-coalesce%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%3A175-183%0A**%60_closed%60%20guard%20is%20outside%20the%20lock%20%E2%80%94%20concurrent%20%60close%28%29%60%20can%20silently%20drop%20items**%0A%0A%60_closed%60%20is%20read%20before%20acquiring%20the%20lock%2C%20so%20a%20concurrent%20coroutine%20calling%20%60close%28%29%60%20can%20interleave%20as%20follows%3A%0A%0A1.%20%60add%28%29%60%20reads%20%60self._closed%60%20%E2%86%92%20%60False%60%2C%20passes%20the%20guard%0A2.%20%60close%28%29%60%20sets%20%60self._closed%20%3D%20True%60%2C%20drains%20and%20flushes%20the%20buffer%2C%20exits%0A3.%20%60add%28%29%60%20acquires%20the%20lock%20and%20appends%20to%20%60self._buf%60%20%E2%80%94%20item%20is%20never%20drained%0A%0AIn%20asyncio%20this%20requires%20two%20coroutines%20concurrently%20calling%20%60add%28%29%60%20and%20%60close%28%29%60%2C%20which%20the%20current%20streaming%20model%20doesn't%20do%20%28tokens%20are%20produced%20sequentially%20before%20%60close%28%29%60%20is%20called%29.%20Still%2C%20moving%20the%20check%20inside%20the%20lock%20makes%20the%20invariant%20obvious%20and%20prevents%20silent%20loss%20for%20any%20future%20concurrent%20caller%3A%0A%0A%60%60%60python%0Aasync%20def%20add%28self%2C%20update%3A%20StreamTaskMessageDelta%29%20-%3E%20None%3A%0A%20%20%20%20async%20with%20self._lock%3A%0A%20%20%20%20%20%20%20%20if%20self._closed%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20self._buf.append%28update%29%0A%20%20%20%20%20%20%20%20self._buf_chars%20%2B%3D%20_delta_char_len%28update.delta%29%0A%20%20%20%20%20%20%20%20if%20not%20self._first_flushed%20or%20self._buf_chars%20%3E%3D%20self.MAX_BUFFERED_CHARS%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20self._first_flushed%20%3D%20True%0A%20%20%20%20%20%20%20%20%20%20%20%20self._flush_signal.set%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%3A198-204%0A**%60_buf_chars%60%20not%20restored%20after%20re-enqueue%20on%20%60CancelledError%60**%0A%0A%60_drain_locked%28%29%60%20resets%20%60self._buf_chars%20%3D%200%60.%20When%20the%20cancel%20handler%20re-enqueues%20%60drained%5Bidx%3A%5D%60%20back%20into%20%60self._buf%60%2C%20the%20char%20counter%20stays%20at%200%20even%20though%20%60self._buf%60%20is%20no%20longer%20empty.%20This%20is%20benign%20today%20%E2%80%94%20%60self._closed%20%3D%20True%60%20prevents%20any%20new%20%60add%28%29%60%20calls%20that%20rely%20on%20the%20threshold%20check%2C%20and%20the%20final%20drain%20in%20%60close%28%29%60%20reads%20%60self._buf%60%20directly%20%E2%80%94%20but%20it%20leaves%20the%20object%20in%20an%20internally%20inconsistent%20state%20that%20could%20confuse%20future%20readers%20or%20be%20misused%20if%20the%20buffer%20were%20ever%20reused.%0A%0AConsider%20updating%20the%20counter%20alongside%20the%20re-enqueue%3A%0A%60%60%60python%0Aasync%20with%20self._lock%3A%0A%20%20%20%20self._buf%20%3D%20drained%5Bidx%3A%5D%20%2B%20self._buf%0A%20%20%20%20self._buf_chars%20%3D%20sum%28_delta_char_len%28u.delta%29%20for%20u%20in%20self._buf%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/agentex/lib/core/services/adk/streaming.py:175-183
**`_closed` guard is outside the lock — concurrent `close()` can silently drop items**

`_closed` is read before acquiring the lock, so a concurrent coroutine calling `close()` can interleave as follows:

1. `add()` reads `self._closed` → `False`, passes the guard
2. `close()` sets `self._closed = True`, drains and flushes the buffer, exits
3. `add()` acquires the lock and appends to `self._buf` — item is never drained

In asyncio this requires two coroutines concurrently calling `add()` and `close()`, which the current streaming model doesn't do (tokens are produced sequentially before `close()` is called). Still, moving the check inside the lock makes the invariant obvious and prevents silent loss for any future concurrent caller:

```python
async def add(self, update: StreamTaskMessageDelta) -> None:
    async with self._lock:
        if self._closed:
            return
        self._buf.append(update)
        self._buf_chars += _delta_char_len(update.delta)
        if not self._first_flushed or self._buf_chars >= self.MAX_BUFFERED_CHARS:
            self._first_flushed = True
            self._flush_signal.set()
```

### Issue 2 of 2
src/agentex/lib/core/services/adk/streaming.py:198-204
**`_buf_chars` not restored after re-enqueue on `CancelledError`**

`_drain_locked()` resets `self._buf_chars = 0`. When the cancel handler re-enqueues `drained[idx:]` back into `self._buf`, the char counter stays at 0 even though `self._buf` is no longer empty. This is benign today — `self._closed = True` prevents any new `add()` calls that rely on the threshold check, and the final drain in `close()` reads `self._buf` directly — but it leaves the object in an internally inconsistent state that could confuse future readers or be misused if the buffer were ever reused.

Consider updating the counter alongside the re-enqueue:
```python
async with self._lock:
    self._buf = drained[idx:] + self._buf
    self._buf_chars = sum(_delta_char_len(u.delta) for u in self._buf)
```

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["chore(streaming): route TemporalStreamin..."](https://github.com/scaleapi/scale-agentex-python/commit/9fd308a640b917490b91cf370b0047fa1eff74c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30260707)</sub>

<!-- /greptile_comment -->