### PR TITLE
fix(tests): repair test_streaming_model so all 28 tests run and pass

### DIFF
--- a/src/agentex/lib/core/temporal/plugins/openai_agents/tests/conftest.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/tests/conftest.py
@@ -21,6 +21,7 @@ from agents.tool import (
     CodeInterpreterTool,
     ImageGenerationTool,
 )
+from agents.computer import Computer
 from agents.model_settings import Reasoning  # type: ignore[attr-defined]
 from openai.types.responses import (
     ResponseCompletedEvent,
@@ -45,6 +46,34 @@ def mock_openai_client():
 def sample_task_id():
     """Generate a sample task ID"""
     return f"task_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def _streaming_context_vars(sample_task_id):
+    """Populate the streaming ContextVars that ContextInterceptor sets from
+    request headers in real Temporal flows. TemporalStreamingModel.get_response()
+    validates that all three are set before doing any work, so any test that
+    calls get_response() must request this fixture.
+
+    Named with a leading underscore so tests can request it purely for its
+    setup/teardown side effects without ruff flagging it as an unused argument
+    (ARG002). The yielded value is the task_id set on the ContextVar, available
+    for tests that need to assert against it.
+    """
+    from agentex.lib.core.temporal.plugins.openai_agents.interceptors.context_interceptor import (
+        streaming_task_id,
+        streaming_trace_id,
+        streaming_parent_span_id,
+    )
+    task_token = streaming_task_id.set(sample_task_id)
+    trace_token = streaming_trace_id.set("test-trace-id")
+    span_token = streaming_parent_span_id.set("test-parent-span-id")
+    try:
+        yield sample_task_id
+    finally:
+        streaming_task_id.reset(task_token)
+        streaming_trace_id.reset(trace_token)
+        streaming_parent_span_id.reset(span_token)
 
 
 @pytest.fixture
@@ -115,8 +144,13 @@ def sample_file_search_tool():
 
 @pytest.fixture
 def sample_computer_tool():
-    """Sample ComputerTool for testing"""
-    computer = MagicMock()
+    """Sample ComputerTool for testing.
+
+    Production validates ``isinstance(computer, (Computer, AsyncComputer))`` for
+    Responses API serialization, so the mock must be ``spec``-bound to
+    ``Computer`` for the isinstance check to pass.
+    """
+    computer = MagicMock(spec=Computer)
     computer.environment = "desktop"
     computer.dimensions = [1920, 1080]
     return ComputerTool(computer=computer)

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
@@ -8,13 +8,19 @@ import pytest
 from agents import ModelSettings
 from openai import NOT_GIVEN
 from agents.model_settings import Reasoning, MCPToolChoice  # type: ignore[attr-defined]
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseTextDeltaEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseReasoningSummaryTextDeltaEvent,
+)
 
 
 class TestStreamingModelSettings:
     """Test that all ModelSettings parameters work with Responses API"""
 
     @pytest.mark.asyncio
-    async def test_temperature_setting(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_temperature_setting(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test that temperature parameter is properly passed to Responses API"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -45,7 +51,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['temperature'] == temp
 
     @pytest.mark.asyncio
-    async def test_top_p_setting(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_top_p_setting(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test that top_p parameter is properly passed to Responses API"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -75,7 +81,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['top_p'] == expected
 
     @pytest.mark.asyncio
-    async def test_max_tokens_setting(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_max_tokens_setting(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test that max_tokens is properly mapped to max_output_tokens"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -102,7 +108,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['max_output_tokens'] == 2000
 
     @pytest.mark.asyncio
-    async def test_reasoning_effort_settings(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_reasoning_effort_settings(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test reasoning effort levels (low/medium/high)"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -132,7 +138,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['reasoning'] == {"effort": effort}
 
     @pytest.mark.asyncio
-    async def test_reasoning_summary_settings(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_reasoning_summary_settings(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test reasoning summary settings (auto/none)"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -162,7 +168,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['reasoning'] == {"effort": "medium", "summary": summary}
 
     @pytest.mark.asyncio
-    async def test_tool_choice_variations(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_function_tool):
+    async def test_tool_choice_variations(self, streaming_model, _streaming_context_vars, sample_task_id, sample_function_tool):
         """Test various tool_choice settings"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -200,7 +206,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['tool_choice'] == expected
 
     @pytest.mark.asyncio
-    async def test_parallel_tool_calls(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_function_tool):
+    async def test_parallel_tool_calls(self, streaming_model, _streaming_context_vars, sample_task_id, sample_function_tool):
         """Test parallel tool calls setting"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -228,7 +234,7 @@ class TestStreamingModelSettings:
             assert create_call.kwargs['parallel_tool_calls'] == parallel
 
     @pytest.mark.asyncio
-    async def test_truncation_strategy(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_truncation_strategy(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test truncation parameter"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -256,7 +262,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['truncation'] == "auto"
 
     @pytest.mark.asyncio
-    async def test_response_include(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_file_search_tool):
+    async def test_response_include(self, streaming_model, _streaming_context_vars, sample_task_id, sample_file_search_tool):
         """Test response include parameter"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -288,7 +294,7 @@ class TestStreamingModelSettings:
         assert "file_search_call.results" in include_list  # Added by file search tool
 
     @pytest.mark.asyncio
-    async def test_verbosity(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_verbosity(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test verbosity settings"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -315,7 +321,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['text'] == {"verbosity": "high"}
 
     @pytest.mark.asyncio
-    async def test_metadata_and_store(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_metadata_and_store(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test metadata and store parameters"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -349,7 +355,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['store'] == store
 
     @pytest.mark.asyncio
-    async def test_extra_headers_and_body(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_extra_headers_and_body(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test extra customization parameters"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -386,7 +392,7 @@ class TestStreamingModelSettings:
         assert create_call.kwargs['extra_query'] == extra_query
 
     @pytest.mark.asyncio
-    async def test_top_logprobs(self, streaming_model, _mock_adk_streaming, sample_task_id):
+    async def test_top_logprobs(self, streaming_model, _streaming_context_vars, sample_task_id):
         """Test top_logprobs parameter"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -421,7 +427,7 @@ class TestStreamingModelTools:
     """Test that all tool types work with streaming"""
 
     @pytest.mark.asyncio
-    async def test_function_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_function_tool):
+    async def test_function_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_function_tool):
         """Test FunctionTool conversion and streaming"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -451,7 +457,7 @@ class TestStreamingModelTools:
         assert 'parameters' in tools[0]
 
     @pytest.mark.asyncio
-    async def test_web_search_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_web_search_tool):
+    async def test_web_search_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_web_search_tool):
         """Test WebSearchTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -478,7 +484,7 @@ class TestStreamingModelTools:
         assert tools[0]['type'] == 'web_search'
 
     @pytest.mark.asyncio
-    async def test_file_search_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_file_search_tool):
+    async def test_file_search_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_file_search_tool):
         """Test FileSearchTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -507,7 +513,7 @@ class TestStreamingModelTools:
         assert tools[0]['max_num_results'] == 10
 
     @pytest.mark.asyncio
-    async def test_computer_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_computer_tool):
+    async def test_computer_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_computer_tool):
         """Test ComputerTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -537,7 +543,7 @@ class TestStreamingModelTools:
         assert tools[0]['display_height'] == 1080
 
     @pytest.mark.asyncio
-    async def test_multiple_computer_tools_error(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_computer_tool):
+    async def test_multiple_computer_tools_error(self, streaming_model, _streaming_context_vars, sample_task_id, sample_computer_tool):
         """Test that multiple computer tools raise an error"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -561,7 +567,7 @@ class TestStreamingModelTools:
             )
 
     @pytest.mark.asyncio
-    async def test_hosted_mcp_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_hosted_mcp_tool):
+    async def test_hosted_mcp_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_hosted_mcp_tool):
         """Test HostedMCPTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -589,7 +595,7 @@ class TestStreamingModelTools:
         assert tools[0]['server_label'] == 'test_server'
 
     @pytest.mark.asyncio
-    async def test_image_generation_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_image_generation_tool):
+    async def test_image_generation_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_image_generation_tool):
         """Test ImageGenerationTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -616,7 +622,7 @@ class TestStreamingModelTools:
         assert tools[0]['type'] == 'image_generation'
 
     @pytest.mark.asyncio
-    async def test_code_interpreter_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_code_interpreter_tool):
+    async def test_code_interpreter_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_code_interpreter_tool):
         """Test CodeInterpreterTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -643,7 +649,7 @@ class TestStreamingModelTools:
         assert tools[0]['type'] == 'code_interpreter'
 
     @pytest.mark.asyncio
-    async def test_local_shell_tool(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_local_shell_tool):
+    async def test_local_shell_tool(self, streaming_model, _streaming_context_vars, sample_task_id, sample_local_shell_tool):
         """Test LocalShellTool conversion"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -671,7 +677,7 @@ class TestStreamingModelTools:
         # working_directory no longer in API - LocalShellTool uses executor internally
 
     @pytest.mark.asyncio
-    async def test_handoffs(self, streaming_model, _mock_adk_streaming, sample_task_id, sample_handoff):
+    async def test_handoffs(self, streaming_model, _streaming_context_vars, sample_task_id, sample_handoff):
         """Test Handoff conversion to function tools"""
         streaming_model.client.responses.create = AsyncMock()
 
@@ -700,7 +706,7 @@ class TestStreamingModelTools:
         assert tools[0]['description'] == 'Transfer to support agent'
 
     @pytest.mark.asyncio
-    async def test_mixed_tools(self, streaming_model, _mock_adk_streaming, sample_task_id,
+    async def test_mixed_tools(self, streaming_model, _streaming_context_vars, sample_task_id,
                               sample_function_tool, sample_web_search_tool, sample_handoff):
         """Test multiple tools together"""
         streaming_model.client.responses.create = AsyncMock()
@@ -736,19 +742,24 @@ class TestStreamingModelBasics:
     """Test core streaming functionality"""
 
     @pytest.mark.asyncio
-    async def test_responses_api_streaming(self, streaming_model, mock_adk_streaming, sample_task_id):
+    async def test_responses_api_streaming(self, streaming_model, mock_adk_streaming, _streaming_context_vars, sample_task_id):
         """Test basic Responses API streaming flow"""
         streaming_model.client.responses.create = AsyncMock()
 
-        # Create a mock stream with text deltas
+        # Production uses ``isinstance(event, ...)`` against the OpenAI Responses
+        # event types to dispatch. ``spec=...`` makes isinstance pass without
+        # triggering pydantic validation on partially-constructed events.
+        item_added = MagicMock(spec=ResponseOutputItemAddedEvent)
+        item_added.item = MagicMock(type="message")
+        item_added.output_index = 0
+        text_delta_1 = MagicMock(spec=ResponseTextDeltaEvent)
+        text_delta_1.delta = "Hello "
+        text_delta_2 = MagicMock(spec=ResponseTextDeltaEvent)
+        text_delta_2.delta = "world!"
+        completed = MagicMock(spec=ResponseCompletedEvent)
+        completed.response = MagicMock(output=[], usage=MagicMock())
         mock_stream = AsyncMock()
-        events = [
-            MagicMock(type="response.output_item.added", item=MagicMock(type="message")),
-            MagicMock(type="response.text.delta", delta="Hello "),
-            MagicMock(type="response.text.delta", delta="world!"),
-            MagicMock(type="response.completed", response=MagicMock(output=[]))
-        ]
-        mock_stream.__aiter__.return_value = iter(events)
+        mock_stream.__aiter__.return_value = iter([item_added, text_delta_1, text_delta_2, completed])
         streaming_model.client.responses.create.return_value = mock_stream
 
         result = await streaming_model.get_response(
@@ -773,17 +784,24 @@ class TestStreamingModelBasics:
         assert isinstance(result, ModelResponse)
 
     @pytest.mark.asyncio
-    async def test_task_id_threading(self, streaming_model, mock_adk_streaming):
-        """Test that task_id is properly threaded through to streaming context"""
+    async def test_task_id_threading(self, streaming_model, mock_adk_streaming, _streaming_context_vars):
+        """Test that task_id from the streaming ContextVar is threaded through to
+        the streaming context. ``_streaming_context_vars`` yields the task_id that
+        was set on the ContextVar, which is what production reads (the kwarg
+        ``task_id=...`` to ``get_response`` is swallowed by ``**kwargs`` and ignored).
+        """
         streaming_model.client.responses.create = AsyncMock()
 
+        item_added = MagicMock(spec=ResponseOutputItemAddedEvent)
+        item_added.item = MagicMock(type="message")
+        item_added.output_index = 0
+        completed = MagicMock(spec=ResponseCompletedEvent)
+        completed.response = MagicMock(output=[], usage=MagicMock())
         mock_stream = AsyncMock()
-        mock_stream.__aiter__.return_value = iter([
-            MagicMock(type="response.completed", response=MagicMock(output=[]))
-        ])
+        mock_stream.__aiter__.return_value = iter([item_added, completed])
         streaming_model.client.responses.create.return_value = mock_stream
 
-        task_id = "test_task_12345"
+        expected_task_id = _streaming_context_vars
 
         await streaming_model.get_response(
             system_instructions="Test",
@@ -793,27 +811,30 @@ class TestStreamingModelBasics:
             output_schema=None,
             handoffs=[],
             tracing=None,
-            task_id=task_id
         )
 
-        # Verify task_id was passed to streaming context
+        # Verify the ContextVar's task_id was threaded through to the streaming context
         mock_adk_streaming.streaming_task_message_context.assert_called()
         call_args = mock_adk_streaming.streaming_task_message_context.call_args
-        assert call_args.kwargs['task_id'] == task_id
+        assert call_args.kwargs['task_id'] == expected_task_id
 
     @pytest.mark.asyncio
-    async def test_redis_context_creation(self, streaming_model, mock_adk_streaming, sample_task_id):
+    async def test_redis_context_creation(self, streaming_model, mock_adk_streaming, _streaming_context_vars, sample_task_id):
         """Test that Redis streaming contexts are created properly"""
         streaming_model.client.responses.create = AsyncMock()
 
-        # Mock stream with reasoning
+        # Production uses ``isinstance`` against OpenAI Responses event types;
+        # ``spec=...`` makes isinstance pass without triggering pydantic validation.
+        item_added = MagicMock(spec=ResponseOutputItemAddedEvent)
+        item_added.item = MagicMock(type="reasoning")
+        item_added.output_index = 0
+        reasoning_delta = MagicMock(spec=ResponseReasoningSummaryTextDeltaEvent)
+        reasoning_delta.delta = "Thinking..."
+        reasoning_delta.summary_index = 0
+        completed = MagicMock(spec=ResponseCompletedEvent)
+        completed.response = MagicMock(output=[], usage=MagicMock())
         mock_stream = AsyncMock()
-        events = [
-            MagicMock(type="response.output_item.added", item=MagicMock(type="reasoning")),
-            MagicMock(type="response.reasoning_summary_text.delta", delta="Thinking...", summary_index=0),
-            MagicMock(type="response.completed", response=MagicMock(output=[]))
-        ]
-        mock_stream.__aiter__.return_value = iter(events)
+        mock_stream.__aiter__.return_value = iter([item_added, reasoning_delta, completed])
         streaming_model.client.responses.create.return_value = mock_stream
 
         await streaming_model.get_response(
@@ -832,10 +853,16 @@ class TestStreamingModelBasics:
 
     @pytest.mark.asyncio
     async def test_missing_task_id_error(self, streaming_model):
-        """Test that missing task_id raises appropriate error"""
+        """Test that missing streaming ContextVars raise an appropriate error.
+
+        Production reads task_id, trace_id, and parent_span_id from ContextVars
+        populated by ContextInterceptor. Without ``_streaming_context_vars``
+        requested, all three are at their defaults — empty strings — and
+        ``get_response`` raises before doing any work.
+        """
         streaming_model.client.responses.create = AsyncMock()
 
-        with pytest.raises(ValueError, match="task_id is required"):
+        with pytest.raises(ValueError, match=r"task_id.*required"):
             await streaming_model.get_response(
                 system_instructions="Test",
                 input="Hello",
@@ -844,5 +871,4 @@ class TestStreamingModelBasics:
                 output_schema=None,
                 handoffs=[],
                 tracing=None,
-                task_id=None  # Missing task_id
             )


### PR DESCRIPTION
## Summary

The entire `test_streaming_model.py` suite has been broken on `main` for some time — running it shows **4 failed + 24 errors, 0 passing**. None of those tests have actually been exercising `TemporalStreamingModel` since whichever refactor introduced the drift. This PR fixes the four root causes so the suite runs end-to-end (28/28 pass) and starts catching real regressions again.

## Bugs fixed

### Bug 1: Fixture name typo (24 errors)

`conftest.py` defines the streaming-mock fixture as `mock_adk_streaming` (no leading underscore), but every test in `TestStreamingModelSettings` and `TestStreamingModelTools` requests it as `_mock_adk_streaming`. Pytest can't resolve the fixture, so all 24 tests error before their bodies run.

The fixture is `autouse=True` and the parameter value was never used in any test body, so the param was purely vestigial — the original author appears to have intended the leading underscore as the standard pytest convention for *intentionally unused side-effect fixtures*, but applied it to the consumer instead of the fixture name.

**Fix:** Replaced the dead `_mock_adk_streaming` parameter with the new `_streaming_context_vars` fixture (see Bug 2), which these tests genuinely need.

### Bug 2: Test/code drift on validation contract (3 of 4 original failures)

`TemporalStreamingModel.get_response()` reads `task_id`, `trace_id`, and `parent_span_id` from **ContextVars** populated by `ContextInterceptor` from request headers in real Temporal flows. Tests had been passing `task_id=...` as a kwarg, which is silently swallowed by `**kwargs` and ignored — so all three ContextVars stayed at their defaults, the validation at the top of `get_response` raised, and no test in `TestStreamingModelBasics` ever reached its assertions.

**Fix:** New `_streaming_context_vars` fixture in `conftest.py` populates all three ContextVars (with proper teardown via tokens), simulating what `ContextInterceptor` does in production. Tests that need the validation to pass now request this fixture.

### Bug 3: `sample_computer_tool` fixture vs. recent ComputerTool narrowing (1 error)

Commit `4c269080` (\"Narrow ComputerTool.computer union for Responses API serialization\") added `isinstance(computer, (Computer, AsyncComputer))` validation to `_convert_tools`, but `sample_computer_tool` still constructed a bare `MagicMock()`. `test_computer_tool` started failing at conversion time.

**Fix:** Switched to `MagicMock(spec=Computer)` so `isinstance` passes. Same pattern other fixtures in the file already use (`HostedMCPTool`, `ImageGenerationTool`, etc.).

### Bug 4: Stale event mocks (1 of 4 original failures + 2 surfaced after Bug 2)

Three tests in `TestStreamingModelBasics` that assert on `streaming_task_message_context` calls built their event sequences with raw `MagicMock(type=\"...\")`. Production dispatches via `isinstance(event, ResponseOutputItemAddedEvent)` etc. — bare `MagicMock` never satisfies that, so dispatch was silently skipped and the assertions failed.

**Fix:** Switched to `MagicMock(spec=ResponseOutputItemAddedEvent)` (and the other event types) for each event in those streams. `spec=` makes `isinstance` pass without triggering pydantic validation on the event's required fields (which would also need `sequence_number`, real `Response` instances, etc.).

`test_task_id_threading` additionally asserted against a hardcoded `task_id=\"test_task_12345\"` that never actually got threaded anywhere — the kwarg was ignored just like in Bug 2. Updated the assertion to use the value yielded by `_streaming_context_vars`, which is what production reads from the ContextVar.

## Verification

| Check | Result |
|---|---|
| `pytest src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py` | **28 passed in 8.01s** (was 4 failed + 24 errors) |
| `ruff check` on changed files | 0 errors |
| `pyright` on changed files | 0 errors, 0 warnings |

## Test plan

- [x] Run the full file: 28/28 pass locally
- [x] Lint and typecheck on changed files clean
- [ ] Confirm CI on the PR shows the same 28/28 (was 0/28 on `main`)
- [ ] Confirm no other test files relied on the `_mock_adk_streaming` name (none found in the codebase, but worth a CI re-check)

## Why these are real fixes, not just \"make the failures go away\"

- The new `_streaming_context_vars` fixture isn't a workaround — it explicitly mirrors what `ContextInterceptor` does in production. Tests that exercise `get_response()` now actually hit the same validation/dispatch path real flows do.
- `MagicMock(spec=...)` is the canonical pytest pattern for satisfying `isinstance` without rebuilding production data structures from scratch. Same approach is already used elsewhere in this conftest.
- Pre-existing assertions about `streaming_task_message_context` being called are now actually verifiable — previously the dispatcher was skipping over MagicMock events without anyone noticing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes four root causes that left all 28 streaming model tests broken. The `conftest.py` changes are clean — the new `_streaming_context_vars` fixture properly mirrors production's `ContextInterceptor` with correct token-based teardown, and the `MagicMock(spec=Computer)` fix is the right approach. One residual bare mock in `test_multiple_computer_tools_error` could cause the test to assert the wrong exception if the isinstance guard fires first.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the bare MagicMock() for computer2 in test_multiple_computer_tools_error; all other findings are P2 quality suggestions.

One P1 finding remains: computer2 = MagicMock() (no spec=Computer) in test_multiple_computer_tools_error could cause the test to raise the wrong error if the isinstance guard in _convert_tools fires before the multi-tool check. All other issues are P2 concerns that don't block merge.

src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py — specifically line 551 (computer2 = MagicMock() should be MagicMock(spec=Computer)).
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/temporal/plugins/openai_agents/tests/conftest.py | Adds `_streaming_context_vars` fixture with proper ContextVar setup/teardown via tokens, and fixes `sample_computer_tool` to use `MagicMock(spec=Computer)` — both changes are correct and well-motivated. |
| src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py | Replaces `_mock_adk_streaming` with `_streaming_context_vars`, upgrades event mocks to spec-bound objects in `TestStreamingModelBasics`, and rewires `test_task_id_threading` to use the ContextVar value. One residual bare `MagicMock()` for `computer2` (line 551) may fail the isinstance guard before the intended multi-tool error is raised; self-referential `initial_content` assertion (line 779) is vacuously true; Settings/Tools tests still use bare completed-event mocks that skip production dispatch. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test
    participant Fixture as _streaming_context_vars
    participant ContextVar as ContextVars (streaming_task_id etc.)
    participant GetResponse as TemporalStreamingModel.get_response()
    participant Interceptor as ContextInterceptor (production)

    Note over Interceptor,ContextVar: Production flow
    Interceptor->>ContextVar: set(task_id, trace_id, span_id) from request headers

    Note over Test,ContextVar: Test flow (this PR)
    Test->>Fixture: request _streaming_context_vars
    Fixture->>ContextVar: set(sample_task_id, test-trace-id, test-parent-span-id)
    Fixture-->>Test: yield sample_task_id (token held)
    Test->>GetResponse: get_response(...) — no task_id kwarg needed
    GetResponse->>ContextVar: read streaming_task_id.get()
    ContextVar-->>GetResponse: sample_task_id
    GetResponse-->>Test: ModelResponse
    Test->>Fixture: teardown
    Fixture->>ContextVar: reset(token) — restore prior state
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py`, line 551 ([link](https://github.com/scaleapi/scale-agentex-python/blob/25a98ca962895bbe8c7195137ecc75e6f2a5796b/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py#L551)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Bare `MagicMock()` for second `ComputerTool` may fail isinstance check before the multi-tool guard**

   The PR's Bug 3 fix (switching `sample_computer_tool` to `MagicMock(spec=Computer)`) was needed because production's `_convert_tools` runs `isinstance(computer, (Computer, AsyncComputer))` validation. The same validation applies to every `ComputerTool` passed in, including `second_computer_tool` here. If the isinstance check fires before the "only one computer tool" guard, this test will raise a different error than `ValueError("You can only provide one computer tool")` — causing it to fail or produce a false positive.

   Apply the same pattern used in `sample_computer_tool`:
   ```python
   computer2 = MagicMock(spec=Computer)
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
   Line: 551

   Comment:
   **Bare `MagicMock()` for second `ComputerTool` may fail isinstance check before the multi-tool guard**

   The PR's Bug 3 fix (switching `sample_computer_tool` to `MagicMock(spec=Computer)`) was needed because production's `_convert_tools` runs `isinstance(computer, (Computer, AsyncComputer))` validation. The same validation applies to every `ComputerTool` passed in, including `second_computer_tool` here. If the isinstance check fires before the "only one computer tool" guard, this test will raise a different error than `ValueError("You can only provide one computer tool")` — causing it to fail or produce a false positive.

   Apply the same pattern used in `sample_computer_tool`:
   ```python
   computer2 = MagicMock(spec=Computer)
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%20551%0A%0AComment%3A%0A**Bare%20%60MagicMock%28%29%60%20for%20second%20%60ComputerTool%60%20may%20fail%20isinstance%20check%20before%20the%20multi-tool%20guard**%0A%0AThe%20PR's%20Bug%203%20fix%20%28switching%20%60sample_computer_tool%60%20to%20%60MagicMock%28spec%3DComputer%29%60%29%20was%20needed%20because%20production's%20%60_convert_tools%60%20runs%20%60isinstance%28computer%2C%20%28Computer%2C%20AsyncComputer%29%29%60%20validation.%20The%20same%20validation%20applies%20to%20every%20%60ComputerTool%60%20passed%20in%2C%20including%20%60second_computer_tool%60%20here.%20If%20the%20isinstance%20check%20fires%20before%20the%20%22only%20one%20computer%20tool%22%20guard%2C%20this%20test%20will%20raise%20a%20different%20error%20than%20%60ValueError%28%22You%20can%20only%20provide%20one%20computer%20tool%22%29%60%20%E2%80%94%20causing%20it%20to%20fail%20or%20produce%20a%20false%20positive.%0A%0AApply%20the%20same%20pattern%20used%20in%20%60sample_computer_tool%60%3A%0A%60%60%60python%0Acomputer2%20%3D%20MagicMock%28spec%3DComputer%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=334&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%20551%0A%0AComment%3A%0A**Bare%20%60MagicMock%28%29%60%20for%20second%20%60ComputerTool%60%20may%20fail%20isinstance%20check%20before%20the%20multi-tool%20guard**%0A%0AThe%20PR's%20Bug%203%20fix%20%28switching%20%60sample_computer_tool%60%20to%20%60MagicMock%28spec%3DComputer%29%60%29%20was%20needed%20because%20production's%20%60_convert_tools%60%20runs%20%60isinstance%28computer%2C%20%28Computer%2C%20AsyncComputer%29%29%60%20validation.%20The%20same%20validation%20applies%20to%20every%20%60ComputerTool%60%20passed%20in%2C%20including%20%60second_computer_tool%60%20here.%20If%20the%20isinstance%20check%20fires%20before%20the%20%22only%20one%20computer%20tool%22%20guard%2C%20this%20test%20will%20raise%20a%20different%20error%20than%20%60ValueError%28%22You%20can%20only%20provide%20one%20computer%20tool%22%29%60%20%E2%80%94%20causing%20it%20to%20fail%20or%20produce%20a%20false%20positive.%0A%0AApply%20the%20same%20pattern%20used%20in%20%60sample_computer_tool%60%3A%0A%60%60%60python%0Acomputer2%20%3D%20MagicMock%28spec%3DComputer%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=334&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22fix%2Fstreaming-model-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstreaming-model-tests%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%20551%0A%0AComment%3A%0A**Bare%20%60MagicMock%28%29%60%20for%20second%20%60ComputerTool%60%20may%20fail%20isinstance%20check%20before%20the%20multi-tool%20guard**%0A%0AThe%20PR's%20Bug%203%20fix%20%28switching%20%60sample_computer_tool%60%20to%20%60MagicMock%28spec%3DComputer%29%60%29%20was%20needed%20because%20production's%20%60_convert_tools%60%20runs%20%60isinstance%28computer%2C%20%28Computer%2C%20AsyncComputer%29%29%60%20validation.%20The%20same%20validation%20applies%20to%20every%20%60ComputerTool%60%20passed%20in%2C%20including%20%60second_computer_tool%60%20here.%20If%20the%20isinstance%20check%20fires%20before%20the%20%22only%20one%20computer%20tool%22%20guard%2C%20this%20test%20will%20raise%20a%20different%20error%20than%20%60ValueError%28%22You%20can%20only%20provide%20one%20computer%20tool%22%29%60%20%E2%80%94%20causing%20it%20to%20fail%20or%20produce%20a%20false%20positive.%0A%0AApply%20the%20same%20pattern%20used%20in%20%60sample_computer_tool%60%3A%0A%60%60%60python%0Acomputer2%20%3D%20MagicMock%28spec%3DComputer%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>


2. `src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py`, line 777-780 ([link](https://github.com/scaleapi/scale-agentex-python/blob/25a98ca962895bbe8c7195137ecc75e6f2a5796b/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py#L777-L780)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Self-referential `initial_content` assertion is trivially true**

   The `assert_called_with(...)` check reads the actual `call_args.kwargs['initial_content']` as the *expected* value, so it unconditionally passes for any non-empty call. Only the `task_id` comparison does real work here. Either assert against a concrete expected value for `initial_content`, or drop to `assert_called_once()` if the content is intentionally unspecified.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
   Line: 777-780

   Comment:
   **Self-referential `initial_content` assertion is trivially true**

   The `assert_called_with(...)` check reads the actual `call_args.kwargs['initial_content']` as the *expected* value, so it unconditionally passes for any non-empty call. Only the `task_id` comparison does real work here. Either assert against a concrete expected value for `initial_content`, or drop to `assert_called_once()` if the content is intentionally unspecified.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%20777-780%0A%0AComment%3A%0A**Self-referential%20%60initial_content%60%20assertion%20is%20trivially%20true**%0A%0AThe%20%60assert_called_with%28...%29%60%20check%20reads%20the%20actual%20%60call_args.kwargs%5B'initial_content'%5D%60%20as%20the%20*expected*%20value%2C%20so%20it%20unconditionally%20passes%20for%20any%20non-empty%20call.%20Only%20the%20%60task_id%60%20comparison%20does%20real%20work%20here.%20Either%20assert%20against%20a%20concrete%20expected%20value%20for%20%60initial_content%60%2C%20or%20drop%20to%20%60assert_called_once%28%29%60%20if%20the%20content%20is%20intentionally%20unspecified.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=334&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%20777-780%0A%0AComment%3A%0A**Self-referential%20%60initial_content%60%20assertion%20is%20trivially%20true**%0A%0AThe%20%60assert_called_with%28...%29%60%20check%20reads%20the%20actual%20%60call_args.kwargs%5B'initial_content'%5D%60%20as%20the%20*expected*%20value%2C%20so%20it%20unconditionally%20passes%20for%20any%20non-empty%20call.%20Only%20the%20%60task_id%60%20comparison%20does%20real%20work%20here.%20Either%20assert%20against%20a%20concrete%20expected%20value%20for%20%60initial_content%60%2C%20or%20drop%20to%20%60assert_called_once%28%29%60%20if%20the%20content%20is%20intentionally%20unspecified.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=334&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22fix%2Fstreaming-model-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstreaming-model-tests%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%20777-780%0A%0AComment%3A%0A**Self-referential%20%60initial_content%60%20assertion%20is%20trivially%20true**%0A%0AThe%20%60assert_called_with%28...%29%60%20check%20reads%20the%20actual%20%60call_args.kwargs%5B'initial_content'%5D%60%20as%20the%20*expected*%20value%2C%20so%20it%20unconditionally%20passes%20for%20any%20non-empty%20call.%20Only%20the%20%60task_id%60%20comparison%20does%20real%20work%20here.%20Either%20assert%20against%20a%20concrete%20expected%20value%20for%20%60initial_content%60%2C%20or%20drop%20to%20%60assert_called_once%28%29%60%20if%20the%20content%20is%20intentionally%20unspecified.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>


3. `src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py`, line 29-32 ([link](https://github.com/scaleapi/scale-agentex-python/blob/25a98ca962895bbe8c7195137ecc75e6f2a5796b/src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py#L29-L32)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Bare `MagicMock` completed events in `TestStreamingModelSettings` / `TestStreamingModelTools` skip production event dispatch**

   All ~24 mock streams in these classes still use `MagicMock(type="response.completed", ...)`. Because production dispatches via `isinstance(event, ResponseCompletedEvent)`, these bare mocks fail the isinstance check and the completed event is silently ignored. The tests pass only because they assert on `responses.create` call arguments (captured before streaming), not on the returned `ModelResponse`. Consider applying `MagicMock(spec=ResponseCompletedEvent)` (with `.response = MagicMock(output=[], usage=MagicMock())`), consistent with what `TestStreamingModelBasics` does after this PR.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py
   Line: 29-32

   Comment:
   **Bare `MagicMock` completed events in `TestStreamingModelSettings` / `TestStreamingModelTools` skip production event dispatch**

   All ~24 mock streams in these classes still use `MagicMock(type="response.completed", ...)`. Because production dispatches via `isinstance(event, ResponseCompletedEvent)`, these bare mocks fail the isinstance check and the completed event is silently ignored. The tests pass only because they assert on `responses.create` call arguments (captured before streaming), not on the returned `ModelResponse`. Consider applying `MagicMock(spec=ResponseCompletedEvent)` (with `.response = MagicMock(output=[], usage=MagicMock())`), consistent with what `TestStreamingModelBasics` does after this PR.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%2029-32%0A%0AComment%3A%0A**Bare%20%60MagicMock%60%20completed%20events%20in%20%60TestStreamingModelSettings%60%20%2F%20%60TestStreamingModelTools%60%20skip%20production%20event%20dispatch**%0A%0AAll%20~24%20mock%20streams%20in%20these%20classes%20still%20use%20%60MagicMock%28type%3D%22response.completed%22%2C%20...%29%60.%20Because%20production%20dispatches%20via%20%60isinstance%28event%2C%20ResponseCompletedEvent%29%60%2C%20these%20bare%20mocks%20fail%20the%20isinstance%20check%20and%20the%20completed%20event%20is%20silently%20ignored.%20The%20tests%20pass%20only%20because%20they%20assert%20on%20%60responses.create%60%20call%20arguments%20%28captured%20before%20streaming%29%2C%20not%20on%20the%20returned%20%60ModelResponse%60.%20Consider%20applying%20%60MagicMock%28spec%3DResponseCompletedEvent%29%60%20%28with%20%60.response%20%3D%20MagicMock%28output%3D%5B%5D%2C%20usage%3DMagicMock%28%29%29%60%29%2C%20consistent%20with%20what%20%60TestStreamingModelBasics%60%20does%20after%20this%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=334&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%2029-32%0A%0AComment%3A%0A**Bare%20%60MagicMock%60%20completed%20events%20in%20%60TestStreamingModelSettings%60%20%2F%20%60TestStreamingModelTools%60%20skip%20production%20event%20dispatch**%0A%0AAll%20~24%20mock%20streams%20in%20these%20classes%20still%20use%20%60MagicMock%28type%3D%22response.completed%22%2C%20...%29%60.%20Because%20production%20dispatches%20via%20%60isinstance%28event%2C%20ResponseCompletedEvent%29%60%2C%20these%20bare%20mocks%20fail%20the%20isinstance%20check%20and%20the%20completed%20event%20is%20silently%20ignored.%20The%20tests%20pass%20only%20because%20they%20assert%20on%20%60responses.create%60%20call%20arguments%20%28captured%20before%20streaming%29%2C%20not%20on%20the%20returned%20%60ModelResponse%60.%20Consider%20applying%20%60MagicMock%28spec%3DResponseCompletedEvent%29%60%20%28with%20%60.response%20%3D%20MagicMock%28output%3D%5B%5D%2C%20usage%3DMagicMock%28%29%29%60%29%2C%20consistent%20with%20what%20%60TestStreamingModelBasics%60%20does%20after%20this%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=334&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22fix%2Fstreaming-model-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstreaming-model-tests%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%0ALine%3A%2029-32%0A%0AComment%3A%0A**Bare%20%60MagicMock%60%20completed%20events%20in%20%60TestStreamingModelSettings%60%20%2F%20%60TestStreamingModelTools%60%20skip%20production%20event%20dispatch**%0A%0AAll%20~24%20mock%20streams%20in%20these%20classes%20still%20use%20%60MagicMock%28type%3D%22response.completed%22%2C%20...%29%60.%20Because%20production%20dispatches%20via%20%60isinstance%28event%2C%20ResponseCompletedEvent%29%60%2C%20these%20bare%20mocks%20fail%20the%20isinstance%20check%20and%20the%20completed%20event%20is%20silently%20ignored.%20The%20tests%20pass%20only%20because%20they%20assert%20on%20%60responses.create%60%20call%20arguments%20%28captured%20before%20streaming%29%2C%20not%20on%20the%20returned%20%60ModelResponse%60.%20Consider%20applying%20%60MagicMock%28spec%3DResponseCompletedEvent%29%60%20%28with%20%60.response%20%3D%20MagicMock%28output%3D%5B%5D%2C%20usage%3DMagicMock%28%29%29%60%29%2C%20consistent%20with%20what%20%60TestStreamingModelBasics%60%20does%20after%20this%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A551%0A**Bare%20%60MagicMock%28%29%60%20for%20second%20%60ComputerTool%60%20may%20fail%20isinstance%20check%20before%20the%20multi-tool%20guard**%0A%0AThe%20PR's%20Bug%203%20fix%20%28switching%20%60sample_computer_tool%60%20to%20%60MagicMock%28spec%3DComputer%29%60%29%20was%20needed%20because%20production's%20%60_convert_tools%60%20runs%20%60isinstance%28computer%2C%20%28Computer%2C%20AsyncComputer%29%29%60%20validation.%20The%20same%20validation%20applies%20to%20every%20%60ComputerTool%60%20passed%20in%2C%20including%20%60second_computer_tool%60%20here.%20If%20the%20isinstance%20check%20fires%20before%20the%20%22only%20one%20computer%20tool%22%20guard%2C%20this%20test%20will%20raise%20a%20different%20error%20than%20%60ValueError%28%22You%20can%20only%20provide%20one%20computer%20tool%22%29%60%20%E2%80%94%20causing%20it%20to%20fail%20or%20produce%20a%20false%20positive.%0A%0AApply%20the%20same%20pattern%20used%20in%20%60sample_computer_tool%60%3A%0A%60%60%60python%0Acomputer2%20%3D%20MagicMock%28spec%3DComputer%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A777-780%0A**Self-referential%20%60initial_content%60%20assertion%20is%20trivially%20true**%0A%0AThe%20%60assert_called_with%28...%29%60%20check%20reads%20the%20actual%20%60call_args.kwargs%5B'initial_content'%5D%60%20as%20the%20*expected*%20value%2C%20so%20it%20unconditionally%20passes%20for%20any%20non-empty%20call.%20Only%20the%20%60task_id%60%20comparison%20does%20real%20work%20here.%20Either%20assert%20against%20a%20concrete%20expected%20value%20for%20%60initial_content%60%2C%20or%20drop%20to%20%60assert_called_once%28%29%60%20if%20the%20content%20is%20intentionally%20unspecified.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A29-32%0A**Bare%20%60MagicMock%60%20completed%20events%20in%20%60TestStreamingModelSettings%60%20%2F%20%60TestStreamingModelTools%60%20skip%20production%20event%20dispatch**%0A%0AAll%20~24%20mock%20streams%20in%20these%20classes%20still%20use%20%60MagicMock%28type%3D%22response.completed%22%2C%20...%29%60.%20Because%20production%20dispatches%20via%20%60isinstance%28event%2C%20ResponseCompletedEvent%29%60%2C%20these%20bare%20mocks%20fail%20the%20isinstance%20check%20and%20the%20completed%20event%20is%20silently%20ignored.%20The%20tests%20pass%20only%20because%20they%20assert%20on%20%60responses.create%60%20call%20arguments%20%28captured%20before%20streaming%29%2C%20not%20on%20the%20returned%20%60ModelResponse%60.%20Consider%20applying%20%60MagicMock%28spec%3DResponseCompletedEvent%29%60%20%28with%20%60.response%20%3D%20MagicMock%28output%3D%5B%5D%2C%20usage%3DMagicMock%28%29%29%60%29%2C%20consistent%20with%20what%20%60TestStreamingModelBasics%60%20does%20after%20this%20PR.%0A%0A&pr=334&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A551%0A**Bare%20%60MagicMock%28%29%60%20for%20second%20%60ComputerTool%60%20may%20fail%20isinstance%20check%20before%20the%20multi-tool%20guard**%0A%0AThe%20PR's%20Bug%203%20fix%20%28switching%20%60sample_computer_tool%60%20to%20%60MagicMock%28spec%3DComputer%29%60%29%20was%20needed%20because%20production's%20%60_convert_tools%60%20runs%20%60isinstance%28computer%2C%20%28Computer%2C%20AsyncComputer%29%29%60%20validation.%20The%20same%20validation%20applies%20to%20every%20%60ComputerTool%60%20passed%20in%2C%20including%20%60second_computer_tool%60%20here.%20If%20the%20isinstance%20check%20fires%20before%20the%20%22only%20one%20computer%20tool%22%20guard%2C%20this%20test%20will%20raise%20a%20different%20error%20than%20%60ValueError%28%22You%20can%20only%20provide%20one%20computer%20tool%22%29%60%20%E2%80%94%20causing%20it%20to%20fail%20or%20produce%20a%20false%20positive.%0A%0AApply%20the%20same%20pattern%20used%20in%20%60sample_computer_tool%60%3A%0A%60%60%60python%0Acomputer2%20%3D%20MagicMock%28spec%3DComputer%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A777-780%0A**Self-referential%20%60initial_content%60%20assertion%20is%20trivially%20true**%0A%0AThe%20%60assert_called_with%28...%29%60%20check%20reads%20the%20actual%20%60call_args.kwargs%5B'initial_content'%5D%60%20as%20the%20*expected*%20value%2C%20so%20it%20unconditionally%20passes%20for%20any%20non-empty%20call.%20Only%20the%20%60task_id%60%20comparison%20does%20real%20work%20here.%20Either%20assert%20against%20a%20concrete%20expected%20value%20for%20%60initial_content%60%2C%20or%20drop%20to%20%60assert_called_once%28%29%60%20if%20the%20content%20is%20intentionally%20unspecified.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A29-32%0A**Bare%20%60MagicMock%60%20completed%20events%20in%20%60TestStreamingModelSettings%60%20%2F%20%60TestStreamingModelTools%60%20skip%20production%20event%20dispatch**%0A%0AAll%20~24%20mock%20streams%20in%20these%20classes%20still%20use%20%60MagicMock%28type%3D%22response.completed%22%2C%20...%29%60.%20Because%20production%20dispatches%20via%20%60isinstance%28event%2C%20ResponseCompletedEvent%29%60%2C%20these%20bare%20mocks%20fail%20the%20isinstance%20check%20and%20the%20completed%20event%20is%20silently%20ignored.%20The%20tests%20pass%20only%20because%20they%20assert%20on%20%60responses.create%60%20call%20arguments%20%28captured%20before%20streaming%29%2C%20not%20on%20the%20returned%20%60ModelResponse%60.%20Consider%20applying%20%60MagicMock%28spec%3DResponseCompletedEvent%29%60%20%28with%20%60.response%20%3D%20MagicMock%28output%3D%5B%5D%2C%20usage%3DMagicMock%28%29%29%60%29%2C%20consistent%20with%20what%20%60TestStreamingModelBasics%60%20does%20after%20this%20PR.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=334&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22fix%2Fstreaming-model-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstreaming-model-tests%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A551%0A**Bare%20%60MagicMock%28%29%60%20for%20second%20%60ComputerTool%60%20may%20fail%20isinstance%20check%20before%20the%20multi-tool%20guard**%0A%0AThe%20PR's%20Bug%203%20fix%20%28switching%20%60sample_computer_tool%60%20to%20%60MagicMock%28spec%3DComputer%29%60%29%20was%20needed%20because%20production's%20%60_convert_tools%60%20runs%20%60isinstance%28computer%2C%20%28Computer%2C%20AsyncComputer%29%29%60%20validation.%20The%20same%20validation%20applies%20to%20every%20%60ComputerTool%60%20passed%20in%2C%20including%20%60second_computer_tool%60%20here.%20If%20the%20isinstance%20check%20fires%20before%20the%20%22only%20one%20computer%20tool%22%20guard%2C%20this%20test%20will%20raise%20a%20different%20error%20than%20%60ValueError%28%22You%20can%20only%20provide%20one%20computer%20tool%22%29%60%20%E2%80%94%20causing%20it%20to%20fail%20or%20produce%20a%20false%20positive.%0A%0AApply%20the%20same%20pattern%20used%20in%20%60sample_computer_tool%60%3A%0A%60%60%60python%0Acomputer2%20%3D%20MagicMock%28spec%3DComputer%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A777-780%0A**Self-referential%20%60initial_content%60%20assertion%20is%20trivially%20true**%0A%0AThe%20%60assert_called_with%28...%29%60%20check%20reads%20the%20actual%20%60call_args.kwargs%5B'initial_content'%5D%60%20as%20the%20*expected*%20value%2C%20so%20it%20unconditionally%20passes%20for%20any%20non-empty%20call.%20Only%20the%20%60task_id%60%20comparison%20does%20real%20work%20here.%20Either%20assert%20against%20a%20concrete%20expected%20value%20for%20%60initial_content%60%2C%20or%20drop%20to%20%60assert_called_once%28%29%60%20if%20the%20content%20is%20intentionally%20unspecified.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Ftests%2Ftest_streaming_model.py%3A29-32%0A**Bare%20%60MagicMock%60%20completed%20events%20in%20%60TestStreamingModelSettings%60%20%2F%20%60TestStreamingModelTools%60%20skip%20production%20event%20dispatch**%0A%0AAll%20~24%20mock%20streams%20in%20these%20classes%20still%20use%20%60MagicMock%28type%3D%22response.completed%22%2C%20...%29%60.%20Because%20production%20dispatches%20via%20%60isinstance%28event%2C%20ResponseCompletedEvent%29%60%2C%20these%20bare%20mocks%20fail%20the%20isinstance%20check%20and%20the%20completed%20event%20is%20silently%20ignored.%20The%20tests%20pass%20only%20because%20they%20assert%20on%20%60responses.create%60%20call%20arguments%20%28captured%20before%20streaming%29%2C%20not%20on%20the%20returned%20%60ModelResponse%60.%20Consider%20applying%20%60MagicMock%28spec%3DResponseCompletedEvent%29%60%20%28with%20%60.response%20%3D%20MagicMock%28output%3D%5B%5D%2C%20usage%3DMagicMock%28%29%29%60%29%2C%20consistent%20with%20what%20%60TestStreamingModelBasics%60%20does%20after%20this%20PR.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py:551
**Bare `MagicMock()` for second `ComputerTool` may fail isinstance check before the multi-tool guard**

The PR's Bug 3 fix (switching `sample_computer_tool` to `MagicMock(spec=Computer)`) was needed because production's `_convert_tools` runs `isinstance(computer, (Computer, AsyncComputer))` validation. The same validation applies to every `ComputerTool` passed in, including `second_computer_tool` here. If the isinstance check fires before the "only one computer tool" guard, this test will raise a different error than `ValueError("You can only provide one computer tool")` — causing it to fail or produce a false positive.

Apply the same pattern used in `sample_computer_tool`:
```python
computer2 = MagicMock(spec=Computer)
```

### Issue 2 of 3
src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py:777-780
**Self-referential `initial_content` assertion is trivially true**

The `assert_called_with(...)` check reads the actual `call_args.kwargs['initial_content']` as the *expected* value, so it unconditionally passes for any non-empty call. Only the `task_id` comparison does real work here. Either assert against a concrete expected value for `initial_content`, or drop to `assert_called_once()` if the content is intentionally unspecified.

### Issue 3 of 3
src/agentex/lib/core/temporal/plugins/openai_agents/tests/test_streaming_model.py:29-32
**Bare `MagicMock` completed events in `TestStreamingModelSettings` / `TestStreamingModelTools` skip production event dispatch**

All ~24 mock streams in these classes still use `MagicMock(type="response.completed", ...)`. Because production dispatches via `isinstance(event, ResponseCompletedEvent)`, these bare mocks fail the isinstance check and the completed event is silently ignored. The tests pass only because they assert on `responses.create` call arguments (captured before streaming), not on the returned `ModelResponse`. Consider applying `MagicMock(spec=ResponseCompletedEvent)` (with `.response = MagicMock(output=[], usage=MagicMock())`), consistent with what `TestStreamingModelBasics` does after this PR.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): repair test\_streaming\_model ..."](https://github.com/scaleapi/scale-agentex-python/commit/25a98ca962895bbe8c7195137ecc75e6f2a5796b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30265988)</sub>

<!-- /greptile_comment -->