### PR TITLE
fix(adk): Always inject headers on execute activity

### DIFF
--- a/src/agentex/lib/core/temporal/plugins/openai_agents/interceptors/context_interceptor.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/interceptors/context_interceptor.py
@@ -85,33 +85,24 @@ class ContextWorkflowOutboundInterceptor(WorkflowOutboundInterceptor):
     def start_activity(self, input: StartActivityInput) -> workflow.ActivityHandle:
         """Add task_id, trace_id, and parent_span_id to headers when starting model activities."""
 
-        # Only add headers for model activity calls (OpenAI and Claude)
-        activity_name = str(input.activity) if hasattr(input, 'activity') else ""
+        try:
+            workflow_instance = workflow.instance()
+            task_id = getattr(workflow_instance, '_task_id', None)
+            trace_id = getattr(workflow_instance, '_trace_id', None)
+            parent_span_id = getattr(workflow_instance, '_parent_span_id', None)
 
-        if ("invoke_model_activity" in activity_name or
-            "invoke-model-activity" in activity_name or
-            "run_claude_agent_activity" in activity_name):
-            # Get task_id, trace_id, and parent_span_id from workflow instance instead of inbound interceptor
-            try:
-                workflow_instance = workflow.instance()
-                task_id = getattr(workflow_instance, '_task_id', None)
-                trace_id = getattr(workflow_instance, '_trace_id', None)
-                parent_span_id = getattr(workflow_instance, '_parent_span_id', None)
+            if task_id and trace_id and parent_span_id:
+                if not input.headers:
+                    input.headers = {}
 
-                if task_id and trace_id and parent_span_id:
-                    # Initialize headers if needed
-                    if not input.headers:
-                        input.headers = {}
-
-                    # Add task_id to headers
-                    input.headers[TASK_ID_HEADER] = self._payload_converter.to_payload(task_id)  # type: ignore[index]
-                    input.headers[TRACE_ID_HEADER] = self._payload_converter.to_payload(trace_id)  # type: ignore[index]
-                    input.headers[PARENT_SPAN_ID_HEADER] = self._payload_converter.to_payload(parent_span_id)  # type: ignore[index]
-                    logger.debug(f"[OutboundInterceptor] Added task_id, trace_id, and parent_span_id to activity headers: {task_id}, {trace_id}, {parent_span_id}")
-                else:
-                    logger.warning("[OutboundInterceptor] No _task_id, _trace_id, or _parent_span_id found in workflow instance")
-            except Exception as e:
-                logger.error(f"[OutboundInterceptor] Failed to get task_id, trace_id, or parent_span_id from workflow instance: {e}")
+                input.headers[TASK_ID_HEADER] = self._payload_converter.to_payload(task_id)  # type: ignore[index]
+                input.headers[TRACE_ID_HEADER] = self._payload_converter.to_payload(trace_id)  # type: ignore[index]
+                input.headers[PARENT_SPAN_ID_HEADER] = self._payload_converter.to_payload(parent_span_id)  # type: ignore[index]
+                logger.debug(f"[OutboundInterceptor] Added task_id, trace_id, and parent_span_id to activity headers: {task_id}, {trace_id}, {parent_span_id}")
+            else:
+                logger.warning("[OutboundInterceptor] No _task_id, _trace_id, or _parent_span_id found in workflow instance")
+        except Exception as e:
+            logger.error(f"[OutboundInterceptor] Failed to get task_id, trace_id, or parent_span_id from workflow instance: {e}")
 
         return self.next.start_activity(input)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the activity-name allowlist from `ContextWorkflowOutboundInterceptor.start_activity`, so `task_id`, `trace_id`, and `parent_span_id` headers are now injected into every outbound activity, not just `invoke_model_activity` / `run_claude_agent_activity`. This fixes cases where other activities in a workflow needed the same context propagation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the only finding is a minor log-level concern that does not affect correctness.

The change is a straightforward removal of an overly-narrow allowlist. The core propagation logic is unchanged and correct. The single finding is a P2 warning-log noise issue that doesn't impact behavior or data integrity.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/temporal/plugins/openai_agents/interceptors/context_interceptor.py | Removes the activity-name allowlist filter so that task_id/trace_id/parent_span_id headers are injected on every outbound activity start, not just named model activities. The logic itself is correct, but the warning log that fires when context attributes are absent will now trigger for all non-model workflows, potentially causing log noise. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Finterceptors%2Fcontext_interceptor.py%3A103%0A**Warning%20log%20noise%20for%20non-context%20workflows**%0A%0ANow%20that%20headers%20are%20injected%20for%20_all_%20activities%20%28not%20just%20model%20activities%29%2C%20workflows%20that%20legitimately%20have%20no%20%60_task_id%60%2F%60_trace_id%60%2F%60_parent_span_id%60%20will%20emit%20a%20%60WARNING%60%20for%20every%20single%20activity%20they%20start.%20This%20can%20flood%20logs%20with%20spurious%20warnings%20that%20aren't%20actionable.%20Consider%20downgrading%20this%20branch%20to%20%60DEBUG%60%20since%20%22no%20context%20found%22%20is%20now%20expected%20for%20non-model%20workflows.%0A%0A&pr=337&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Finterceptors%2Fcontext_interceptor.py%3A103%0A**Warning%20log%20noise%20for%20non-context%20workflows**%0A%0ANow%20that%20headers%20are%20injected%20for%20_all_%20activities%20%28not%20just%20model%20activities%29%2C%20workflows%20that%20legitimately%20have%20no%20%60_task_id%60%2F%60_trace_id%60%2F%60_parent_span_id%60%20will%20emit%20a%20%60WARNING%60%20for%20every%20single%20activity%20they%20start.%20This%20can%20flood%20logs%20with%20spurious%20warnings%20that%20aren't%20actionable.%20Consider%20downgrading%20this%20branch%20to%20%60DEBUG%60%20since%20%22no%20context%20found%22%20is%20now%20expected%20for%20non-model%20workflows.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=337&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22declan-scale%2Fupdate-context-interceptor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22declan-scale%2Fupdate-context-interceptor%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Finterceptors%2Fcontext_interceptor.py%3A103%0A**Warning%20log%20noise%20for%20non-context%20workflows**%0A%0ANow%20that%20headers%20are%20injected%20for%20_all_%20activities%20%28not%20just%20model%20activities%29%2C%20workflows%20that%20legitimately%20have%20no%20%60_task_id%60%2F%60_trace_id%60%2F%60_parent_span_id%60%20will%20emit%20a%20%60WARNING%60%20for%20every%20single%20activity%20they%20start.%20This%20can%20flood%20logs%20with%20spurious%20warnings%20that%20aren't%20actionable.%20Consider%20downgrading%20this%20branch%20to%20%60DEBUG%60%20since%20%22no%20context%20found%22%20is%20now%20expected%20for%20non-model%20workflows.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/agentex/lib/core/temporal/plugins/openai_agents/interceptors/context_interceptor.py:103
**Warning log noise for non-context workflows**

Now that headers are injected for _all_ activities (not just model activities), workflows that legitimately have no `_task_id`/`_trace_id`/`_parent_span_id` will emit a `WARNING` for every single activity they start. This can flood logs with spurious warnings that aren't actionable. Consider downgrading this branch to `DEBUG` since "no context found" is now expected for non-model workflows.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(adk): Always inject headers on execu..."](https://github.com/scaleapi/scale-agentex-python/commit/d52c73f9fdc6990e11719427631e159769a3dc1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30379182)</sub>

<!-- /greptile_comment -->