### PR TITLE
Fix Redis stream leak: MAXLEN on xadd + sliding TTL on stream keys

### DIFF
--- a/src/agentex/lib/core/adapters/streams/adapter_redis.py
+++ b/src/agentex/lib/core/adapters/streams/adapter_redis.py
@@ -15,18 +15,26 @@ from agentex.lib.core.adapters.streams.port import StreamRepository
 logger = make_logger(__name__)
 
 
+_DEFAULT_STREAM_MAXLEN = 10000
+
+
 class RedisStreamRepository(StreamRepository):
     """
     A simplified Redis implementation of the EventStreamRepository interface.
     Optimized for text/JSON streaming with SSE.
     """
 
-    def __init__(self, redis_url: str | None = None):
+    def __init__(self, redis_url: str | None = None, stream_maxlen: int | None = None):
         # Get Redis URL from environment if not provided
         self.redis_url = redis_url or os.environ.get(
             "REDIS_URL", "redis://localhost:6379"
         )
         self.redis = redis.from_url(self.redis_url)
+        self.stream_maxlen = (
+            stream_maxlen
+            if stream_maxlen is not None
+            else int(os.environ.get("REDIS_STREAM_MAXLEN", _DEFAULT_STREAM_MAXLEN))
+        )
 
     @override
     async def send_event(self, topic: str, event: dict[str, Any]) -> str:
@@ -47,10 +55,11 @@ class RedisStreamRepository(StreamRepository):
             # # Uncomment to debug
             # logger.info(f"Sending event to Redis stream {topic}: {event_json}")
 
-            # Add to Redis stream with a reasonable max length
             message_id = await self.redis.xadd(
                 name=topic,
                 fields={"data": event_json},
+                maxlen=self.stream_maxlen,
+                approximate=True,
             )
 
             return message_id

--- a/src/agentex/lib/core/adapters/streams/adapter_redis.py
+++ b/src/agentex/lib/core/adapters/streams/adapter_redis.py
@@ -16,6 +16,7 @@ logger = make_logger(__name__)
 
 
 _DEFAULT_STREAM_MAXLEN = 10000
+_DEFAULT_STREAM_TTL_SECONDS = 3600
 
 
 class RedisStreamRepository(StreamRepository):
@@ -24,7 +25,12 @@ class RedisStreamRepository(StreamRepository):
     Optimized for text/JSON streaming with SSE.
     """
 
-    def __init__(self, redis_url: str | None = None, stream_maxlen: int | None = None):
+    def __init__(
+        self,
+        redis_url: str | None = None,
+        stream_maxlen: int | None = None,
+        stream_ttl_seconds: int | None = None,
+    ):
         # Get Redis URL from environment if not provided
         self.redis_url = redis_url or os.environ.get(
             "REDIS_URL", "redis://localhost:6379"
@@ -34,6 +40,14 @@ class RedisStreamRepository(StreamRepository):
             stream_maxlen
             if stream_maxlen is not None
             else int(os.environ.get("REDIS_STREAM_MAXLEN", _DEFAULT_STREAM_MAXLEN))
+        )
+        # 0 disables sliding TTL.
+        self.stream_ttl_seconds = (
+            stream_ttl_seconds
+            if stream_ttl_seconds is not None
+            else int(
+                os.environ.get("REDIS_STREAM_TTL_SECONDS", _DEFAULT_STREAM_TTL_SECONDS)
+            )
         )
 
     @override
@@ -55,12 +69,40 @@ class RedisStreamRepository(StreamRepository):
             # # Uncomment to debug
             # logger.info(f"Sending event to Redis stream {topic}: {event_json}")
 
-            message_id = await self.redis.xadd(
-                name=topic,
-                fields={"data": event_json},
-                maxlen=self.stream_maxlen,
-                approximate=True,
-            )
+            # Pipeline XADD + EXPIRE in one round-trip so the stream key gets
+            # a sliding TTL — orphaned streams (no writes for the TTL window)
+            # self-delete. Mirrors the server-side adapter (scaleapi/scale-agentex#215).
+            if self.stream_ttl_seconds > 0:
+                async with self.redis.pipeline(transaction=False) as pipe:
+                    pipe.xadd(
+                        name=topic,
+                        fields={"data": event_json},
+                        maxlen=self.stream_maxlen,
+                        approximate=True,
+                    )
+                    pipe.expire(name=topic, time=self.stream_ttl_seconds)
+                    # raise_on_error=False so an EXPIRE failure does not surface
+                    # to the caller after XADD already succeeded — that would
+                    # risk callers retrying and duplicating messages. A failed
+                    # TTL refresh is recoverable: MAXLEN still caps RAM and the
+                    # next write resets the clock.
+                    results = await pipe.execute(raise_on_error=False)
+                    # results[0] = xadd message ID (or Exception)
+                    # results[1] = expire bool (or Exception)
+                    message_id = results[0]
+                    if isinstance(message_id, Exception):
+                        raise message_id
+                    if isinstance(results[1], Exception):
+                        logger.warning(
+                            f"Failed to refresh TTL on stream {topic}: {results[1]}"
+                        )
+            else:
+                message_id = await self.redis.xadd(
+                    name=topic,
+                    fields={"data": event_json},
+                    maxlen=self.stream_maxlen,
+                    approximate=True,
+                )
 
             return message_id
         except Exception as e:


### PR DESCRIPTION
## Summary

The `RedisStreamRepository` in this SDK has been leaking memory in production: every `task:{id}` stream grows unbounded for the lifetime of the task and is never deleted. On a long-lived cluster (BP) this manifested as 12k+ orphaned task streams consuming most of a 6GB Redis cache, requiring manual `redis-cli DEL` flushes.

Two complementary fixes, one commit each. Both mirror patterns the agentex server-side adapter (`scaleapi/scale-agentex` `agentex/src/adapters/streams/adapter_redis.py`) already uses.

### Commit 1 — `perf(streaming): add MAXLEN to Redis xadd`

`RedisStreamRepository.send_event` was calling `xadd` with no `MAXLEN`, despite a comment claiming "Add to Redis stream with a reasonable max length". The cap was intended but never wired up.

Matches the server adapter's pattern from [scale-agentex PR #111](https://github.com/scaleapi/scale-agentex/pull/111) (Jan 2). Default 10000 entries, overridable via `REDIS_STREAM_MAXLEN` env var.

### Commit 2 — `feat(streaming): add sliding TTL to Redis stream keys`

Mirrors [scale-agentex PR #215](https://github.com/scaleapi/scale-agentex/pull/215) (Stas, just merged) on the SDK side. Pipelines `XADD` with `EXPIRE` in one round-trip. Each delta write refreshes the TTL on the stream key, so:

- An actively-streaming agent (or actively-reading SSE consumer keeping the key warm via server-side reads) keeps the key alive.
- Once the agent stops writing, the key ages out and Redis auto-deletes it after `REDIS_STREAM_TTL_SECONDS`.
- An orphaned stream (no writes, no consumer) self-deletes within the TTL window — no explicit cleanup_stream call needed.

Default TTL: 3600 seconds (1h), matching the server. Configurable via `REDIS_STREAM_TTL_SECONDS` env var. Setting it to 0 short-circuits to plain `XADD` (no TTL refresh).

Implementation notes:
- `transaction=False` on the pipeline: connection-level batching, no MULTI/EXEC overhead for a hot path.
- `raise_on_error=False`: if `EXPIRE` fails after `XADD` succeeded, log and move on. We must not propagate the failure to the caller — the message has been published; a retry would duplicate it. The next successful `XADD` will reset the TTL anyway.

## Why this approach instead of cleanup_stream?

An earlier draft of this PR added an explicit `cleanup_stream` call to all terminal task transitions in `TasksService` (`complete`, `fail`, `cancel`, `terminate`, `timeout`, `delete`). Stas pointed out two issues with that approach which the EXPIRE pattern sidesteps:

1. **Race with `task_updated` events.** When the server processes a terminal task transition (`POST /tasks/{id}/complete`), it publishes a `task_updated` event to the same `task:{id}` stream so connected SSE consumers see the state change. An SDK-side `cleanup_stream` immediately after the API call returns would race that event — a frontend mid-`XREAD` could miss the COMPLETED transition.
2. **Multi-subscriber unfairness.** The existing server-side `cleanup_stream`-on-disconnect path nukes the topic for all subscribers when one disconnects. Adding more `cleanup_stream` callsites compounds that latent bug.

EXPIRE avoids both: it only fires after inactivity, so any active reader keeps the key alive long enough to consume final events, and the topic-deletion-on-disconnect bug is rendered moot once the SDK no longer relies on explicit DEL.

## Validation

End-to-end tested against BP's dev cluster on 2026-05-05 with this branch path-pinned into the agent images. Ran an eval (`-k 2`, 2 examples → 2 orchestrator workflows + 2 tardis subagent workflows = 4 task streams).

**Redis state ~3 minutes after eval finished:**

| Task | Type | XLEN | TTL |
|---|---|---|---|
| `task:58baa63e-...` | orchestrator | 105 | 3424s |
| `task:251f2dac-...` | orchestrator | 112 | 3436s |
| `task:7d87bbd3-...` | tardis subagent | 139 | 3402s |
| `task:49bb2778-...` | tardis subagent | 83 | 3388s |

All four streams have active TTLs of ~3400s (~57 min, which is `3600s - elapsed_since_last_write`). They will self-delete from Redis ~57 min from the last delta write — no explicit cleanup call needed.

**Side-by-side baseline** (same Redis cluster, same time, but pods running the unmodified `agentex-sdk==0.10.3` from PyPI):

| Task | XLEN | TTL |
|---|---|---|
| `task:e2963d73-...` | 120 | NO_TTL |
| `task:f7c9f250-...` | 171 | NO_TTL |
| `task:30526127-...` | 152 | NO_TTL |
| `task:c3dcb6ec-...` | 94 | NO_TTL |
| _(... ~80 more, all NO_TTL ...)_ | | |

The only difference between the two cohorts is the SDK version pinned in the agent images. The TTL is the difference this PR makes.

This pattern also closes the orphan case our application layer can't fix: long-lived orchestrator workflows (which never call `tasks.complete` because they're designed to stay alive across multiple user messages) used to leak their stream forever. Now their stream auto-cleans within `REDIS_STREAM_TTL_SECONDS` of the last delta, regardless of workflow lifecycle.

## Test plan

- [x] SDK lints cleanly (`uv run ruff check src/agentex/lib/core/adapters/streams/adapter_redis.py`)
- [x] Existing tests still pass (no behavior change to existing API surface; new kwargs are optional)
- [x] Live cluster validation: pipelined writes succeed; TTL set on stream keys; side-by-side proof against unmodified SDK on same cluster
- [x] Backwards compatibility: `RedisStreamRepository()` with no kwargs continues to work; setting `REDIS_STREAM_TTL_SECONDS=0` disables the TTL behavior entirely

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Wires up the previously-dead `MAXLEN` cap on `xadd` (10 000 entries, env-overridable) to prevent unbounded stream growth.
- Pipelines `XADD` + `EXPIRE` in one round-trip (`transaction=False`) to give each stream key a sliding TTL (default 3 600 s, env-overridable), so orphaned streams self-delete without explicit `cleanup_stream` calls.
- Error handling correctly re-raises XADD failures while tolerating EXPIRE failures with a warning log, preventing caller-visible duplicates on retry.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — logic is correct, error handling is deliberate and well-commented, and live cluster validation confirms the intended behavior.

No P0 or P1 issues found. The pipelined XADD + EXPIRE pattern is correct: commands are sent in-order on the same connection so EXPIRE reliably finds the key XADD just created. The raise_on_error=False / isinstance-Exception split is intentional and well-documented inline. MAXLEN wiring and env-var fallback logic are straightforward.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/adapters/streams/adapter_redis.py | Adds MAXLEN trimming to xadd and a pipelined EXPIRE for sliding TTL; error handling correctly re-raises XADD failures while tolerating EXPIRE failures with a warning log. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant send_event
    participant RedisPipeline
    participant Redis

    Caller->>send_event: send_event(topic, event)
    send_event->>send_event: json.dumps(event)
    
    alt stream_ttl_seconds > 0 (default: 3600s)
        send_event->>RedisPipeline: pipeline(transaction=False)
        send_event->>RedisPipeline: pipe.xadd(topic, data, maxlen=10000, approximate=True)
        send_event->>RedisPipeline: pipe.expire(topic, ttl_seconds)
        send_event->>RedisPipeline: pipe.execute(raise_on_error=False)
        RedisPipeline->>Redis: XADD topic MAXLEN ~ 10000 * data json
        RedisPipeline->>Redis: EXPIRE topic 3600
        Redis-->>RedisPipeline: [message_id, 1]
        RedisPipeline-->>send_event: results[0]=message_id, results[1]=1
        send_event->>send_event: check results[0] for Exception (re-raise if XADD failed)
        send_event->>send_event: check results[1] for Exception (warn if EXPIRE failed)
    else stream_ttl_seconds == 0 (TTL disabled)
        send_event->>Redis: XADD topic MAXLEN ~ 10000 * data json
        Redis-->>send_event: message_id
    end

    send_event-->>Caller: message_id
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(streaming): add sliding TTL to Redi..."](https://github.com/scaleapi/scale-agentex-python/commit/d97d6b13aa676548ec8bacb6cb9cfacf5fa73b11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30645562)</sub>

<!-- /greptile_comment -->