### PR TITLE
build(deps) bump scale-gp-beta to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ authors = [
 dependencies = [
     "httpx>=0.28.1,<0.29",
     "pydantic>=2.0.0, <3",
-  "typing-extensions>=4.14, <5",
-  "anyio>=3.5.0, <5",
-  "distro>=1.7.0, <2",
-  "sniffio",
+    "typing-extensions>=4.14, <5",
+    "anyio>=3.5.0, <5",
+    "distro>=1.7.0, <2",
+    "sniffio",
     "typer>=0.16,<0.17",
     "questionary>=2.0.1,<3",
     "rich>=13.9.2,<14",
@@ -41,7 +41,7 @@ dependencies = [
     "pytest>=8.4.0",
     "json_log_formatter>=1.1.1",
     "pytest-asyncio>=1.0.0",
-    "scale-gp-beta>=0.1.0a20",
+    "scale-gp-beta>=0.2.0",
     "ipykernel>=6.29.5",
     "openai>=2.2,<3", # Required by openai-agents; litellm now supports openai 2.x (issue #13711 resolved: https://github.com/BerriAI/litellm/issues/13711)
     "cloudpickle>=3.1.1",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,12 +12,14 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.13.5
     # via agentex-sdk
     # via httpx-aiohttp
     # via litellm
 aiosignal==1.4.0
     # via aiohttp
+annotated-doc==0.0.4
+    # via fastapi
 annotated-types==0.7.0
     # via pydantic
 anthropic==0.86.0
@@ -58,7 +60,7 @@ charset-normalizer==3.4.6
     # via requests
 claude-agent-sdk==0.1.52
     # via agentex-sdk
-click==8.3.1
+click==8.1.8
     # via litellm
     # via typer
     # via uvicorn
@@ -98,7 +100,7 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.115.14
+fastapi==0.136.1
     # via agentex-sdk
 fastuuid==0.14.0
     # via litellm
@@ -121,7 +123,7 @@ hf-xet==1.4.2
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via agentex-sdk
     # via anthropic
     # via httpx-aiohttp
@@ -146,7 +148,7 @@ idna==3.11
     # via httpx
     # via requests
     # via yarl
-importlib-metadata==8.7.1
+importlib-metadata==8.5.0
     # via litellm
     # via opentelemetry-api
 iniconfig==2.1.0
@@ -173,7 +175,7 @@ jsonpointer==3.1.1
     # via jsonpatch
 jsonref==1.1.0
     # via agentex-sdk
-jsonschema==4.26.0
+jsonschema==4.23.0
     # via agentex-sdk
     # via litellm
     # via mcp
@@ -192,7 +194,7 @@ langgraph-checkpoint==4.0.1
     # via agentex-sdk
 langsmith==0.7.22
     # via langchain-core
-litellm==1.83.0
+litellm==1.83.7
     # via agentex-sdk
 markdown-it-py==3.0.0
     # via rich
@@ -319,7 +321,7 @@ python-dateutil==2.9.0.post0
     # via jupyter-client
     # via kubernetes
     # via time-machine
-python-dotenv==1.2.2
+python-dotenv==1.0.1
     # via litellm
     # via mcp
     # via pydantic-settings
@@ -368,7 +370,7 @@ ruff==0.14.13
     # via agentex-sdk
 scale-gp==0.1.0a61
     # via agentex-sdk
-scale-gp-beta==0.1.0a51
+scale-gp-beta==0.2.0
     # via agentex-sdk
 shellingham==1.5.4
     # via typer
@@ -378,7 +380,6 @@ six==1.17.0
 sniffio==1.3.1
     # via agentex-sdk
     # via anthropic
-    # via httpx
     # via openai
     # via scale-gp
     # via scale-gp-beta
@@ -386,7 +387,8 @@ sse-starlette==3.0.3
     # via mcp
 stack-data==0.6.3
     # via ipython
-starlette==0.46.2
+starlette==1.0.0
+    # via agentex-sdk
     # via fastapi
     # via mcp
 temporalio==1.26.0
@@ -401,6 +403,7 @@ time-machine==2.19.0
 tokenizers==0.22.2
     # via litellm
 tornado==6.5.5
+    # via agentex-sdk
     # via ipykernel
     # via jupyter-client
 tqdm==4.67.3
@@ -448,10 +451,12 @@ typing-extensions==4.15.0
     # via referencing
     # via scale-gp
     # via scale-gp-beta
+    # via starlette
     # via temporalio
     # via typer
     # via typing-inspection
 typing-inspection==0.4.2
+    # via fastapi
     # via mcp
     # via pydantic
     # via pydantic-settings

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,12 +12,14 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.13.5
     # via agentex-sdk
     # via httpx-aiohttp
     # via litellm
 aiosignal==1.4.0
     # via aiohttp
+annotated-doc==0.0.4
+    # via fastapi
 annotated-types==0.7.0
     # via pydantic
 anthropic==0.86.0
@@ -55,7 +57,7 @@ charset-normalizer==3.4.6
     # via requests
 claude-agent-sdk==0.1.52
     # via agentex-sdk
-click==8.3.1
+click==8.1.8
     # via litellm
     # via typer
     # via uvicorn
@@ -86,7 +88,7 @@ envier==0.6.1
     # via ddtrace
 executing==2.2.1
     # via stack-data
-fastapi==0.115.14
+fastapi==0.136.1
     # via agentex-sdk
 fastuuid==0.14.0
     # via litellm
@@ -108,7 +110,7 @@ hf-xet==1.4.2
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via agentex-sdk
     # via anthropic
     # via httpx-aiohttp
@@ -130,7 +132,7 @@ idna==3.11
     # via httpx
     # via requests
     # via yarl
-importlib-metadata==8.7.1
+importlib-metadata==8.5.0
     # via litellm
     # via opentelemetry-api
 iniconfig==2.3.0
@@ -157,7 +159,7 @@ jsonpointer==3.1.1
     # via jsonpatch
 jsonref==1.1.0
     # via agentex-sdk
-jsonschema==4.26.0
+jsonschema==4.23.0
     # via agentex-sdk
     # via litellm
     # via mcp
@@ -176,7 +178,7 @@ langgraph-checkpoint==4.0.1
     # via agentex-sdk
 langsmith==0.7.22
     # via langchain-core
-litellm==1.83.0
+litellm==1.83.7
     # via agentex-sdk
 markdown-it-py==4.0.0
     # via rich
@@ -288,7 +290,7 @@ pytest-asyncio==1.3.0
 python-dateutil==2.9.0.post0
     # via jupyter-client
     # via kubernetes
-python-dotenv==1.2.2
+python-dotenv==1.0.1
     # via litellm
     # via mcp
     # via pydantic-settings
@@ -336,7 +338,7 @@ ruff==0.15.8
     # via agentex-sdk
 scale-gp==0.1.0a61
     # via agentex-sdk
-scale-gp-beta==0.1.0a51
+scale-gp-beta==0.2.0
     # via agentex-sdk
 shellingham==1.5.4
     # via typer
@@ -346,7 +348,6 @@ six==1.17.0
 sniffio==1.3.1
     # via agentex-sdk
     # via anthropic
-    # via httpx
     # via openai
     # via scale-gp
     # via scale-gp-beta
@@ -354,7 +355,8 @@ sse-starlette==3.0.3
     # via mcp
 stack-data==0.6.3
     # via ipython
-starlette==0.46.2
+starlette==1.0.0
+    # via agentex-sdk
     # via fastapi
     # via mcp
 temporalio==1.26.0
@@ -368,6 +370,7 @@ tiktoken==0.12.0
 tokenizers==0.22.2
     # via litellm
 tornado==6.5.5
+    # via agentex-sdk
     # via ipykernel
     # via jupyter-client
 tqdm==4.67.3
@@ -413,10 +416,12 @@ typing-extensions==4.15.0
     # via referencing
     # via scale-gp
     # via scale-gp-beta
+    # via starlette
     # via temporalio
     # via typer
     # via typing-inspection
 typing-inspection==0.4.2
+    # via fastapi
     # via mcp
     # via pydantic
     # via pydantic-settings


### PR DESCRIPTION
This version bump is necessary to make use of the new features in the sgp tracing SDK

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `scale-gp-beta` from `>=0.1.0a20` (pinned at `0.1.0a51`) to `>=0.2.0` to enable new SGP tracing SDK features. The version change is straightforward in `pyproject.toml`, but the resulting lock-file resolution cascades into several notable transitive changes.

- **Starlette 1.0.0** (up from `0.46.2`): confirmed major release with breaking changes; all HTTP endpoints and middleware backed by Starlette/FastAPI should be smoke-tested before merging.
- **Package downgrades**: `click` 8.3.1→8.1.8, `importlib-metadata` 8.7.1→8.5.0, `jsonschema` 4.26.0→4.23.0, and `python-dotenv` 1.2.2→1.0.1 — the `python-dotenv` rollback is the largest and loses 14+ months of fixes.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge without verifying the starlette 1.0.0 breaking changes do not affect the project's HTTP layer.

A P1 is present for the starlette 1.0.0 major-version jump, which has confirmed breaking changes and could silently break FastAPI routes or middleware. The additional package downgrades (especially python-dotenv) add further uncertainty. Score is 3 rather than 4 because the P1 affects a broad foundational layer (all HTTP handling) rather than an isolated code path.

requirements.lock and requirements-dev.lock — specifically the starlette, fastapi, and python-dotenv resolution lines.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Bumps scale-gp-beta minimum from >=0.1.0a20 to >=0.2.0; also fixes indentation on four dependency lines. |
| requirements.lock | Transitive resolution of scale-gp-beta 0.2.0 pulls in fastapi 0.136.1, starlette 1.0.0 (major version with breaking changes), httpx 0.28.1, and downgrades click, importlib-metadata, jsonschema, and python-dotenv. |
| requirements-dev.lock | Same transitive changes as requirements.lock plus dev-only additions; mirrors all starlette/fastapi/downgrade concerns. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pyproject.toml\nscale-gp-beta >= 0.2.0"] --> B["scale-gp-beta==0.2.0"]
    B --> C["fastapi==0.136.1\n(was 0.115.14)"]
    B --> D["annotated-doc==0.0.4\n(new)"]
    B --> E["python-dotenv==1.0.1\n(was 1.2.2 ⬇️)"]
    C --> F["starlette==1.0.0\n(was 0.46.2 ⚠️ major bump)"]
    C --> D
    B --> G["httpx==0.28.1\n(was 0.27.2 ⬆️)"]
    B --> H["click==8.1.8\n(was 8.3.1 ⬇️)"]
    B --> I["litellm==1.83.7\n(was 1.83.0 ⬆️)"]
    B --> J["jsonschema==4.23.0\n(was 4.26.0 ⬇️)"]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Arequirements.lock%3A355-359%0A**Starlette%20major%20version%20jump%20may%20introduce%20breaking%20changes**%0A%0A%60starlette%60%20is%20upgraded%20from%20%600.46.2%60%20to%20%601.0.0%60%20%E2%80%94%20a%20major%20milestone%20confirmed%20to%20contain%20breaking%20changes%20%28released%20March%202026%29.%20The%20impact%20is%20described%20as%20%22minimal%20if%20you've%20kept%20up%20with%20deprecation%20warnings%2C%22%20but%20the%20project%20was%20on%20%600.46.x%60%20which%20is%20several%20minor%20versions%20behind.%20Since%20%60starlette%60%20backs%20every%20%60fastapi%60%20route%2C%20middleware%2C%20and%20exception%20handler%20in%20the%20project%2C%20it's%20worth%20running%20the%20full%20test%20suite%20and%20smoke-testing%20all%20HTTP%20endpoints%20before%20merging.%20%60fastapi%60%20itself%20jumped%20from%20%600.115.14%60%20to%20%600.136.1%60%2C%20which%20also%20carries%20its%20own%20set%20of%20changes%20across%2020%2B%20minor%20versions.%0A%0A%23%23%23%20Issue%202%20of%202%0Arequirements.lock%3A290-295%0A**Several%20transitive%20packages%20were%20downgraded**%0A%0AThe%20resolver%20produced%20downgrades%20for%20multiple%20packages%3A%20%60click%60%208.3.1%E2%86%928.1.8%2C%20%60importlib-metadata%60%208.7.1%E2%86%928.5.0%2C%20%60jsonschema%60%204.26.0%E2%86%924.23.0%2C%20and%20%60python-dotenv%60%201.2.2%E2%86%921.0.1.%20The%20%60python-dotenv%60%20regression%20is%20the%20largest%20%E2%80%94%20it%20rolls%20back%2014%2B%20months%20of%20bug%20fixes%20%281.1.x%20and%201.2.x%20series%29.%20If%20%60scale-gp-beta%3D%3D0.2.0%60%20is%20pinning%20an%20older%20upper%20bound%20on%20any%20of%20these%20packages%2C%20consider%20adding%20explicit%20lower-bound%20constraints%20in%20%60pyproject.toml%60%20to%20prevent%20silent%20regressions%20from%20leaking%20into%20downstream%20environments.%0A%0A&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Arequirements.lock%3A355-359%0A**Starlette%20major%20version%20jump%20may%20introduce%20breaking%20changes**%0A%0A%60starlette%60%20is%20upgraded%20from%20%600.46.2%60%20to%20%601.0.0%60%20%E2%80%94%20a%20major%20milestone%20confirmed%20to%20contain%20breaking%20changes%20%28released%20March%202026%29.%20The%20impact%20is%20described%20as%20%22minimal%20if%20you've%20kept%20up%20with%20deprecation%20warnings%2C%22%20but%20the%20project%20was%20on%20%600.46.x%60%20which%20is%20several%20minor%20versions%20behind.%20Since%20%60starlette%60%20backs%20every%20%60fastapi%60%20route%2C%20middleware%2C%20and%20exception%20handler%20in%20the%20project%2C%20it's%20worth%20running%20the%20full%20test%20suite%20and%20smoke-testing%20all%20HTTP%20endpoints%20before%20merging.%20%60fastapi%60%20itself%20jumped%20from%20%600.115.14%60%20to%20%600.136.1%60%2C%20which%20also%20carries%20its%20own%20set%20of%20changes%20across%2020%2B%20minor%20versions.%0A%0A%23%23%23%20Issue%202%20of%202%0Arequirements.lock%3A290-295%0A**Several%20transitive%20packages%20were%20downgraded**%0A%0AThe%20resolver%20produced%20downgrades%20for%20multiple%20packages%3A%20%60click%60%208.3.1%E2%86%928.1.8%2C%20%60importlib-metadata%60%208.7.1%E2%86%928.5.0%2C%20%60jsonschema%60%204.26.0%E2%86%924.23.0%2C%20and%20%60python-dotenv%60%201.2.2%E2%86%921.0.1.%20The%20%60python-dotenv%60%20regression%20is%20the%20largest%20%E2%80%94%20it%20rolls%20back%2014%2B%20months%20of%20bug%20fixes%20%281.1.x%20and%201.2.x%20series%29.%20If%20%60scale-gp-beta%3D%3D0.2.0%60%20is%20pinning%20an%20older%20upper%20bound%20on%20any%20of%20these%20packages%2C%20consider%20adding%20explicit%20lower-bound%20constraints%20in%20%60pyproject.toml%60%20to%20prevent%20silent%20regressions%20from%20leaking%20into%20downstream%20environments.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22jean-lucas-update-gp-beta-sdk%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jean-lucas-update-gp-beta-sdk%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Arequirements.lock%3A355-359%0A**Starlette%20major%20version%20jump%20may%20introduce%20breaking%20changes**%0A%0A%60starlette%60%20is%20upgraded%20from%20%600.46.2%60%20to%20%601.0.0%60%20%E2%80%94%20a%20major%20milestone%20confirmed%20to%20contain%20breaking%20changes%20%28released%20March%202026%29.%20The%20impact%20is%20described%20as%20%22minimal%20if%20you've%20kept%20up%20with%20deprecation%20warnings%2C%22%20but%20the%20project%20was%20on%20%600.46.x%60%20which%20is%20several%20minor%20versions%20behind.%20Since%20%60starlette%60%20backs%20every%20%60fastapi%60%20route%2C%20middleware%2C%20and%20exception%20handler%20in%20the%20project%2C%20it's%20worth%20running%20the%20full%20test%20suite%20and%20smoke-testing%20all%20HTTP%20endpoints%20before%20merging.%20%60fastapi%60%20itself%20jumped%20from%20%600.115.14%60%20to%20%600.136.1%60%2C%20which%20also%20carries%20its%20own%20set%20of%20changes%20across%2020%2B%20minor%20versions.%0A%0A%23%23%23%20Issue%202%20of%202%0Arequirements.lock%3A290-295%0A**Several%20transitive%20packages%20were%20downgraded**%0A%0AThe%20resolver%20produced%20downgrades%20for%20multiple%20packages%3A%20%60click%60%208.3.1%E2%86%928.1.8%2C%20%60importlib-metadata%60%208.7.1%E2%86%928.5.0%2C%20%60jsonschema%60%204.26.0%E2%86%924.23.0%2C%20and%20%60python-dotenv%60%201.2.2%E2%86%921.0.1.%20The%20%60python-dotenv%60%20regression%20is%20the%20largest%20%E2%80%94%20it%20rolls%20back%2014%2B%20months%20of%20bug%20fixes%20%281.1.x%20and%201.2.x%20series%29.%20If%20%60scale-gp-beta%3D%3D0.2.0%60%20is%20pinning%20an%20older%20upper%20bound%20on%20any%20of%20these%20packages%2C%20consider%20adding%20explicit%20lower-bound%20constraints%20in%20%60pyproject.toml%60%20to%20prevent%20silent%20regressions%20from%20leaking%20into%20downstream%20environments.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
requirements.lock:355-359
**Starlette major version jump may introduce breaking changes**

`starlette` is upgraded from `0.46.2` to `1.0.0` — a major milestone confirmed to contain breaking changes (released March 2026). The impact is described as "minimal if you've kept up with deprecation warnings," but the project was on `0.46.x` which is several minor versions behind. Since `starlette` backs every `fastapi` route, middleware, and exception handler in the project, it's worth running the full test suite and smoke-testing all HTTP endpoints before merging. `fastapi` itself jumped from `0.115.14` to `0.136.1`, which also carries its own set of changes across 20+ minor versions.

### Issue 2 of 2
requirements.lock:290-295
**Several transitive packages were downgraded**

The resolver produced downgrades for multiple packages: `click` 8.3.1→8.1.8, `importlib-metadata` 8.7.1→8.5.0, `jsonschema` 4.26.0→4.23.0, and `python-dotenv` 1.2.2→1.0.1. The `python-dotenv` regression is the largest — it rolls back 14+ months of bug fixes (1.1.x and 1.2.x series). If `scale-gp-beta==0.2.0` is pinning an older upper bound on any of these packages, consider adding explicit lower-bound constraints in `pyproject.toml` to prevent silent regressions from leaking into downstream environments.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["build(deps) bump scale-gp-beta to 0.2.0"](https://github.com/scaleapi/scale-agentex-python/commit/3bb0118240fce69003565cdf57197623b41b0ce9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30863540)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->