### PR TITLE
ci: add conventional commit and PR base checks

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,68 @@
+name: Lint PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            ci
+            build
+            perf
+            revert
+          requireScope: false
+          # Allow skipping this check with a label (e.g. for automated/bot PRs)
+          ignoreLabels: |
+            skip-conventional-commit-check
+
+  validate-pr-base:
+    name: Validate PR base branch
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main'
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check base branch
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'target-main') }}
+        run: |
+          # Exempt automated PRs (Stainless codegen, release-please, dependabot, etc.)
+          case "$PR_AUTHOR" in
+            stainless-app|stainless-app[bot]|release-please[bot]|github-actions[bot]|dependabot[bot])
+              echo "PR is from automation ($PR_AUTHOR); allowing PR targeting main."
+              exit 0
+              ;;
+          esac
+
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "Found 'target-main' label; allowing PR targeting main."
+            exit 0
+          fi
+
+          echo "::error title=PR should target 'next'::PRs should target the 'next' branch by default. The 'main' branch is reserved for release-please and Stainless automation. If this PR is an intentional hotfix or automation exception, add the 'target-main' label to bypass this check, or re-target the PR base to 'next'."
+          exit 1

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           # Exempt automated PRs (Stainless codegen, release-please, dependabot, etc.)
           case "$PR_AUTHOR" in
-            stainless-app|stainless-app[bot]|release-please[bot]|github-actions[bot]|dependabot[bot])
+            stainless-app|stainless-app\[bot\]|release-please\[bot\]|github-actions\[bot\]|dependabot\[bot\])
               echo "PR is from automation ($PR_AUTHOR); allowing PR targeting main."
               exit 0
               ;;

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -18,9 +18,20 @@ jobs:
       - name: Check Conventional Commits format
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
+          # Exempt automated PRs (Stainless codegen, release-please, dependabot, etc.).
+          # These bots may not always emit Conventional-Commits-formatted titles
+          # (dependabot's default "Bump foo from 1.0 to 1.1" doesn't match) and we
+          # don't want their PRs blocked by this check. Mirrors validate-pr-base.
+          case "$PR_AUTHOR" in
+            stainless-app|stainless-app\[bot\]|release-please\[bot\]|github-actions\[bot\]|dependabot\[bot\])
+              echo "PR is from automation ($PR_AUTHOR); skipping title check."
+              exit 0
+              ;;
+          esac
+
           # Conventional Commits: <type>(<optional-scope>)(!): <subject>
-          # Allowed types match the project's release-please changelog sections.
           PATTERN='^(feat|fix|docs|style|refactor|test|chore|ci|build|perf|revert)(\([^)]+\))?!?: .+'
 
           if printf '%s' "$PR_TITLE" | grep -qE "$PATTERN"; then
@@ -28,9 +39,7 @@ jobs:
             exit 0
           fi
 
-          # The ::error workflow command must be written to stdout for GitHub Actions
-          # to pick it up as an annotation. The supplementary detail goes to stderr so
-          # it shows up in the log but not as an annotation.
+          # ::error must be on stdout for GitHub Actions to surface it as an annotation.
           echo "::error title=Invalid PR title::PR title must follow Conventional Commits format. Got: $PR_TITLE"
           {
             echo "  Got:      $PR_TITLE"
@@ -61,9 +70,13 @@ jobs:
         run: |
           MARKER='<!-- lint-pr-validate-base -->'
 
-          # Find any existing marker comment so we can update or delete it.
-          existing_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -n1)
+          # Look up an existing marker comment so we can update/delete it.
+          # --paginate handles PRs with >30 comments. If the lookup fails
+          # (transient API error, fork PR token without read scope), continue
+          # with no existing_id so we still emit the failure annotation.
+          existing_id=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" 2>/dev/null \
+            | head -n1) || existing_id=""
 
           delete_comment() {
             if [ -n "$existing_id" ]; then
@@ -78,7 +91,7 @@ jobs:
             exit 0
           fi
 
-          # Exempt automated PRs (Stainless codegen, release-please, dependabot, etc.).
+          # Exempt automated PRs (must mirror validate-pr-title's list).
           case "$PR_AUTHOR" in
             stainless-app|stainless-app\[bot\]|release-please\[bot\]|github-actions\[bot\]|dependabot\[bot\])
               delete_comment
@@ -94,7 +107,10 @@ jobs:
             exit 0
           fi
 
-          # Failure: post or update an explanatory PR comment, then fail the check.
+          # Failure path: try to post or update an explanatory comment.
+          # The write may fail on fork PRs (GITHUB_TOKEN has read-only scope
+          # upstream) or due to transient API errors. Guard each gh call so
+          # the ::error annotation and exit 1 still run regardless.
           body_file=$(mktemp)
           {
             echo "$MARKER"
@@ -109,14 +125,20 @@ jobs:
             echo "See \`CONTRIBUTING.md\` for the full branch model."
           } > "$body_file"
 
+          comment_status="ok"
           if [ -n "$existing_id" ]; then
             gh api -X PATCH "repos/$REPO/issues/comments/$existing_id" \
-              -F body=@"$body_file" >/dev/null
-            echo "Updated existing PR comment ($existing_id)."
+              -F body=@"$body_file" >/dev/null 2>&1 || comment_status="failed"
+            [ "$comment_status" = "ok" ] && echo "Updated existing PR comment ($existing_id)."
           else
-            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$body_file" >/dev/null
-            echo "Posted new PR comment."
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$body_file" >/dev/null 2>&1 || comment_status="failed"
+            [ "$comment_status" = "ok" ] && echo "Posted new PR comment."
           fi
 
-          echo "::error title=PR should target 'next'::See the PR comment for resolution steps. Re-target to 'next' or add the 'target-main' label."
+          if [ "$comment_status" = "failed" ]; then
+            echo "::warning title=Could not write PR comment::Likely a fork PR (no upstream write scope) or a transient API error. The check still fails — see the next annotation for resolution steps."
+          fi
+
+          # ::error must be on stdout to surface as an annotation.
+          echo "::error title=PR should target 'next'::Re-target to 'next' or add the 'target-main' label. See the PR comment for full details."
           exit 1

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -14,30 +14,35 @@ jobs:
   validate-pr-title:
     name: Validate PR title (Conventional Commits)
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      pull-requests: read
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-conventional-commit-check') }}
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      - name: Check Conventional Commits format
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            docs
-            style
-            refactor
-            test
-            chore
-            ci
-            build
-            perf
-            revert
-          requireScope: false
-          # Allow skipping this check with a label (e.g. for automated/bot PRs)
-          ignoreLabels: |
-            skip-conventional-commit-check
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Conventional Commits: <type>(<optional-scope>)(!): <subject>
+          # Allowed types match the project's release-please changelog sections.
+          PATTERN='^(feat|fix|docs|style|refactor|test|chore|ci|build|perf|revert)(\([^)]+\))?!?: .+'
+
+          if printf '%s' "$PR_TITLE" | grep -qE "$PATTERN"; then
+            echo "PR title is a valid Conventional Commit: $PR_TITLE"
+            exit 0
+          fi
+
+          {
+            echo "::error title=Invalid PR title::PR title must follow Conventional Commits format."
+            echo "  Got:      $PR_TITLE"
+            echo "  Expected: <type>(<optional-scope>)(!): <subject>"
+            echo "  Types:    feat, fix, docs, style, refactor, test, chore, ci, build, perf, revert"
+            echo ""
+            echo "  Examples:"
+            echo "    feat: add new endpoint"
+            echo "    fix(client): handle empty response"
+            echo "    chore!: drop python 3.11 support"
+            echo ""
+            echo "  Add the 'skip-conventional-commit-check' label to bypass this check."
+          } >&2
+          exit 1
 
   validate-pr-base:
     name: Validate PR base branch

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -28,8 +28,11 @@ jobs:
             exit 0
           fi
 
+          # The ::error workflow command must be written to stdout for GitHub Actions
+          # to pick it up as an annotation. The supplementary detail goes to stderr so
+          # it shows up in the log but not as an annotation.
+          echo "::error title=Invalid PR title::PR title must follow Conventional Commits format. Got: $PR_TITLE"
           {
-            echo "::error title=Invalid PR title::PR title must follow Conventional Commits format."
             echo "  Got:      $PR_TITLE"
             echo "  Expected: <type>(<optional-scope>)(!): <subject>"
             echo "  Types:    feat, fix, docs, style, refactor, test, chore, ci, build, perf, revert"

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -14,7 +14,6 @@ jobs:
   validate-pr-title:
     name: Validate PR title (Conventional Commits)
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-conventional-commit-check') }}
     steps:
       - name: Check Conventional Commits format
         env:
@@ -39,35 +38,82 @@ jobs:
             echo "    feat: add new endpoint"
             echo "    fix(client): handle empty response"
             echo "    chore!: drop python 3.11 support"
-            echo ""
-            echo "  Add the 'skip-conventional-commit-check' label to bypass this check."
           } >&2
           exit 1
 
   validate-pr-base:
     name: Validate PR base branch
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main'
     permissions:
-      pull-requests: read
+      pull-requests: write
     steps:
-      - name: Check base branch
+      - name: Validate base branch and manage PR comment
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'target-main') }}
         run: |
-          # Exempt automated PRs (Stainless codegen, release-please, dependabot, etc.)
+          MARKER='<!-- lint-pr-validate-base -->'
+
+          # Find any existing marker comment so we can update or delete it.
+          existing_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -n1)
+
+          delete_comment() {
+            if [ -n "$existing_id" ]; then
+              gh api -X DELETE "repos/$REPO/issues/comments/$existing_id" >/dev/null 2>&1 || true
+            fi
+          }
+
+          # PR doesn't target main — nothing to enforce.
+          if [ "$PR_BASE" != "main" ]; then
+            delete_comment
+            echo "PR base is '$PR_BASE'; check passes."
+            exit 0
+          fi
+
+          # Exempt automated PRs (Stainless codegen, release-please, dependabot, etc.).
           case "$PR_AUTHOR" in
             stainless-app|stainless-app\[bot\]|release-please\[bot\]|github-actions\[bot\]|dependabot\[bot\])
+              delete_comment
               echo "PR is from automation ($PR_AUTHOR); allowing PR targeting main."
               exit 0
               ;;
           esac
 
+          # Per-PR opt-out via label.
           if [ "$HAS_LABEL" = "true" ]; then
+            delete_comment
             echo "Found 'target-main' label; allowing PR targeting main."
             exit 0
           fi
 
-          echo "::error title=PR should target 'next'::PRs should target the 'next' branch by default. The 'main' branch is reserved for release-please and Stainless automation. If this PR is an intentional hotfix or automation exception, add the 'target-main' label to bypass this check, or re-target the PR base to 'next'."
+          # Failure: post or update an explanatory PR comment, then fail the check.
+          body_file=$(mktemp)
+          {
+            echo "$MARKER"
+            echo
+            echo "**This PR is targeting \`main\`, but PRs should target the \`next\` branch by default.**"
+            echo
+            echo "The \`main\` branch is reserved for release-please and Stainless automation. To resolve, pick one of:"
+            echo
+            echo "- **Re-target the PR to \`next\`** (recommended). On the PR page, click **Edit** next to the title and change the base branch to \`next\`."
+            echo "- **Add the \`target-main\` label** if this is an intentional exception (e.g. an urgent hotfix). The check will re-run and pass."
+            echo
+            echo "See \`CONTRIBUTING.md\` for the full branch model."
+          } > "$body_file"
+
+          if [ -n "$existing_id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing_id" \
+              -F body=@"$body_file" >/dev/null
+            echo "Updated existing PR comment ($existing_id)."
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$body_file" >/dev/null
+            echo "Posted new PR comment."
+          fi
+
+          echo "::error title=PR should target 'next'::See the PR comment for resolution steps. Re-target to 'next' or add the 'target-main' label."
           exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Contribution workflow
+
+- This repository is a Stainless-generated SDK. Open PRs against the `next` branch (not `main`).
+  Stainless watches `next` and release-please opens release PRs from `next` → `main`.
+- PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) — the
+  `Validate PR title (Conventional Commits)` CI check enforces this on every PR.
+- The `Validate PR base branch` CI check fails on PRs targeting `main` from non-automation accounts
+  and posts a comment with resolution steps. Add the `target-main` label only for genuine
+  exceptions (e.g. an urgent hotfix).
+- See `CONTRIBUTING.md` for the full workflow.
+
 ## Development Commands
 
 ### Package Management in the top level repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,39 @@ Alternatively if you don't want to install `Rye`, you can stick with the standar
 $ pip install -r requirements-dev.lock
 ```
 
+## Contribution workflow
+
+This repository is generated and released by [Stainless](https://www.stainless.com/). To keep the
+release pipeline working, contributions need to follow the branch model and commit conventions below.
+
+### Branch model
+
+- Always open PRs against the `next` branch — not `main`. Stainless watches `next` to produce SDK
+  builds and the automated version-bump PR.
+- Typical flow:
+  1. Pull the latest `next` locally and branch off it.
+  2. Make and push your changes, then open a PR targeting `next`.
+  3. Get the PR reviewed and merged into `next`.
+  4. Stainless will open (or update) a release PR bumping the version — review and merge that PR
+     to ship to `main`/PyPI. A new release PR will not be cut while a previous one is still open,
+     so unblock pending release PRs before expecting a new one.
+- Do not merge generated code directly into `next` via PR. Let the generator produce those changes.
+- The `Validate PR base branch` CI check fails on PRs targeting `main` from non-automation accounts
+  and posts a comment with resolution steps. If you genuinely need to PR directly to `main` (e.g. an
+  urgent hotfix), add the `target-main` label to bypass the check.
+
+### Conventional commits
+
+Commit messages and PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/),
+because the changelog and release notes are derived from them. The `Validate PR title (Conventional Commits)`
+CI check enforces this on every PR. Common prefixes:
+
+- `feat(api): ...` — new functionality
+- `fix(types): ...` — bug fixes
+- `docs(readme): ...` — documentation-only changes (required for manual README/docs overrides to be
+  picked up by the generator)
+- `chore(internal): ...` — internal changes that don't affect users
+
 ## Modifying/Adding code
 
 Most of the SDK is generated code. Modifications to code will be persisted between generations, but may


### PR DESCRIPTION
## Summary

Adds CI enforcement and contributor docs for two project conventions across the Stainless SDK repos:

1. **Conventional Commits** — PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) format. Enforced by a pure-shell regex check (no third-party action, so it works under restrictive Actions allowlists). No skip label — every PR must comply so the release-please changelog stays consistent.
2. **PR base branch** — PRs from human contributors should target `next` (not `main`). The `next → main` flow is what release-please and Stainless already use, so this aligns developer workflow with how releases are actually cut. PRs targeting `main` fail the check and the workflow posts a PR comment with resolution steps; the comment is auto-deleted when the check passes (re-target, label, or bot exemption).

## What's in this PR

- `.github/workflows/lint-pr.yaml`
  - `validate-pr-title` — pure-shell regex against the project's release-please type list (`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`, `revert`).
  - `validate-pr-base` — fails on PRs targeting `main`, with exemptions for automation accounts (`stainless-app`, `release-please[bot]`, `github-actions[bot]`, `dependabot[bot]`) and a per-PR `target-main` label escape hatch. Posts (or updates) an explanatory PR comment on failure and removes it once resolved.
- `CONTRIBUTING.md` — adds (or tightens) a "Contribution workflow" section covering the branch model and conventional-commits requirement, with notes on the new CI checks and the `target-main` escape hatch.
- `CLAUDE.md` — adds a short "Contribution workflow" section so Claude Code sessions follow the same convention.

## Behavior

| Scenario | `validate-pr-title` | `validate-pr-base` | PR comment |
| --- | --- | --- | --- |
| PR to `next` with valid title | pass | pass | none |
| PR to `next` with invalid title | fail (with annotated example) | pass | none |
| PR to `main` from human, no label | pass (assuming valid title) | fail | posted with re-target instructions |
| PR to `main` with `target-main` label | pass | pass | removed if previously posted |
| PR to `main` from `release-please[bot]` etc. | pass | pass | removed if previously posted |
| Re-target from `main` → `next` | pass | pass | removed automatically |

## Test plan

- [x] PR title check passes (this PR title is `ci: ...`).
- [x] PR base check passes because this PR targets `next`.
- [x] Verified end-to-end on this branch: a PR targeting `main` failed the check and posted the explanatory comment; re-targeting to `next` passed the check and removed the comment.
- [ ] After merge, confirm the next regular dev PR runs both checks and that release-please / Stainless PRs continue to land on `main` without friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new GitHub Actions CI checks: `validate-pr-title` (pure-shell Conventional Commits regex enforcement) and `validate-pr-base` (blocks PRs targeting `main` from non-automation accounts, with a self-updating PR comment and `target-main` label escape hatch). Documentation in `CONTRIBUTING.md` and `CLAUDE.md` is also updated to describe the new workflow conventions.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the understanding that Dependabot PRs may fail the title check if this is set as a required status check.

One P1 found: validate-pr-title lacks the bot exemptions present in validate-pr-base, and no dependabot.yml configures CC-format titles, meaning Dependabot dependency-update PRs will fail the title check. Score capped at 4 by the P1 ceiling.

.github/workflows/lint-pr.yaml — the validate-pr-title job needs bot exemptions mirroring those in validate-pr-base, or a dependabot.yml that configures CC-style commit prefixes.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/lint-pr.yaml | New workflow adding PR title and base-branch validation; validate-pr-title lacks bot exemptions present in validate-pr-base, which will cause Dependabot PRs to fail the title check since no dependabot.yml configures CC-format titles. |
| CONTRIBUTING.md | Adds 'Contribution workflow' section documenting the branch model and conventional commits requirement; content is accurate and consistent with the new CI checks. |
| CLAUDE.md | Adds short 'Contribution workflow' section for Claude Code sessions; accurate summary of the branch model and CI enforcement. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR Event
opened/edited/sync/label] --> B[validate-pr-title]
    A --> C[validate-pr-base]

    B --> B1{Title matches
CC regex?}
    B1 -->|Yes| B2[✅ Pass]
    B1 -->|No| B3[❌ Fail
::error annotation]

    C --> C1{base == main?}
    C1 -->|No| C2[Delete marker comment
✅ Pass]
    C1 -->|Yes| C3{Bot author?
stainless-app / release-please
github-actions / dependabot}
    C3 -->|Yes| C4[Delete marker comment
✅ Pass]
    C3 -->|No| C5{Has target-main
label?}
    C5 -->|Yes| C6[Delete marker comment
✅ Pass]
    C5 -->|No| C7[Post/update PR comment
❌ Fail]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Flint-pr.yaml%3A14-45%0A**Bot%20PRs%20will%20fail%20title%20check%20%E2%80%94%20no%20automation%20exemption**%0A%0A%60validate-pr-base%60%20explicitly%20exempts%20%60dependabot%5Bbot%5D%60%2C%20%60release-please%5Bbot%5D%60%2C%20%60github-actions%5Bbot%5D%60%2C%20and%20%60stainless-app%5Bbot%5D%60%20from%20its%20enforcement%20logic%2C%20but%20%60validate-pr-title%60%20has%20no%20equivalent%20exemption.%20There%20is%20no%20%60dependabot.yml%60%20in%20this%20repo%20that%20configures%20a%20CC-style%20commit%20prefix%2C%20so%20default%20Dependabot%20titles%20%28%22Bump%20requests%20from%202.28.0%20to%202.31.0%22%29%20will%20never%20match%20the%20CC%20regex.%20If%20this%20check%20is%20set%20as%20a%20required%20status%20check%2C%20every%20Dependabot%20dependency-update%20PR%20targeting%20%60main%60%20will%20be%20blocked.%0A%0A&pr=346&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Flint-pr.yaml%3A14-45%0A**Bot%20PRs%20will%20fail%20title%20check%20%E2%80%94%20no%20automation%20exemption**%0A%0A%60validate-pr-base%60%20explicitly%20exempts%20%60dependabot%5Bbot%5D%60%2C%20%60release-please%5Bbot%5D%60%2C%20%60github-actions%5Bbot%5D%60%2C%20and%20%60stainless-app%5Bbot%5D%60%20from%20its%20enforcement%20logic%2C%20but%20%60validate-pr-title%60%20has%20no%20equivalent%20exemption.%20There%20is%20no%20%60dependabot.yml%60%20in%20this%20repo%20that%20configures%20a%20CC-style%20commit%20prefix%2C%20so%20default%20Dependabot%20titles%20%28%22Bump%20requests%20from%202.28.0%20to%202.31.0%22%29%20will%20never%20match%20the%20CC%20regex.%20If%20this%20check%20is%20set%20as%20a%20required%20status%20check%2C%20every%20Dependabot%20dependency-update%20PR%20targeting%20%60main%60%20will%20be%20blocked.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=346&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22add-lint-pr-workflow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22add-lint-pr-workflow%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Flint-pr.yaml%3A14-45%0A**Bot%20PRs%20will%20fail%20title%20check%20%E2%80%94%20no%20automation%20exemption**%0A%0A%60validate-pr-base%60%20explicitly%20exempts%20%60dependabot%5Bbot%5D%60%2C%20%60release-please%5Bbot%5D%60%2C%20%60github-actions%5Bbot%5D%60%2C%20and%20%60stainless-app%5Bbot%5D%60%20from%20its%20enforcement%20logic%2C%20but%20%60validate-pr-title%60%20has%20no%20equivalent%20exemption.%20There%20is%20no%20%60dependabot.yml%60%20in%20this%20repo%20that%20configures%20a%20CC-style%20commit%20prefix%2C%20so%20default%20Dependabot%20titles%20%28%22Bump%20requests%20from%202.28.0%20to%202.31.0%22%29%20will%20never%20match%20the%20CC%20regex.%20If%20this%20check%20is%20set%20as%20a%20required%20status%20check%2C%20every%20Dependabot%20dependency-update%20PR%20targeting%20%60main%60%20will%20be%20blocked.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/lint-pr.yaml:14-45
**Bot PRs will fail title check — no automation exemption**

`validate-pr-base` explicitly exempts `dependabot[bot]`, `release-please[bot]`, `github-actions[bot]`, and `stainless-app[bot]` from its enforcement logic, but `validate-pr-title` has no equivalent exemption. There is no `dependabot.yml` in this repo that configures a CC-style commit prefix, so default Dependabot titles ("Bump requests from 2.28.0 to 2.31.0") will never match the CC regex. If this check is set as a required status check, every Dependabot dependency-update PR targeting `main` will be blocked.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ci): emit ::error to stdout so GitHu..."](https://github.com/scaleapi/scale-agentex-python/commit/b3d8a6a3d0e053673c9be23c84716c4b5990e99a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31188401)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->