### PR TITLE
feat: make workflow execution timeout configurable via env var

### DIFF
--- a/.github/workflows/agentex-tutorials-test.yml
+++ b/.github/workflows/agentex-tutorials-test.yml
@@ -2,7 +2,7 @@ name: Test Tutorial Agents
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, next]
   push:
     branches: [main]
   workflow_dispatch:

--- a/src/agentex/lib/core/temporal/services/temporal_task_service.py
+++ b/src/agentex/lib/core/temporal/services/temporal_task_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from datetime import timedelta
 
 from agentex.types.task import Task
 from agentex.types.agent import Agent
@@ -41,6 +42,7 @@ class TemporalTaskService:
             ),
             id=task.id,
             task_queue=self._env_vars.WORKFLOW_TASK_QUEUE,
+            execution_timeout=timedelta(seconds=self._env_vars.WORKFLOW_EXECUTION_TIMEOUT_SECONDS),
         )
 
     async def get_state(self, task_id: str) -> WorkflowState:

--- a/src/agentex/lib/environment_variables.py
+++ b/src/agentex/lib/environment_variables.py
@@ -6,6 +6,7 @@ from enum import Enum
 from pathlib import Path
 
 from dotenv import load_dotenv
+from pydantic import Field
 
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.utils.model_utils import BaseModel
@@ -32,6 +33,7 @@ class EnvVarKeys(str, Enum):
     # Workflow Configuration
     WORKFLOW_NAME = "WORKFLOW_NAME"
     WORKFLOW_TASK_QUEUE = "WORKFLOW_TASK_QUEUE"
+    WORKFLOW_EXECUTION_TIMEOUT_SECONDS = "WORKFLOW_EXECUTION_TIMEOUT_SECONDS"
     # Temporal Worker Configuration
     HEALTH_CHECK_PORT = "HEALTH_CHECK_PORT"
     # Auth Configuration
@@ -74,6 +76,11 @@ class EnvironmentVariables(BaseModel):
     # Workflow Configuration
     WORKFLOW_TASK_QUEUE: str | None = None
     WORKFLOW_NAME: str | None = None
+    # Maximum total time (in seconds) a workflow execution can run, including
+    # retries and continue-as-new. Defaults to 24h to bound runaway workflows;
+    # agents with longer-running tasks should override this. Must be > 0 — a
+    # zero or negative timedelta would cause every submitted workflow to fail.
+    WORKFLOW_EXECUTION_TIMEOUT_SECONDS: int = Field(default=86400, gt=0)
     # Temporal Worker Configuration
     HEALTH_CHECK_PORT: int = 80
     # Auth Configuration


### PR DESCRIPTION
## Summary

- Adds a new `WORKFLOW_EXECUTION_TIMEOUT_SECONDS` environment variable that controls the Temporal `execution_timeout` used when `TemporalTaskService.submit_task` starts an agent's workflow.
- Default remains **86400** (24h), so existing deployments are unchanged.
- Agents whose tasks legitimately run longer than 24h (long-running automations, multi-day human-in-the-loop flows, etc.) can now extend the cap by setting the env var on their deployment, e.g. `WORKFLOW_EXECUTION_TIMEOUT_SECONDS=1209600` for 14 days.

## Why

Previously the SDK hardcoded `execution_timeout=timedelta(seconds=86400)` as the default in `TemporalClient.start_workflow`, and `TemporalTaskService.submit_task` did not override it. Any agent intended to run longer than 24h would have its workflow forcibly timed out by Temporal even when the agent's own internal task timeout was longer.

Per Temporal's [documented guidance](https://docs.temporal.io/develop/python/workflows/timeouts), Workflow Execution Timeout has no upper bound — workflows are designed to be long-running — so increasing the cap is safe.

## Test plan

- [ ] Unit: existing tests still pass (no test directly covered `submit_task`'s execution_timeout argument before this change; behavior preserved by the 86400 default).
- [ ] Manual: deploy an agent with `WORKFLOW_EXECUTION_TIMEOUT_SECONDS` set to a longer value and confirm the Temporal `WorkflowExecutionTimeout` reflects the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Introduces `WORKFLOW_EXECUTION_TIMEOUT_SECONDS` env var (default `86400`, validated `gt=0`) so agents with long-running workflows can raise the Temporal execution timeout without code changes.
- Wires the value directly into `TemporalTaskService.submit_task` via `execution_timeout=timedelta(seconds=...)`, preserving the previous 24 h default for existing deployments.
- Extends the tutorial-agent CI workflow to also trigger on PRs targeting the `next` branch.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are minimal, backwards-compatible, and correctly validated.

All three changed files are clean: the new env var has proper gt=0 Pydantic validation (addressing the previously flagged concern), the timeout is wired correctly into Temporal's start_workflow, and the CI change is intentional. No P0 or P1 issues found.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/environment_variables.py | Adds WORKFLOW_EXECUTION_TIMEOUT_SECONDS to EnvVarKeys enum and EnvironmentVariables model with Field(default=86400, gt=0) validation; previously-flagged missing lower-bound guard is present. |
| src/agentex/lib/core/temporal/services/temporal_task_service.py | Wires the new env var into start_workflow as execution_timeout=timedelta(seconds=...) and imports timedelta from datetime; logic is straightforward and correct. |
| .github/workflows/agentex-tutorials-test.yml | Adds next to the pull_request branch filter so tutorial tests run on PRs targeting next; push trigger intentionally left as main-only. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Env as EnvironmentVariables
    participant TTS as TemporalTaskService
    participant TC as TemporalClient
    participant T as Temporal Server

    Note over Env: WORKFLOW_EXECUTION_TIMEOUT_SECONDS loaded from env (default 86400, gt=0)
    TTS->>Env: read WORKFLOW_EXECUTION_TIMEOUT_SECONDS
    TTS->>TC: "start_workflow(..., execution_timeout=timedelta(seconds=N))"
    TC->>T: "StartWorkflowExecution (WorkflowExecutionTimeout = N s)"
    T-->>TC: workflow_id
    TC-->>TTS: workflow_id
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat: make workflow execution timeout co..."](https://github.com/scaleapi/scale-agentex-python/commit/d2fbe00056d13bdc91621cbcc3d9456d446b527a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31236885)</sub>

<!-- /greptile_comment -->