### PR TITLE
feat!: remove AgentexTracingProcessor from default tracing processors

### DIFF
--- a/src/agentex/lib/core/tracing/tracing_processor_manager.py
+++ b/src/agentex/lib/core/tracing/tracing_processor_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from threading import Lock
 
-from agentex.lib.types.tracing import TracingProcessorConfig, AgentexTracingProcessorConfig
+from agentex.lib.types.tracing import TracingProcessorConfig
 from agentex.lib.core.tracing.processors.sgp_tracing_processor import (
     SGPSyncTracingProcessor,
     SGPAsyncTracingProcessor,
@@ -73,22 +73,8 @@ GLOBAL_TRACING_PROCESSOR_MANAGER = TracingProcessorManager()
 add_tracing_processor_config = GLOBAL_TRACING_PROCESSOR_MANAGER.add_processor_config
 set_tracing_processor_configs = GLOBAL_TRACING_PROCESSOR_MANAGER.set_processor_configs
 
-# Lazy initialization to avoid circular imports
-_default_initialized = False
-
-def _ensure_default_initialized():
-    """Ensure default processor is initialized (lazy to avoid circular imports)."""
-    global _default_initialized
-    if not _default_initialized:
-        add_tracing_processor_config(AgentexTracingProcessorConfig())
-        _default_initialized = True
-
 def get_sync_tracing_processors():
-    """Get sync processors, initializing defaults if needed."""
-    _ensure_default_initialized()
     return GLOBAL_TRACING_PROCESSOR_MANAGER.get_sync_processors()
 
 def get_async_tracing_processors():
-    """Get async processors, initializing defaults if needed."""
-    _ensure_default_initialized()
     return GLOBAL_TRACING_PROCESSOR_MANAGER.get_async_processors()


### PR DESCRIPTION
Part of [AGX1-233](https://linear.app/scale-epd/issue/AGX1-233/remove-agentextracingprocessor-and-its-supporting-api-surface) — first step in removing `AgentexTracingProcessor` and its backing API surface.

## Summary
- Drop the lazy default-init machinery in `tracing_processor_manager.py` that auto-registered `AgentexTracingProcessorConfig` on the first call to `get_sync_tracing_processors` / `get_async_tracing_processors`.
- The agentex tracing processor is now opt-in — callers register it explicitly via `add_tracing_processor_config(AgentexTracingProcessorConfig())`, matching the existing `SGPTracingProcessorConfig` flow.

## Behavior change (breaking)
Previously, just using the tracer caused every span to trigger `client.spans.create(...)` against the Agentex API. After this change, no processors are registered by default — spans are no-ops unless a processor is explicitly registered. Agents relying on the implicit default will need to add the explicit registration to keep emitting spans to Agentex.

## Test plan
- [x] `rye run ruff check` clean on the changed file
- [x] `rye run pyright` clean on the changed file
- [ ] Verify an agent with explicit `add_tracing_processor_config(AgentexTracingProcessorConfig())` still emits spans
- [ ] Verify an agent without explicit registration no longer emits spans by default