### PR TITLE
fix: render .env.example template in agentex init

### DIFF
--- a/src/agentex/lib/cli/commands/init.py
+++ b/src/agentex/lib/cli/commands/init.py
@@ -75,6 +75,7 @@ def create_project_structure(
     # Create root files
     root_templates = {
         ".dockerignore.j2": ".dockerignore",
+        ".env.example.j2": ".env.example",
         "manifest.yaml.j2": "manifest.yaml",
         "README.md.j2": "README.md",
         "environments.yaml.j2": "environments.yaml",


### PR DESCRIPTION
## Summary

- The `.env.example.j2` template file was added to every template directory but never wired into `init.py`, so generated projects silently lacked a `.env.example`.
- Adds `.env.example.j2` → `.env.example` to the `root_templates` dict so every template type emits the file.
- Fixes the friction where users have to put `LITELLM_API_KEY` directly into `manifest.yaml` because there's no obvious place to put it locally.

## Test plan

- [ ] Run `agentex init` for each template type (sync, sync-openai-agents, sync-langgraph, default, default-langgraph, temporal, temporal-openai-agents) and confirm `.env.example` appears in the project root with the expected `LITELLM_API_KEY=` / commented `OPENAI_BASE_URL=` placeholders
- [ ] Confirm rendered `.env.example` substitutes `{{ agent_name }}` correctly in the header comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wires the pre-existing `.env.example.j2` template into the `root_templates` dict in `create_project_structure`, so every `agentex init` run now emits a `.env.example` file in the project root. All 7 template directories already contained identical `.env.example.j2` files, and the `{{ agent_name }}` placeholder resolves correctly from the existing context dict.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, correct one-line fix with all template files already in place.

Single-line addition to a dict; template files exist in all 7 template directories, the Jinja2 variable resolves correctly, and there are no side effects or regressions.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/cli/commands/init.py | Single-line addition to root_templates dict; correct and complete — all 7 template directories have the corresponding .env.example.j2 file and the agent_name context variable is already provided. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[agentex init] --> B[User selects template type]
    B --> C[create_project_structure]
    C --> D[Render project/ files\nacp.py, workflow.py, etc.]
    C --> E[Render root_templates]
    E --> F[.dockerignore]
    E --> G[.env.example NEW]
    E --> H[manifest.yaml]
    E --> I[README.md]
    E --> J[environments.yaml]
    E --> K[Dockerfile / pyproject.toml]
    E --> L[dev.ipynb]
    G --> M[Written to project root\nwith agent_name substituted]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcli%2Fcommands%2Finit.py%3A293-299%0A**Post-init%20guidance%20doesn't%20mention%20the%20new%20%60.env.example%60**%0A%0AThe%20PR's%20stated%20goal%20is%20to%20reduce%20friction%20around%20%60LITELLM_API_KEY%60%20setup%2C%20but%20the%20%22Development%20Setup%22%20step%203%20only%20shows%20%60uv%20venv%20%26%26%20uv%20sync%20%26%26%20source%20.venv%2Fbin%2Factivate%60%20without%20prompting%20users%20to%20copy%20%60.env.example%60%20%E2%86%92%20%60.env%60%20and%20fill%20in%20the%20key.%20A%20user%20who%20doesn't%20notice%20the%20generated%20file%20would%20still%20hit%20the%20same%20friction.%20Adding%20a%20line%20like%20%60cp%20.env.example%20.env%20%20%23%20then%20add%20your%20LITELLM_API_KEY%60%20here%20would%20close%20the%20loop.%0A%0A&pr=351&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcli%2Fcommands%2Finit.py%3A293-299%0A**Post-init%20guidance%20doesn't%20mention%20the%20new%20%60.env.example%60**%0A%0AThe%20PR's%20stated%20goal%20is%20to%20reduce%20friction%20around%20%60LITELLM_API_KEY%60%20setup%2C%20but%20the%20%22Development%20Setup%22%20step%203%20only%20shows%20%60uv%20venv%20%26%26%20uv%20sync%20%26%26%20source%20.venv%2Fbin%2Factivate%60%20without%20prompting%20users%20to%20copy%20%60.env.example%60%20%E2%86%92%20%60.env%60%20and%20fill%20in%20the%20key.%20A%20user%20who%20doesn't%20notice%20the%20generated%20file%20would%20still%20hit%20the%20same%20friction.%20Adding%20a%20line%20like%20%60cp%20.env.example%20.env%20%20%23%20then%20add%20your%20LITELLM_API_KEY%60%20here%20would%20close%20the%20loop.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=351&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22dm%2Finit-render-env-example%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dm%2Finit-render-env-example%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcli%2Fcommands%2Finit.py%3A293-299%0A**Post-init%20guidance%20doesn't%20mention%20the%20new%20%60.env.example%60**%0A%0AThe%20PR's%20stated%20goal%20is%20to%20reduce%20friction%20around%20%60LITELLM_API_KEY%60%20setup%2C%20but%20the%20%22Development%20Setup%22%20step%203%20only%20shows%20%60uv%20venv%20%26%26%20uv%20sync%20%26%26%20source%20.venv%2Fbin%2Factivate%60%20without%20prompting%20users%20to%20copy%20%60.env.example%60%20%E2%86%92%20%60.env%60%20and%20fill%20in%20the%20key.%20A%20user%20who%20doesn't%20notice%20the%20generated%20file%20would%20still%20hit%20the%20same%20friction.%20Adding%20a%20line%20like%20%60cp%20.env.example%20.env%20%20%23%20then%20add%20your%20LITELLM_API_KEY%60%20here%20would%20close%20the%20loop.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/agentex/lib/cli/commands/init.py:293-299
**Post-init guidance doesn't mention the new `.env.example`**

The PR's stated goal is to reduce friction around `LITELLM_API_KEY` setup, but the "Development Setup" step 3 only shows `uv venv && uv sync && source .venv/bin/activate` without prompting users to copy `.env.example` → `.env` and fill in the key. A user who doesn't notice the generated file would still hit the same friction. Adding a line like `cp .env.example .env  # then add your LITELLM_API_KEY` here would close the loop.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: render .env.example template in age..."](https://github.com/scaleapi/scale-agentex-python/commit/d2cfc3aeebf76a598ba5c85810510d252b511f4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31368946)</sub>

<!-- /greptile_comment -->