### PR TITLE
fix: wire SGP_CLIENT_BASE_URL and silence openai-agents tracer in templates

### DIFF
--- a/src/agentex/lib/cli/templates/default-langgraph/.env.example.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/default/.env.example.j2
+++ b/src/agentex/lib/cli/templates/default/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/sync-langgraph/.env.example.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/sync-openai-agents/.env.example.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2
@@ -13,7 +13,12 @@ from agentex.types.task_message_update import TaskMessageUpdate, StreamTaskMessa
 from agentex.types.task_message_content import TaskMessageContent
 from agentex.types.text_content import TextContent
 from agentex.lib.utils.logging import make_logger
-from agents import Agent, Runner, RunConfig, function_tool
+from agents import Agent, Runner, RunConfig, function_tool, set_tracing_disabled
+
+# Disable the openai-agents SDK's native tracer so it doesn't ship traces to
+# api.openai.com using OPENAI_API_KEY (which may be a LiteLLM proxy key).
+# SGP tracing below still runs via the Agentex tracing manager.
+set_tracing_disabled(True)
 
 
 logger = make_logger(__name__)
@@ -25,12 +30,14 @@ if _litellm_key:
 
 SGP_API_KEY = os.environ.get("SGP_API_KEY", "")
 SGP_ACCOUNT_ID = os.environ.get("SGP_ACCOUNT_ID", "")
+SGP_CLIENT_BASE_URL = os.environ.get("SGP_CLIENT_BASE_URL", "")
 
 if SGP_API_KEY and SGP_ACCOUNT_ID:
     add_tracing_processor_config(
         SGPTracingProcessorConfig(
             sgp_api_key=SGP_API_KEY,
             sgp_account_id=SGP_ACCOUNT_ID,
+            sgp_base_url=SGP_CLIENT_BASE_URL,
         )
     )
 

--- a/src/agentex/lib/cli/templates/sync/.env.example.j2
+++ b/src/agentex/lib/cli/templates/sync/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/.env.example.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2
@@ -10,7 +10,13 @@ from agentex.lib.core.temporal.types.workflow import SignalName
 from agentex.lib.utils.logging import make_logger
 from agentex.types.text_content import TextContent
 from agentex.lib.environment_variables import EnvironmentVariables
-from agents import Agent, Runner
+from agents import Agent, Runner, set_tracing_disabled
+
+# Disable the openai-agents SDK's native tracer so it doesn't ship traces to
+# api.openai.com using OPENAI_API_KEY (which may be a LiteLLM proxy key).
+# SGP tracing below still runs via the Agentex tracing manager.
+set_tracing_disabled(True)
+
 from agentex.lib.core.temporal.plugins.openai_agents.hooks.hooks import TemporalStreamingHooks
 from pydantic import BaseModel
 from typing import List, Dict, Any
@@ -39,6 +45,7 @@ add_tracing_processor_config(
     SGPTracingProcessorConfig(
         sgp_api_key=os.environ.get("SGP_API_KEY", ""),
         sgp_account_id=os.environ.get("SGP_ACCOUNT_ID", ""),
+        sgp_base_url=os.environ.get("SGP_CLIENT_BASE_URL", ""),
     )
 )
 

--- a/src/agentex/lib/cli/templates/temporal/.env.example.j2
+++ b/src/agentex/lib/cli/templates/temporal/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=


### PR DESCRIPTION
## Summary

Two tracing pitfalls hit when running the openai-agents templates against a non-default SGP environment with a LiteLLM proxy key:

1. **`SGP_CLIENT_BASE_URL` was being silently dropped.** The `sync-openai-agents` and `temporal-openai-agents` templates constructed `SGPTracingProcessorConfig` without `sgp_base_url`, so the SDK fell back to its default host regardless of what the user set in `.env`. Result: 404s from the wrong SGP environment until you noticed and patched it yourself. (`sync-langgraph` and `default-langgraph` already had this wired up — no change needed there.)
2. **openai-agents SDK native tracer was 401'ing every request.** It ships traces to `api.openai.com` using `OPENAI_API_KEY`, which fails when that key is actually a LiteLLM proxy key (the recommended setup per the templates' own LiteLLM key swap). Calling `set_tracing_disabled(True)` at module load silences that exporter. SGP traces continue to flow via the Agentex tracing manager.

Also added `# SGP_CLIENT_BASE_URL=` to every `.env.example.j2` so the knob is visible when users copy `.env.example` to `.env`.

## Files changed

- `templates/*/.env.example.j2` (all 7) — add commented `SGP_CLIENT_BASE_URL`
- `templates/sync-openai-agents/project/acp.py.j2` — wire `sgp_base_url` + `set_tracing_disabled(True)`
- `templates/temporal-openai-agents/project/workflow.py.j2` — same two fixes

## Test plan

- [ ] Run `agentex init` for `sync-openai-agents` against an SGP environment that requires a non-default base URL (e.g. enterprise SGP), set `SGP_CLIENT_BASE_URL` in `.env`, and confirm spans land in the dashboard
- [ ] Confirm no `Tracing client error 401: ... Incorrect API key provided: sk-...` lines appear in logs when running with a LiteLLM proxy key as `OPENAI_API_KEY`
- [ ] Repeat for `temporal-openai-agents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two tracing pitfalls in the `sync-openai-agents` and `temporal-openai-agents` templates: it wires `SGP_CLIENT_BASE_URL` into `SGPTracingProcessorConfig` (matching the existing langgraph templates) and disables the openai-agents SDK's native tracer to prevent 401s when `OPENAI_API_KEY` is a LiteLLM proxy key. All seven `.env.example.j2` files also gain a commented-out `SGP_CLIENT_BASE_URL` line for discoverability.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — fixes real user-facing bugs with no regressions; only finding is a minor import-ordering style issue in a template file.

All changes are P2 or lower. The fixes are correct and consistent with the pre-existing langgraph template pattern. One style issue (E402 mid-import execution in workflow.py.j2) has no runtime impact but is worth cleaning up in a generated template.

src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2 — import ordering style issue
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2 | Adds set_tracing_disabled(True) and wires SGP_CLIENT_BASE_URL into SGPTracingProcessorConfig; changes are correct and consistent with langgraph templates |
| src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2 | Mirrors acp.py.j2 fixes; set_tracing_disabled(True) is placed mid-import which is unconventional but intentional; sgp_base_url wired correctly |
| src/agentex/lib/cli/templates/sync-openai-agents/.env.example.j2 | Adds commented SGP_CLIENT_BASE_URL knob for discoverability; straightforward documentation improvement |
| src/agentex/lib/cli/templates/temporal-openai-agents/.env.example.j2 | Adds commented SGP_CLIENT_BASE_URL knob; same as all other .env.example.j2 templates |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Module load] --> B[import agents SDK]
    B --> C["set_tracing_disabled(True)"]
    C --> D{SGP_API_KEY\n& SGP_ACCOUNT_ID\nset?}
    D -- Yes --> E["add_tracing_processor_config(\n  SGPTracingProcessorConfig(\n    sgp_base_url=SGP_CLIENT_BASE_URL\n  )\n)"]
    D -- No --> F[Tracing disabled / no-op]
    E --> G[SGP Tracing Active\nvia Agentex manager]
    C --> H[openai-agents native tracer\nsilenced — no calls to\napi.openai.com]
    G --> I[Spans land in\nSGP dashboard]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcli%2Ftemplates%2Ftemporal-openai-agents%2Fproject%2Fworkflow.py.j2%3A13-29%0AModule-level%20code%20between%20import%20blocks%20is%20an%20E402%20violation%20and%20is%20inconsistent%20with%20how%20the%20same%20fix%20is%20applied%20in%20%60acp.py.j2%60%20%28where%20%60set_tracing_disabled%28True%29%60%20comes%20after%20all%20imports%29.%20Moving%20all%20imports%20to%20the%20top%20and%20calling%20%60set_tracing_disabled%60%20afterward%20keeps%20the%20intent%20intact%20without%20breaking%20PEP%208%20%2F%20isort%20expectations%20in%20the%20generated%20file.%0A%0A%60%60%60suggestion%0Afrom%20agents%20import%20Agent%2C%20Runner%2C%20set_tracing_disabled%0Afrom%20agentex.lib.core.temporal.plugins.openai_agents.hooks.hooks%20import%20TemporalStreamingHooks%0Afrom%20pydantic%20import%20BaseModel%0Afrom%20typing%20import%20List%2C%20Dict%2C%20Any%0Afrom%20temporalio.contrib%20import%20openai_agents%0Afrom%20project.activities%20import%20get_weather%0Afrom%20agentex.lib.core.tracing.tracing_processor_manager%20import%20%28%0A%20%20%20%20add_tracing_processor_config%2C%0A%29%0Afrom%20agentex.lib.types.tracing%20import%20SGPTracingProcessorConfig%0Afrom%20datetime%20import%20timedelta%0A%0A%23%20Disable%20the%20openai-agents%20SDK's%20native%20tracer%20so%20it%20doesn't%20ship%20traces%20to%0A%23%20api.openai.com%20using%20OPENAI_API_KEY%20%28which%20may%20be%20a%20LiteLLM%20proxy%20key%29.%0A%23%20SGP%20tracing%20below%20still%20runs%20via%20the%20Agentex%20tracing%20manager.%0Aset_tracing_disabled%28True%29%0A%60%60%60%0A%0A&pr=352&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcli%2Ftemplates%2Ftemporal-openai-agents%2Fproject%2Fworkflow.py.j2%3A13-29%0AModule-level%20code%20between%20import%20blocks%20is%20an%20E402%20violation%20and%20is%20inconsistent%20with%20how%20the%20same%20fix%20is%20applied%20in%20%60acp.py.j2%60%20%28where%20%60set_tracing_disabled%28True%29%60%20comes%20after%20all%20imports%29.%20Moving%20all%20imports%20to%20the%20top%20and%20calling%20%60set_tracing_disabled%60%20afterward%20keeps%20the%20intent%20intact%20without%20breaking%20PEP%208%20%2F%20isort%20expectations%20in%20the%20generated%20file.%0A%0A%60%60%60suggestion%0Afrom%20agents%20import%20Agent%2C%20Runner%2C%20set_tracing_disabled%0Afrom%20agentex.lib.core.temporal.plugins.openai_agents.hooks.hooks%20import%20TemporalStreamingHooks%0Afrom%20pydantic%20import%20BaseModel%0Afrom%20typing%20import%20List%2C%20Dict%2C%20Any%0Afrom%20temporalio.contrib%20import%20openai_agents%0Afrom%20project.activities%20import%20get_weather%0Afrom%20agentex.lib.core.tracing.tracing_processor_manager%20import%20%28%0A%20%20%20%20add_tracing_processor_config%2C%0A%29%0Afrom%20agentex.lib.types.tracing%20import%20SGPTracingProcessorConfig%0Afrom%20datetime%20import%20timedelta%0A%0A%23%20Disable%20the%20openai-agents%20SDK's%20native%20tracer%20so%20it%20doesn't%20ship%20traces%20to%0A%23%20api.openai.com%20using%20OPENAI_API_KEY%20%28which%20may%20be%20a%20LiteLLM%20proxy%20key%29.%0A%23%20SGP%20tracing%20below%20still%20runs%20via%20the%20Agentex%20tracing%20manager.%0Aset_tracing_disabled%28True%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=352&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22dm%2Ftemplate-tracing-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dm%2Ftemplate-tracing-fixes%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcli%2Ftemplates%2Ftemporal-openai-agents%2Fproject%2Fworkflow.py.j2%3A13-29%0AModule-level%20code%20between%20import%20blocks%20is%20an%20E402%20violation%20and%20is%20inconsistent%20with%20how%20the%20same%20fix%20is%20applied%20in%20%60acp.py.j2%60%20%28where%20%60set_tracing_disabled%28True%29%60%20comes%20after%20all%20imports%29.%20Moving%20all%20imports%20to%20the%20top%20and%20calling%20%60set_tracing_disabled%60%20afterward%20keeps%20the%20intent%20intact%20without%20breaking%20PEP%208%20%2F%20isort%20expectations%20in%20the%20generated%20file.%0A%0A%60%60%60suggestion%0Afrom%20agents%20import%20Agent%2C%20Runner%2C%20set_tracing_disabled%0Afrom%20agentex.lib.core.temporal.plugins.openai_agents.hooks.hooks%20import%20TemporalStreamingHooks%0Afrom%20pydantic%20import%20BaseModel%0Afrom%20typing%20import%20List%2C%20Dict%2C%20Any%0Afrom%20temporalio.contrib%20import%20openai_agents%0Afrom%20project.activities%20import%20get_weather%0Afrom%20agentex.lib.core.tracing.tracing_processor_manager%20import%20%28%0A%20%20%20%20add_tracing_processor_config%2C%0A%29%0Afrom%20agentex.lib.types.tracing%20import%20SGPTracingProcessorConfig%0Afrom%20datetime%20import%20timedelta%0A%0A%23%20Disable%20the%20openai-agents%20SDK's%20native%20tracer%20so%20it%20doesn't%20ship%20traces%20to%0A%23%20api.openai.com%20using%20OPENAI_API_KEY%20%28which%20may%20be%20a%20LiteLLM%20proxy%20key%29.%0A%23%20SGP%20tracing%20below%20still%20runs%20via%20the%20Agentex%20tracing%20manager.%0Aset_tracing_disabled%28True%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2:13-29
Module-level code between import blocks is an E402 violation and is inconsistent with how the same fix is applied in `acp.py.j2` (where `set_tracing_disabled(True)` comes after all imports). Moving all imports to the top and calling `set_tracing_disabled` afterward keeps the intent intact without breaking PEP 8 / isort expectations in the generated file.

```suggestion
from agents import Agent, Runner, set_tracing_disabled
from agentex.lib.core.temporal.plugins.openai_agents.hooks.hooks import TemporalStreamingHooks
from pydantic import BaseModel
from typing import List, Dict, Any
from temporalio.contrib import openai_agents
from project.activities import get_weather
from agentex.lib.core.tracing.tracing_processor_manager import (
    add_tracing_processor_config,
)
from agentex.lib.types.tracing import SGPTracingProcessorConfig
from datetime import timedelta

# Disable the openai-agents SDK's native tracer so it doesn't ship traces to
# api.openai.com using OPENAI_API_KEY (which may be a LiteLLM proxy key).
# SGP tracing below still runs via the Agentex tracing manager.
set_tracing_disabled(True)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: wire SGP\_CLIENT\_BASE\_URL and silenc..."](https://github.com/scaleapi/scale-agentex-python/commit/db31a62edd96230121d9b912b90fdd1bb22e64b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31374028)</sub>

<!-- /greptile_comment -->