### PR TITLE
feat: add Pydantic AI sync streaming converter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "mcp[cli]>=1.4.1",
     "scale-gp>=0.1.0a59",
     "openai-agents==0.14.1",
+    "pydantic-ai-slim>=1.0,<2",
     "tzlocal>=5.3.1",
     "tzdata>=2025.2",
     "pytest>=8.4.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -112,10 +112,13 @@ frozenlist==1.8.0
     # via aiosignal
 fsspec==2026.3.0
     # via huggingface-hub
+genai-prices==0.0.59
+    # via pydantic-ai-slim
 google-auth==2.49.1
     # via kubernetes
 griffelib==2.0.2
     # via openai-agents
+    # via pydantic-ai-slim
 h11==0.16.0
     # via httpcore
     # via uvicorn
@@ -126,12 +129,15 @@ httpcore==1.0.9
 httpx==0.28.1
     # via agentex-sdk
     # via anthropic
+    # via genai-prices
     # via httpx-aiohttp
     # via huggingface-hub
     # via langsmith
     # via litellm
     # via mcp
     # via openai
+    # via pydantic-ai-slim
+    # via pydantic-graph
     # via respx
     # via scale-gp
     # via scale-gp-beta
@@ -196,6 +202,8 @@ langsmith==0.7.22
     # via langchain-core
 litellm==1.83.7
     # via agentex-sdk
+logfire-api==4.32.1
+    # via pydantic-graph
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.3
@@ -236,6 +244,7 @@ opentelemetry-api==1.40.0
     # via ddtrace
     # via opentelemetry-sdk
     # via opentelemetry-semantic-conventions
+    # via pydantic-ai-slim
 opentelemetry-sdk==1.40.0
     # via agentex-sdk
 opentelemetry-semantic-conventions==0.61b0
@@ -287,18 +296,25 @@ pydantic==2.12.5
     # via agentex-sdk
     # via anthropic
     # via fastapi
+    # via genai-prices
     # via langchain-core
     # via langsmith
     # via litellm
     # via mcp
     # via openai
     # via openai-agents
+    # via pydantic-ai-slim
+    # via pydantic-graph
     # via pydantic-settings
     # via python-on-whales
     # via scale-gp
     # via scale-gp-beta
+pydantic-ai-slim==1.92.0
+    # via agentex-sdk
 pydantic-core==2.41.5
     # via pydantic
+pydantic-graph==1.92.0
+    # via pydantic-ai-slim
 pydantic-settings==2.13.1
     # via mcp
 pygments==2.19.2
@@ -459,6 +475,8 @@ typing-inspection==0.4.2
     # via fastapi
     # via mcp
     # via pydantic
+    # via pydantic-ai-slim
+    # via pydantic-graph
     # via pydantic-settings
 tzdata==2025.3
     # via agentex-sdk

--- a/requirements.lock
+++ b/requirements.lock
@@ -99,10 +99,13 @@ frozenlist==1.8.0
     # via aiosignal
 fsspec==2026.3.0
     # via huggingface-hub
+genai-prices==0.0.59
+    # via pydantic-ai-slim
 google-auth==2.49.1
     # via kubernetes
 griffelib==2.0.2
     # via openai-agents
+    # via pydantic-ai-slim
 h11==0.16.0
     # via httpcore
     # via uvicorn
@@ -113,12 +116,15 @@ httpcore==1.0.9
 httpx==0.28.1
     # via agentex-sdk
     # via anthropic
+    # via genai-prices
     # via httpx-aiohttp
     # via huggingface-hub
     # via langsmith
     # via litellm
     # via mcp
     # via openai
+    # via pydantic-ai-slim
+    # via pydantic-graph
     # via scale-gp
     # via scale-gp-beta
 httpx-aiohttp==0.1.12
@@ -180,6 +186,8 @@ langsmith==0.7.22
     # via langchain-core
 litellm==1.83.7
     # via agentex-sdk
+logfire-api==4.32.1
+    # via pydantic-graph
 markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
@@ -214,6 +222,7 @@ opentelemetry-api==1.40.0
     # via ddtrace
     # via opentelemetry-sdk
     # via opentelemetry-semantic-conventions
+    # via pydantic-ai-slim
 opentelemetry-sdk==1.40.0
     # via agentex-sdk
 opentelemetry-semantic-conventions==0.61b0
@@ -260,18 +269,25 @@ pydantic==2.12.5
     # via agentex-sdk
     # via anthropic
     # via fastapi
+    # via genai-prices
     # via langchain-core
     # via langsmith
     # via litellm
     # via mcp
     # via openai
     # via openai-agents
+    # via pydantic-ai-slim
+    # via pydantic-graph
     # via pydantic-settings
     # via python-on-whales
     # via scale-gp
     # via scale-gp-beta
+pydantic-ai-slim==1.92.0
+    # via agentex-sdk
 pydantic-core==2.41.5
     # via pydantic
+pydantic-graph==1.92.0
+    # via pydantic-ai-slim
 pydantic-settings==2.13.1
     # via mcp
 pygments==2.20.0
@@ -424,6 +440,8 @@ typing-inspection==0.4.2
     # via fastapi
     # via mcp
     # via pydantic
+    # via pydantic-ai-slim
+    # via pydantic-graph
     # via pydantic-settings
 tzdata==2025.3
     # via agentex-sdk

--- a/src/agentex/_files.py
+++ b/src/agentex/_files.py
@@ -99,7 +99,7 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
     elif is_sequence_t(files):
         files = [(key, await _async_transform_file(file)) for key, file in files]
     else:
-        raise TypeError("Unexpected file type input {type(files)}, expected mapping or sequence")
+        raise TypeError(f"Unexpected file type input {type(files)}, expected mapping or sequence")
 
     return files
 

--- a/src/agentex/lib/adk/providers/_modules/pydantic_ai.py
+++ b/src/agentex/lib/adk/providers/_modules/pydantic_ai.py
@@ -1,0 +1,289 @@
+"""Pydantic AI streaming integration for Agentex.
+
+Converts a Pydantic AI ``AgentStreamEvent`` stream (as yielded by
+``agent.run_stream_events(...)`` or via an ``event_stream_handler``) into the
+Agentex ``StreamTaskMessage*`` events that the Agentex server understands.
+
+Typical sync usage:
+
+    from pydantic_ai import Agent
+    from agentex.lib.adk.providers._modules.pydantic_ai import (
+        convert_pydantic_ai_to_agentex_events,
+    )
+
+    agent = Agent("openai:gpt-4o", system_prompt="...")
+
+    @acp.on_message_send
+    async def handle_message_send(params):
+        async with agent.run_stream_events(params.content.content) as stream:
+            async for event in convert_pydantic_ai_to_agentex_events(stream):
+                yield event
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator
+
+from pydantic_ai.messages import (
+    FinalResultEvent,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    PartDeltaEvent,
+    PartEndEvent,
+    PartStartEvent,
+    TextPart,
+    TextPartDelta,
+    ThinkingPart,
+    ThinkingPartDelta,
+    ToolCallPart,
+    ToolCallPartDelta,
+    ToolReturnPart,
+)
+from pydantic_ai.run import AgentRunResultEvent
+
+from agentex.lib.utils.logging import make_logger
+from agentex.types.reasoning_content_delta import ReasoningContentDelta
+from agentex.types.task_message_content import TextContent
+from agentex.types.task_message_delta import TextDelta
+from agentex.types.task_message_update import (
+    StreamTaskMessageDelta,
+    StreamTaskMessageDone,
+    StreamTaskMessageFull,
+    StreamTaskMessageStart,
+)
+from agentex.types.tool_request_content import ToolRequestContent
+from agentex.types.tool_request_delta import ToolRequestDelta
+from agentex.types.tool_response_content import ToolResponseContent
+
+logger = make_logger(__name__)
+
+
+def _args_delta_to_str(args_delta: str | dict[str, Any] | None) -> str:
+    """Normalize a Pydantic AI ``ToolCallPartDelta.args_delta`` to a string fragment.
+
+    Pydantic AI emits string fragments for providers that stream JSON tokens
+    (OpenAI, Anthropic) and dicts for providers that emit one-shot tool calls.
+    Agentex's ``ToolRequestDelta.arguments_delta`` is concatenated server-side
+    and parsed as a single JSON object on completion, so we always produce a
+    string. For dict deltas this is a one-shot dump; subsequent dict deltas
+    will not compose correctly, but in practice dict deltas arrive as a single
+    final fragment.
+    """
+    if args_delta is None:
+        return ""
+    if isinstance(args_delta, str):
+        return args_delta
+    return json.dumps(args_delta)
+
+
+def _tool_return_content(result: ToolReturnPart | Any) -> Any:
+    """Best-effort extraction of the user-visible content from a tool result.
+
+    ``FunctionToolResultEvent.result`` is ``ToolReturnPart | RetryPromptPart``.
+    For ``ToolReturnPart`` we surface ``.content`` directly; for ``RetryPromptPart``
+    (a retry signal back to the model) we surface a string description so the
+    UI sees the failure reason.
+    """
+    content = getattr(result, "content", None)
+    if content is None:
+        return str(result)
+    if isinstance(content, (str, int, float, bool, list, dict)):
+        return content
+    if hasattr(content, "model_dump"):
+        try:
+            return content.model_dump()
+        except Exception:
+            return str(content)
+    return str(content)
+
+
+async def convert_pydantic_ai_to_agentex_events(
+    stream_response: AsyncIterator[Any],
+) -> AsyncIterator[
+    StreamTaskMessageStart | StreamTaskMessageDelta | StreamTaskMessageFull | StreamTaskMessageDone
+]:
+    """Convert a Pydantic AI agent event stream into Agentex stream events.
+
+    Mapping:
+        PartStartEvent(TextPart)       -> StreamTaskMessageStart(TextContent)
+        PartStartEvent(ThinkingPart)   -> StreamTaskMessageStart(TextContent)         [reasoning channel]
+        PartStartEvent(ToolCallPart)   -> StreamTaskMessageStart(ToolRequestContent)
+        PartDeltaEvent(TextPartDelta)  -> StreamTaskMessageDelta(TextDelta)
+        PartDeltaEvent(ThinkingPart..) -> StreamTaskMessageDelta(ReasoningContentDelta)
+        PartDeltaEvent(ToolCallPart..) -> StreamTaskMessageDelta(ToolRequestDelta)
+        PartEndEvent                   -> StreamTaskMessageDone
+        FunctionToolResultEvent        -> StreamTaskMessageFull(ToolResponseContent)
+        FunctionToolCallEvent          -> (ignored — already covered by Start/Delta/End)
+        FinalResultEvent               -> (ignored — informational; the run-level
+                                          AgentRunResultEvent terminates the stream)
+        AgentRunResultEvent            -> (ignored — Agentex closes the per-message
+                                          stream via PartEndEvent already)
+
+    Args:
+        stream_response: The async iterator yielded by Pydantic AI's
+            ``agent.run_stream_events(...)`` context manager (or a stream of
+            ``AgentStreamEvent`` items received in an ``event_stream_handler``).
+
+    Yields:
+        Agentex ``StreamTaskMessage*`` events suitable for forwarding back over
+        the ACP streaming response.
+    """
+    next_message_index = 0
+    # Maps Pydantic AI's per-response part index to our absolute message index.
+    # Part indices restart at 0 on each new model response in a multi-step run,
+    # so we always overwrite the entry on PartStartEvent.
+    part_to_message_index: dict[int, int] = {}
+    # Tool-call metadata indexed by Pydantic AI part index (so deltas can
+    # surface the tool_call_id even when ToolCallPartDelta.tool_call_id is None).
+    tool_call_meta: dict[int, tuple[str, str]] = {}
+
+    async for event in stream_response:
+        if isinstance(event, PartStartEvent):
+            message_index = next_message_index
+            next_message_index += 1
+            part_to_message_index[event.index] = message_index
+
+            if isinstance(event.part, TextPart):
+                yield StreamTaskMessageStart(
+                    type="start",
+                    index=message_index,
+                    content=TextContent(
+                        type="text",
+                        author="agent",
+                        content=event.part.content or "",
+                    ),
+                )
+            elif isinstance(event.part, ThinkingPart):
+                yield StreamTaskMessageStart(
+                    type="start",
+                    index=message_index,
+                    content=TextContent(
+                        type="text",
+                        author="agent",
+                        content="",
+                    ),
+                )
+                if event.part.content:
+                    yield StreamTaskMessageDelta(
+                        type="delta",
+                        index=message_index,
+                        delta=ReasoningContentDelta(
+                            type="reasoning_content",
+                            content_index=0,
+                            content_delta=event.part.content,
+                        ),
+                    )
+            elif isinstance(event.part, ToolCallPart):
+                tool_call_meta[event.index] = (event.part.tool_call_id, event.part.tool_name)
+                # Pydantic AI may already have a fully-formed args dict at start
+                # when the provider returns the tool call in one shot; surface it
+                # directly so clients see the complete arguments without waiting
+                # for deltas.
+                initial_args: dict[str, Any] = {}
+                if isinstance(event.part.args, dict):
+                    initial_args = event.part.args
+                yield StreamTaskMessageStart(
+                    type="start",
+                    index=message_index,
+                    content=ToolRequestContent(
+                        type="tool_request",
+                        author="agent",
+                        tool_call_id=event.part.tool_call_id,
+                        name=event.part.tool_name,
+                        arguments=initial_args,
+                    ),
+                )
+                if isinstance(event.part.args, str) and event.part.args:
+                    yield StreamTaskMessageDelta(
+                        type="delta",
+                        index=message_index,
+                        delta=ToolRequestDelta(
+                            type="tool_request",
+                            tool_call_id=event.part.tool_call_id,
+                            name=event.part.tool_name,
+                            arguments_delta=event.part.args,
+                        ),
+                    )
+            else:
+                logger.debug("Unhandled PartStartEvent part type: %r", type(event.part).__name__)
+
+        elif isinstance(event, PartDeltaEvent):
+            message_index = part_to_message_index.get(event.index)
+            if message_index is None:
+                logger.debug("PartDeltaEvent for unknown part index %s; skipping", event.index)
+                continue
+
+            if isinstance(event.delta, TextPartDelta):
+                yield StreamTaskMessageDelta(
+                    type="delta",
+                    index=message_index,
+                    delta=TextDelta(type="text", text_delta=event.delta.content_delta),
+                )
+            elif isinstance(event.delta, ThinkingPartDelta):
+                if event.delta.content_delta:
+                    yield StreamTaskMessageDelta(
+                        type="delta",
+                        index=message_index,
+                        delta=ReasoningContentDelta(
+                            type="reasoning_content",
+                            content_index=0,
+                            content_delta=event.delta.content_delta,
+                        ),
+                    )
+            elif isinstance(event.delta, ToolCallPartDelta):
+                meta = tool_call_meta.get(event.index)
+                if meta is None:
+                    # First time we've seen this part; the provider didn't emit
+                    # a PartStartEvent first. Synthesize one from the delta if
+                    # we have enough information.
+                    tool_call_id = event.delta.tool_call_id or ""
+                    tool_name = event.delta.tool_name_delta or ""
+                    tool_call_meta[event.index] = (tool_call_id, tool_name)
+                else:
+                    tool_call_id, tool_name = meta
+                yield StreamTaskMessageDelta(
+                    type="delta",
+                    index=message_index,
+                    delta=ToolRequestDelta(
+                        type="tool_request",
+                        tool_call_id=tool_call_id,
+                        name=tool_name,
+                        arguments_delta=_args_delta_to_str(event.delta.args_delta),
+                    ),
+                )
+            else:
+                logger.debug("Unhandled PartDeltaEvent delta type: %r", type(event.delta).__name__)
+
+        elif isinstance(event, PartEndEvent):
+            message_index = part_to_message_index.get(event.index)
+            if message_index is None:
+                continue
+            yield StreamTaskMessageDone(type="done", index=message_index)
+
+        elif isinstance(event, FunctionToolResultEvent):
+            result = event.result
+            tool_call_id = result.tool_call_id
+            tool_name = getattr(result, "tool_name", "") or ""
+            message_index = next_message_index
+            next_message_index += 1
+            yield StreamTaskMessageFull(
+                type="full",
+                index=message_index,
+                content=ToolResponseContent(
+                    type="tool_response",
+                    author="agent",
+                    tool_call_id=tool_call_id,
+                    name=tool_name,
+                    content=_tool_return_content(result),
+                ),
+            )
+
+        elif isinstance(event, (FunctionToolCallEvent, FinalResultEvent, AgentRunResultEvent)):
+            # Already covered by PartStart/PartDelta/PartEnd events above, or
+            # informational only (FinalResultEvent / AgentRunResultEvent signal
+            # run-level state, not new content to surface).
+            continue
+
+        else:
+            logger.debug("Unhandled Pydantic AI event type: %r", type(event).__name__)

--- a/src/agentex/lib/cli/templates/default-langgraph/.env.example.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/default/.env.example.j2
+++ b/src/agentex/lib/cli/templates/default/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/sync-langgraph/.env.example.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/sync-openai-agents/.env.example.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2
@@ -13,7 +13,12 @@ from agentex.types.task_message_update import TaskMessageUpdate, StreamTaskMessa
 from agentex.types.task_message_content import TaskMessageContent
 from agentex.types.text_content import TextContent
 from agentex.lib.utils.logging import make_logger
-from agents import Agent, Runner, RunConfig, function_tool
+from agents import Agent, Runner, RunConfig, function_tool, set_tracing_disabled
+
+# Disable the openai-agents SDK's native tracer so it doesn't ship traces to
+# api.openai.com using OPENAI_API_KEY (which may be a LiteLLM proxy key).
+# SGP tracing below still runs via the Agentex tracing manager.
+set_tracing_disabled(True)
 
 
 logger = make_logger(__name__)
@@ -25,12 +30,14 @@ if _litellm_key:
 
 SGP_API_KEY = os.environ.get("SGP_API_KEY", "")
 SGP_ACCOUNT_ID = os.environ.get("SGP_ACCOUNT_ID", "")
+SGP_CLIENT_BASE_URL = os.environ.get("SGP_CLIENT_BASE_URL", "")
 
 if SGP_API_KEY and SGP_ACCOUNT_ID:
     add_tracing_processor_config(
         SGPTracingProcessorConfig(
             sgp_api_key=SGP_API_KEY,
             sgp_account_id=SGP_ACCOUNT_ID,
+            sgp_base_url=SGP_CLIENT_BASE_URL,
         )
     )
 

--- a/src/agentex/lib/cli/templates/sync/.env.example.j2
+++ b/src/agentex/lib/cli/templates/sync/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/.env.example.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2
@@ -10,7 +10,13 @@ from agentex.lib.core.temporal.types.workflow import SignalName
 from agentex.lib.utils.logging import make_logger
 from agentex.types.text_content import TextContent
 from agentex.lib.environment_variables import EnvironmentVariables
-from agents import Agent, Runner
+from agents import Agent, Runner, set_tracing_disabled
+
+# Disable the openai-agents SDK's native tracer so it doesn't ship traces to
+# api.openai.com using OPENAI_API_KEY (which may be a LiteLLM proxy key).
+# SGP tracing below still runs via the Agentex tracing manager.
+set_tracing_disabled(True)
+
 from agentex.lib.core.temporal.plugins.openai_agents.hooks.hooks import TemporalStreamingHooks
 from pydantic import BaseModel
 from typing import List, Dict, Any
@@ -39,6 +45,7 @@ add_tracing_processor_config(
     SGPTracingProcessorConfig(
         sgp_api_key=os.environ.get("SGP_API_KEY", ""),
         sgp_account_id=os.environ.get("SGP_ACCOUNT_ID", ""),
+        sgp_base_url=os.environ.get("SGP_CLIENT_BASE_URL", ""),
     )
 )
 

--- a/src/agentex/lib/cli/templates/temporal/.env.example.j2
+++ b/src/agentex/lib/cli/templates/temporal/.env.example.j2
@@ -10,3 +10,4 @@ LITELLM_API_KEY=
 # SGP Configuration (optional - for tracing)
 # SGP_API_KEY=
 # SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/core/tracing/tracing_processor_manager.py
+++ b/src/agentex/lib/core/tracing/tracing_processor_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from threading import Lock
 
-from agentex.lib.types.tracing import TracingProcessorConfig, AgentexTracingProcessorConfig
+from agentex.lib.types.tracing import TracingProcessorConfig
 from agentex.lib.core.tracing.processors.sgp_tracing_processor import (
     SGPSyncTracingProcessor,
     SGPAsyncTracingProcessor,
@@ -73,22 +73,8 @@ GLOBAL_TRACING_PROCESSOR_MANAGER = TracingProcessorManager()
 add_tracing_processor_config = GLOBAL_TRACING_PROCESSOR_MANAGER.add_processor_config
 set_tracing_processor_configs = GLOBAL_TRACING_PROCESSOR_MANAGER.set_processor_configs
 
-# Lazy initialization to avoid circular imports
-_default_initialized = False
-
-def _ensure_default_initialized():
-    """Ensure default processor is initialized (lazy to avoid circular imports)."""
-    global _default_initialized
-    if not _default_initialized:
-        add_tracing_processor_config(AgentexTracingProcessorConfig())
-        _default_initialized = True
-
 def get_sync_tracing_processors():
-    """Get sync processors, initializing defaults if needed."""
-    _ensure_default_initialized()
     return GLOBAL_TRACING_PROCESSOR_MANAGER.get_sync_processors()
 
 def get_async_tracing_processors():
-    """Get async processors, initializing defaults if needed."""
-    _ensure_default_initialized()
     return GLOBAL_TRACING_PROCESSOR_MANAGER.get_async_processors()

--- a/tests/lib/adk/providers/test_pydantic_ai.py
+++ b/tests/lib/adk/providers/test_pydantic_ai.py
@@ -1,0 +1,397 @@
+"""Tests for the Pydantic AI -> Agentex stream event converter."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator
+
+import pytest
+from pydantic_ai.messages import (
+    FinalResultEvent,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    PartDeltaEvent,
+    PartEndEvent,
+    PartStartEvent,
+    RetryPromptPart,
+    TextPart,
+    TextPartDelta,
+    ThinkingPart,
+    ThinkingPartDelta,
+    ToolCallPart,
+    ToolCallPartDelta,
+    ToolReturnPart,
+)
+
+from agentex.lib.adk.providers._modules.pydantic_ai import (
+    _args_delta_to_str,
+    convert_pydantic_ai_to_agentex_events,
+)
+from agentex.types.reasoning_content_delta import ReasoningContentDelta
+from agentex.types.task_message_content import TextContent
+from agentex.types.task_message_delta import TextDelta
+from agentex.types.task_message_update import (
+    StreamTaskMessageDelta,
+    StreamTaskMessageDone,
+    StreamTaskMessageFull,
+    StreamTaskMessageStart,
+)
+from agentex.types.tool_request_content import ToolRequestContent
+from agentex.types.tool_request_delta import ToolRequestDelta
+from agentex.types.tool_response_content import ToolResponseContent
+
+
+async def _aiter(events: list[Any]) -> AsyncIterator[Any]:
+    for e in events:
+        yield e
+
+
+async def _collect(stream: AsyncIterator[Any]) -> list[Any]:
+    return [e async for e in stream]
+
+
+class TestArgsDeltaToStr:
+    def test_none(self):
+        assert _args_delta_to_str(None) == ""
+
+    def test_string_passthrough(self):
+        assert _args_delta_to_str('{"k":') == '{"k":'
+
+    def test_dict_dumps_json(self):
+        assert json.loads(_args_delta_to_str({"city": "Paris"})) == {"city": "Paris"}
+
+
+class TestTextStreaming:
+    async def test_plain_text_emits_start_deltas_done(self):
+        events = [
+            PartStartEvent(index=0, part=TextPart(content="")),
+            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta="Hello")),
+            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta=", ")),
+            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta="world!")),
+            PartEndEvent(index=0, part=TextPart(content="Hello, world!")),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+
+        assert len(out) == 5
+        assert isinstance(out[0], StreamTaskMessageStart)
+        assert isinstance(out[0].content, TextContent)
+        assert out[0].content.content == ""
+        assert out[0].index == 0
+
+        for i, expected in enumerate(["Hello", ", ", "world!"], start=1):
+            assert isinstance(out[i], StreamTaskMessageDelta)
+            assert isinstance(out[i].delta, TextDelta)
+            assert out[i].delta.text_delta == expected
+            assert out[i].index == 0
+
+        assert isinstance(out[4], StreamTaskMessageDone)
+        assert out[4].index == 0
+
+    async def test_text_with_initial_content_preserved(self):
+        events = [
+            PartStartEvent(index=0, part=TextPart(content="Already there")),
+            PartEndEvent(index=0, part=TextPart(content="Already there")),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert isinstance(out[0], StreamTaskMessageStart)
+        assert out[0].content.content == "Already there"
+
+
+class TestThinkingStreaming:
+    async def test_thinking_emits_reasoning_deltas(self):
+        events = [
+            PartStartEvent(index=0, part=ThinkingPart(content="")),
+            PartDeltaEvent(index=0, delta=ThinkingPartDelta(content_delta="step 1...")),
+            PartDeltaEvent(index=0, delta=ThinkingPartDelta(content_delta=" step 2.")),
+            PartEndEvent(index=0, part=ThinkingPart(content="step 1... step 2.")),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+
+        assert isinstance(out[0], StreamTaskMessageStart)
+        assert isinstance(out[1], StreamTaskMessageDelta)
+        assert isinstance(out[1].delta, ReasoningContentDelta)
+        assert out[1].delta.content_delta == "step 1..."
+        assert out[1].delta.content_index == 0
+        assert isinstance(out[2].delta, ReasoningContentDelta)
+        assert out[2].delta.content_delta == " step 2."
+        assert isinstance(out[3], StreamTaskMessageDone)
+
+    async def test_thinking_with_initial_content_emits_delta(self):
+        events = [
+            PartStartEvent(index=0, part=ThinkingPart(content="seed reasoning")),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert isinstance(out[0], StreamTaskMessageStart)
+        assert isinstance(out[1], StreamTaskMessageDelta)
+        assert out[1].delta.content_delta == "seed reasoning"
+
+    async def test_thinking_delta_skipped_when_empty(self):
+        events = [
+            PartStartEvent(index=0, part=ThinkingPart(content="")),
+            PartDeltaEvent(index=0, delta=ThinkingPartDelta(content_delta=None)),
+            PartEndEvent(index=0, part=ThinkingPart(content="")),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert len(out) == 2  # Start + Done; no delta for None content
+
+
+class TestToolCallStreaming:
+    async def test_tool_call_streamed_token_by_token(self):
+        """The headline use case: tool-call argument tokens streaming through to the client."""
+        events = [
+            PartStartEvent(
+                index=1,
+                part=ToolCallPart(tool_name="get_weather", args=None, tool_call_id="call_abc"),
+            ),
+            PartDeltaEvent(
+                index=1,
+                delta=ToolCallPartDelta(args_delta='{"city":', tool_call_id="call_abc"),
+            ),
+            PartDeltaEvent(index=1, delta=ToolCallPartDelta(args_delta='"Paris"}')),
+            PartEndEvent(
+                index=1,
+                part=ToolCallPart(
+                    tool_name="get_weather", args='{"city":"Paris"}', tool_call_id="call_abc"
+                ),
+            ),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+
+        assert len(out) == 4
+        assert isinstance(out[0], StreamTaskMessageStart)
+        assert isinstance(out[0].content, ToolRequestContent)
+        assert out[0].content.tool_call_id == "call_abc"
+        assert out[0].content.name == "get_weather"
+        assert out[0].content.arguments == {}
+
+        assert isinstance(out[1].delta, ToolRequestDelta)
+        assert out[1].delta.tool_call_id == "call_abc"
+        assert out[1].delta.name == "get_weather"
+        assert out[1].delta.arguments_delta == '{"city":'
+
+        assert isinstance(out[2].delta, ToolRequestDelta)
+        assert out[2].delta.arguments_delta == '"Paris"}'
+        # tool_call_id is carried forward from the start even when the delta omits it
+        assert out[2].delta.tool_call_id == "call_abc"
+
+        assert isinstance(out[3], StreamTaskMessageDone)
+
+    async def test_tool_call_with_full_args_at_start(self):
+        """Some providers return a tool call in one shot — args dict is set at start."""
+        events = [
+            PartStartEvent(
+                index=0,
+                part=ToolCallPart(
+                    tool_name="search", args={"query": "weather"}, tool_call_id="call_xyz"
+                ),
+            ),
+            PartEndEvent(
+                index=0,
+                part=ToolCallPart(
+                    tool_name="search", args={"query": "weather"}, tool_call_id="call_xyz"
+                ),
+            ),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert isinstance(out[0], StreamTaskMessageStart)
+        assert out[0].content.arguments == {"query": "weather"}
+        # No deltas emitted — args were already complete.
+        assert len(out) == 2
+        assert isinstance(out[1], StreamTaskMessageDone)
+
+    async def test_tool_call_with_full_args_string_at_start(self):
+        """When args is a complete JSON string at start, surface it as a single delta."""
+        events = [
+            PartStartEvent(
+                index=0,
+                part=ToolCallPart(
+                    tool_name="search", args='{"query":"weather"}', tool_call_id="call_z"
+                ),
+            ),
+            PartEndEvent(
+                index=0,
+                part=ToolCallPart(
+                    tool_name="search", args='{"query":"weather"}', tool_call_id="call_z"
+                ),
+            ),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert isinstance(out[0], StreamTaskMessageStart)
+        assert out[0].content.arguments == {}
+        assert isinstance(out[1], StreamTaskMessageDelta)
+        assert out[1].delta.arguments_delta == '{"query":"weather"}'
+
+    async def test_tool_call_dict_args_delta_serialized(self):
+        events = [
+            PartStartEvent(
+                index=0,
+                part=ToolCallPart(tool_name="t", args=None, tool_call_id="cid"),
+            ),
+            PartDeltaEvent(
+                index=0,
+                delta=ToolCallPartDelta(args_delta={"k": "v"}, tool_call_id="cid"),
+            ),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert json.loads(out[1].delta.arguments_delta) == {"k": "v"}
+
+    async def test_tool_result_emits_full(self):
+        events = [
+            PartStartEvent(
+                index=0,
+                part=ToolCallPart(tool_name="get_weather", args=None, tool_call_id="call_abc"),
+            ),
+            PartEndEvent(
+                index=0,
+                part=ToolCallPart(tool_name="get_weather", args="{}", tool_call_id="call_abc"),
+            ),
+            FunctionToolResultEvent(
+                result=ToolReturnPart(
+                    tool_name="get_weather", content="Sunny, 72F", tool_call_id="call_abc"
+                ),
+            ),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+
+        # Last event is the tool result -> Full ToolResponseContent
+        assert isinstance(out[-1], StreamTaskMessageFull)
+        assert isinstance(out[-1].content, ToolResponseContent)
+        assert out[-1].content.tool_call_id == "call_abc"
+        assert out[-1].content.name == "get_weather"
+        assert out[-1].content.content == "Sunny, 72F"
+
+    async def test_tool_retry_prompt_surfaces_as_response(self):
+        events = [
+            FunctionToolResultEvent(
+                result=RetryPromptPart(
+                    content="bad arguments",
+                    tool_name="get_weather",
+                    tool_call_id="call_abc",
+                ),
+            ),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert isinstance(out[0], StreamTaskMessageFull)
+        assert isinstance(out[0].content, ToolResponseContent)
+        assert out[0].content.tool_call_id == "call_abc"
+        assert out[0].content.name == "get_weather"
+        # RetryPromptPart's content is the error message
+        assert out[0].content.content == "bad arguments"
+
+
+class TestMultiStepRun:
+    async def test_text_then_tool_then_text_assigns_distinct_indices(self):
+        """A multi-step run: model emits text + tool call → tool runs → model emits more text.
+
+        Pydantic AI restarts part indices at 0 for each new model response, so
+        the converter must assign fresh Agentex message indices.
+        """
+        events = [
+            # First model response: text at index 0, tool call at index 1
+            PartStartEvent(index=0, part=TextPart(content="")),
+            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta="Looking up...")),
+            PartEndEvent(index=0, part=TextPart(content="Looking up...")),
+            PartStartEvent(
+                index=1,
+                part=ToolCallPart(tool_name="get_weather", args=None, tool_call_id="c1"),
+            ),
+            PartDeltaEvent(index=1, delta=ToolCallPartDelta(args_delta="{}")),
+            PartEndEvent(
+                index=1, part=ToolCallPart(tool_name="get_weather", args="{}", tool_call_id="c1")
+            ),
+            FunctionToolResultEvent(
+                result=ToolReturnPart(tool_name="get_weather", content="Sunny", tool_call_id="c1"),
+            ),
+            # Second model response: text restarts at index 0
+            PartStartEvent(index=0, part=TextPart(content="")),
+            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta="It's sunny.")),
+            PartEndEvent(index=0, part=TextPart(content="It's sunny.")),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+
+        # Pull every Start/Full event and check their assigned message indices
+        anchors = [
+            e for e in out if isinstance(e, (StreamTaskMessageStart, StreamTaskMessageFull))
+        ]
+        indices = [e.index for e in anchors]
+        assert indices == [0, 1, 2, 3], (
+            f"Expected 4 distinct, monotonic message indices for: text1, tool_call, "
+            f"tool_result, text2 — got {indices}"
+        )
+
+        # And the second text's deltas should target the second text's message index.
+        text2_start = anchors[3]
+        text2_deltas = [
+            e
+            for e in out
+            if isinstance(e, StreamTaskMessageDelta)
+            and isinstance(e.delta, TextDelta)
+            and e.index == text2_start.index
+        ]
+        assert len(text2_deltas) == 1
+        assert text2_deltas[0].delta.text_delta == "It's sunny."
+
+
+class TestIgnoredEvents:
+    async def test_function_tool_call_event_is_ignored(self):
+        """FunctionToolCallEvent is redundant with PartStart+Delta+End and should be skipped."""
+        events = [
+            PartStartEvent(
+                index=0,
+                part=ToolCallPart(tool_name="t", args=None, tool_call_id="c"),
+            ),
+            FunctionToolCallEvent(
+                part=ToolCallPart(tool_name="t", args="{}", tool_call_id="c"),
+            ),
+            PartEndEvent(
+                index=0, part=ToolCallPart(tool_name="t", args="{}", tool_call_id="c")
+            ),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        # Start + Done only — no event from FunctionToolCallEvent
+        assert len(out) == 2
+        assert isinstance(out[0], StreamTaskMessageStart)
+        assert isinstance(out[1], StreamTaskMessageDone)
+
+    async def test_final_result_event_ignored(self):
+        events = [
+            FinalResultEvent(tool_name=None, tool_call_id=None),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert out == []
+
+    async def test_unknown_part_index_delta_skipped(self):
+        events = [
+            PartDeltaEvent(index=99, delta=TextPartDelta(content_delta="orphan")),
+        ]
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        assert out == []
+
+
+class TestStartingTextMatchesAuthor:
+    """Sanity check that all emitted content is authored by the agent."""
+
+    @pytest.mark.parametrize(
+        "events",
+        [
+            [PartStartEvent(index=0, part=TextPart(content=""))],
+            [PartStartEvent(index=0, part=ThinkingPart(content=""))],
+            [
+                PartStartEvent(
+                    index=0,
+                    part=ToolCallPart(tool_name="t", args=None, tool_call_id="c"),
+                )
+            ],
+            [
+                FunctionToolResultEvent(
+                    result=ToolReturnPart(tool_name="t", content="ok", tool_call_id="c"),
+                )
+            ],
+        ],
+    )
+    async def test_author_is_agent(self, events: list[Any]):
+        out = await _collect(convert_pydantic_ai_to_agentex_events(_aiter(events)))
+        for e in out:
+            content = getattr(e, "content", None)
+            if content is not None and hasattr(content, "author"):
+                assert content.author == "agent"


### PR DESCRIPTION
## Summary

Slice 1 of the Pydantic AI integration: a sync streaming event converter that maps Pydantic AI's `AgentStreamEvent` stream into Agentex `StreamTaskMessage*` events. Mirrors the existing OpenAI Agents SDK converter pattern in ``sync_provider.py``.

- New module: ``agentex.lib.adk.providers._modules.pydantic_ai`` with ``convert_pydantic_ai_to_agentex_events``
- Maps tool-call argument *tokens* (``ToolCallPartDelta.args_delta``) directly to Agentex's ``ToolRequestDelta.arguments_delta`` — token-by-token tool-call streaming works end-to-end without any new server-side primitives
- ``pydantic-ai-slim>=1.0,<2`` added as hard dep, consistent with ``openai-agents`` / ``langgraph-checkpoint`` / ``claude-agent-sdk``

### Event mapping

| Pydantic AI | Agentex |
|---|---|
| ``PartStartEvent(TextPart)`` | ``StreamTaskMessageStart(TextContent)`` |
| ``PartStartEvent(ThinkingPart)`` | ``StreamTaskMessageStart(TextContent)`` (reasoning channel) |
| ``PartStartEvent(ToolCallPart)`` | ``StreamTaskMessageStart(ToolRequestContent)`` |
| ``PartDeltaEvent(TextPartDelta)`` | ``StreamTaskMessageDelta(TextDelta)`` |
| ``PartDeltaEvent(ThinkingPartDelta)`` | ``StreamTaskMessageDelta(ReasoningContentDelta)`` |
| ``PartDeltaEvent(ToolCallPartDelta)`` | ``StreamTaskMessageDelta(ToolRequestDelta)`` |
| ``PartEndEvent`` | ``StreamTaskMessageDone`` |
| ``FunctionToolResultEvent`` | ``StreamTaskMessageFull(ToolResponseContent)`` |
| ``FunctionToolCallEvent`` / ``FinalResultEvent`` / ``AgentRunResultEvent`` | ignored (covered by the events above or run-level only) |

### Multi-step runs

Pydantic AI restarts part indices at 0 per model response. The converter maintains its own monotonic ``message_index`` and a ``part_index -> message_index`` map that's overwritten on each ``PartStartEvent``, so a multi-step run (text → tool → text) produces 4 distinct Agentex message indices.

## Roadmap

This is the first of several slices to bring Pydantic AI to feature parity with the OpenAI Agents SDK integration:

1. ✅ Sync streaming converter + tests (this PR)
2. Sync hello-world example agent (text-only streaming)
3. Sync agent with tools (tool-call delta streaming)
4. Tracing wired to SGP via ``Agent.instrument_all()``
5. Sync CLI template (``agentex new-agent --type sync-pydantic-ai``)
6. Async (non-Temporal) example + template
7. Temporal example + template (using ``TemporalAgent`` + ``PydanticAIPlugin``)
8. HIL, structured output, multi-agent examples

## Test plan

- [x] 22 unit tests pass: ``rye run pytest tests/lib/adk/providers/test_pydantic_ai.py -v``
- [ ] End-to-end: hello-world agent in agentex-agents (separate PR) chats successfully and streams text token-by-token
- [ ] End-to-end: tool-call args stream token-by-token visible in Agentex UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `convert_pydantic_ai_to_agentex_events`, a new async generator that maps Pydantic AI's `AgentStreamEvent` stream to Agentex `StreamTaskMessage*` events, mirroring the existing OpenAI Agents SDK converter. The implementation and test coverage are solid for the common cases, but there is one behavioral inconsistency with the established OpenAI reasoning channel contract worth resolving before end-to-end validation.

- **P1**: `PartEndEvent` emits `StreamTaskMessageDone` for **all** part types, including `ThinkingPart`. `sync_provider.py` explicitly skips `Done` for reasoning/thinking channels; if the server/client relies on that contract, this extra event will cause a mismatch.
- **P2**: `_args_delta_to_str` silently produces concatenated-invalid JSON when a provider sends more than one dict-typed `args_delta` — adding a warning makes the failure visible.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for unit-test purposes; the P1 ThinkingPart done-event inconsistency should be resolved before the first end-to-end integration is attempted

One P1 finding (ThinkingPart emitting Done events contrary to the established reasoning-channel contract) caps the score at 4; lack of end-to-end validation further lowers it. P2 findings are contained.

src/agentex/lib/adk/providers/_modules/pydantic_ai.py — the ThinkingPart PartEndEvent handling at lines 448-452
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/adk/providers/_modules/pydantic_ai.py | New Pydantic AI → Agentex streaming converter; has a P1 behavioral inconsistency for ThinkingPart done events and a P2 dict-delta JSON composition issue |
| tests/lib/adk/providers/test_pydantic_ai.py | 22 unit tests covering all major event-mapping paths; missing coverage for AgentRunResultEvent in the ignored-events suite |
| pyproject.toml | Adds pydantic-ai-slim>=1.0,<2 as a hard dependency, consistent with other framework deps |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PAI as Pydantic AI Stream
    participant Conv as convert_pydantic_ai_to_agentex_events
    participant AEX as Agentex Server

    PAI->>Conv: PartStartEvent(TextPart)
    Conv->>AEX: StreamTaskMessageStart(TextContent)
    PAI->>Conv: PartDeltaEvent(TextPartDelta)
    Conv->>AEX: StreamTaskMessageDelta(TextDelta)
    PAI->>Conv: PartEndEvent
    Conv->>AEX: StreamTaskMessageDone

    PAI->>Conv: PartStartEvent(ThinkingPart)
    Conv->>AEX: StreamTaskMessageStart(TextContent, empty)
    PAI->>Conv: PartDeltaEvent(ThinkingPartDelta)
    Conv->>AEX: StreamTaskMessageDelta(ReasoningContentDelta)
    PAI->>Conv: PartEndEvent
    Conv->>AEX: StreamTaskMessageDone (differs from OpenAI provider)

    PAI->>Conv: PartStartEvent(ToolCallPart)
    Conv->>AEX: StreamTaskMessageStart(ToolRequestContent)
    PAI->>Conv: PartDeltaEvent(ToolCallPartDelta)
    Conv->>AEX: StreamTaskMessageDelta(ToolRequestDelta)
    PAI->>Conv: PartEndEvent
    Conv->>AEX: StreamTaskMessageDone

    PAI->>Conv: FunctionToolResultEvent
    Conv->>AEX: StreamTaskMessageFull(ToolResponseContent)

    PAI->>Conv: FunctionToolCallEvent / FinalResultEvent / AgentRunResultEvent
    Conv-->>AEX: (ignored)
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/agentex/lib/adk/providers/_modules/pydantic_ai.py`, line 448-452 ([link](https://github.com/scaleapi/scale-agentex-python/blob/ea22edcc63666ed4b4a01886f2880185418c382e/src/agentex/lib/adk/providers/_modules/pydantic_ai.py#L448-L452)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`ThinkingPart` end emits `StreamTaskMessageDone` — inconsistent with existing reasoning-channel contract**

   `sync_provider.py` (the established OpenAI converter) explicitly skips `StreamTaskMessageDone` for reasoning/thinking channels: `if message_type not in ("reasoning_content", "reasoning_summary"): yield StreamTaskMessageDone(...)`. The `pydantic_ai.py` converter emits `Done` for **all** parts via the generic `PartEndEvent` branch, including `ThinkingPart`. If the Agentex server or client treats reasoning channels as never receiving a done event (relying only on the last delta to close them), this extra `Done` for thinking parts will cause a behavioral mismatch. End-to-end tests are still pending, making this a silent risk.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/adk/providers/_modules/pydantic_ai.py
   Line: 448-452

   Comment:
   **`ThinkingPart` end emits `StreamTaskMessageDone` — inconsistent with existing reasoning-channel contract**

   `sync_provider.py` (the established OpenAI converter) explicitly skips `StreamTaskMessageDone` for reasoning/thinking channels: `if message_type not in ("reasoning_content", "reasoning_summary"): yield StreamTaskMessageDone(...)`. The `pydantic_ai.py` converter emits `Done` for **all** parts via the generic `PartEndEvent` branch, including `ThinkingPart`. If the Agentex server or client treats reasoning channels as never receiving a done event (relying only on the last delta to close them), this extra `Done` for thinking parts will cause a behavioral mismatch. End-to-end tests are still pending, making this a silent risk.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%0ALine%3A%20448-452%0A%0AComment%3A%0A**%60ThinkingPart%60%20end%20emits%20%60StreamTaskMessageDone%60%20%E2%80%94%20inconsistent%20with%20existing%20reasoning-channel%20contract**%0A%0A%60sync_provider.py%60%20%28the%20established%20OpenAI%20converter%29%20explicitly%20skips%20%60StreamTaskMessageDone%60%20for%20reasoning%2Fthinking%20channels%3A%20%60if%20message_type%20not%20in%20%28%22reasoning_content%22%2C%20%22reasoning_summary%22%29%3A%20yield%20StreamTaskMessageDone%28...%29%60.%20The%20%60pydantic_ai.py%60%20converter%20emits%20%60Done%60%20for%20**all**%20parts%20via%20the%20generic%20%60PartEndEvent%60%20branch%2C%20including%20%60ThinkingPart%60.%20If%20the%20Agentex%20server%20or%20client%20treats%20reasoning%20channels%20as%20never%20receiving%20a%20done%20event%20%28relying%20only%20on%20the%20last%20delta%20to%20close%20them%29%2C%20this%20extra%20%60Done%60%20for%20thinking%20parts%20will%20cause%20a%20behavioral%20mismatch.%20End-to-end%20tests%20are%20still%20pending%2C%20making%20this%20a%20silent%20risk.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%0ALine%3A%20448-452%0A%0AComment%3A%0A**%60ThinkingPart%60%20end%20emits%20%60StreamTaskMessageDone%60%20%E2%80%94%20inconsistent%20with%20existing%20reasoning-channel%20contract**%0A%0A%60sync_provider.py%60%20%28the%20established%20OpenAI%20converter%29%20explicitly%20skips%20%60StreamTaskMessageDone%60%20for%20reasoning%2Fthinking%20channels%3A%20%60if%20message_type%20not%20in%20%28%22reasoning_content%22%2C%20%22reasoning_summary%22%29%3A%20yield%20StreamTaskMessageDone%28...%29%60.%20The%20%60pydantic_ai.py%60%20converter%20emits%20%60Done%60%20for%20**all**%20parts%20via%20the%20generic%20%60PartEndEvent%60%20branch%2C%20including%20%60ThinkingPart%60.%20If%20the%20Agentex%20server%20or%20client%20treats%20reasoning%20channels%20as%20never%20receiving%20a%20done%20event%20%28relying%20only%20on%20the%20last%20delta%20to%20close%20them%29%2C%20this%20extra%20%60Done%60%20for%20thinking%20parts%20will%20cause%20a%20behavioral%20mismatch.%20End-to-end%20tests%20are%20still%20pending%2C%20making%20this%20a%20silent%20risk.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22dm%2Fpydantic-ai-sync-streaming%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dm%2Fpydantic-ai-sync-streaming%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%0ALine%3A%20448-452%0A%0AComment%3A%0A**%60ThinkingPart%60%20end%20emits%20%60StreamTaskMessageDone%60%20%E2%80%94%20inconsistent%20with%20existing%20reasoning-channel%20contract**%0A%0A%60sync_provider.py%60%20%28the%20established%20OpenAI%20converter%29%20explicitly%20skips%20%60StreamTaskMessageDone%60%20for%20reasoning%2Fthinking%20channels%3A%20%60if%20message_type%20not%20in%20%28%22reasoning_content%22%2C%20%22reasoning_summary%22%29%3A%20yield%20StreamTaskMessageDone%28...%29%60.%20The%20%60pydantic_ai.py%60%20converter%20emits%20%60Done%60%20for%20**all**%20parts%20via%20the%20generic%20%60PartEndEvent%60%20branch%2C%20including%20%60ThinkingPart%60.%20If%20the%20Agentex%20server%20or%20client%20treats%20reasoning%20channels%20as%20never%20receiving%20a%20done%20event%20%28relying%20only%20on%20the%20last%20delta%20to%20close%20them%29%2C%20this%20extra%20%60Done%60%20for%20thinking%20parts%20will%20cause%20a%20behavioral%20mismatch.%20End-to-end%20tests%20are%20still%20pending%2C%20making%20this%20a%20silent%20risk.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>


2. `tests/lib/adk/providers/test_pydantic_ai.py`, line 820-853 ([link](https://github.com/scaleapi/scale-agentex-python/blob/ea22edcc63666ed4b4a01886f2880185418c382e/tests/lib/adk/providers/test_pydantic_ai.py#L820-L853)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`AgentRunResultEvent` missing from ignored-events test suite**

   The converter imports and explicitly handles `AgentRunResultEvent` in the `FunctionToolCallEvent | FinalResultEvent | AgentRunResultEvent` branch, but `TestIgnoredEvents` only verifies `FunctionToolCallEvent` and `FinalResultEvent`. Adding a test mirroring `test_final_result_event_ignored` for `AgentRunResultEvent` (requiring `from pydantic_ai.run import AgentRunResultEvent`) would close the coverage gap and confirm the import path is correct.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/lib/adk/providers/test_pydantic_ai.py
   Line: 820-853

   Comment:
   **`AgentRunResultEvent` missing from ignored-events test suite**

   The converter imports and explicitly handles `AgentRunResultEvent` in the `FunctionToolCallEvent | FinalResultEvent | AgentRunResultEvent` branch, but `TestIgnoredEvents` only verifies `FunctionToolCallEvent` and `FinalResultEvent`. Adding a test mirroring `test_final_result_event_ignored` for `AgentRunResultEvent` (requiring `from pydantic_ai.run import AgentRunResultEvent`) would close the coverage gap and confirm the import path is correct.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Flib%2Fadk%2Fproviders%2Ftest_pydantic_ai.py%0ALine%3A%20820-853%0A%0AComment%3A%0A**%60AgentRunResultEvent%60%20missing%20from%20ignored-events%20test%20suite**%0A%0AThe%20converter%20imports%20and%20explicitly%20handles%20%60AgentRunResultEvent%60%20in%20the%20%60FunctionToolCallEvent%20%7C%20FinalResultEvent%20%7C%20AgentRunResultEvent%60%20branch%2C%20but%20%60TestIgnoredEvents%60%20only%20verifies%20%60FunctionToolCallEvent%60%20and%20%60FinalResultEvent%60.%20Adding%20a%20test%20mirroring%20%60test_final_result_event_ignored%60%20for%20%60AgentRunResultEvent%60%20%28requiring%20%60from%20pydantic_ai.run%20import%20AgentRunResultEvent%60%29%20would%20close%20the%20coverage%20gap%20and%20confirm%20the%20import%20path%20is%20correct.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Flib%2Fadk%2Fproviders%2Ftest_pydantic_ai.py%0ALine%3A%20820-853%0A%0AComment%3A%0A**%60AgentRunResultEvent%60%20missing%20from%20ignored-events%20test%20suite**%0A%0AThe%20converter%20imports%20and%20explicitly%20handles%20%60AgentRunResultEvent%60%20in%20the%20%60FunctionToolCallEvent%20%7C%20FinalResultEvent%20%7C%20AgentRunResultEvent%60%20branch%2C%20but%20%60TestIgnoredEvents%60%20only%20verifies%20%60FunctionToolCallEvent%60%20and%20%60FinalResultEvent%60.%20Adding%20a%20test%20mirroring%20%60test_final_result_event_ignored%60%20for%20%60AgentRunResultEvent%60%20%28requiring%20%60from%20pydantic_ai.run%20import%20AgentRunResultEvent%60%29%20would%20close%20the%20coverage%20gap%20and%20confirm%20the%20import%20path%20is%20correct.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22dm%2Fpydantic-ai-sync-streaming%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dm%2Fpydantic-ai-sync-streaming%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Flib%2Fadk%2Fproviders%2Ftest_pydantic_ai.py%0ALine%3A%20820-853%0A%0AComment%3A%0A**%60AgentRunResultEvent%60%20missing%20from%20ignored-events%20test%20suite**%0A%0AThe%20converter%20imports%20and%20explicitly%20handles%20%60AgentRunResultEvent%60%20in%20the%20%60FunctionToolCallEvent%20%7C%20FinalResultEvent%20%7C%20AgentRunResultEvent%60%20branch%2C%20but%20%60TestIgnoredEvents%60%20only%20verifies%20%60FunctionToolCallEvent%60%20and%20%60FinalResultEvent%60.%20Adding%20a%20test%20mirroring%20%60test_final_result_event_ignored%60%20for%20%60AgentRunResultEvent%60%20%28requiring%20%60from%20pydantic_ai.run%20import%20AgentRunResultEvent%60%29%20would%20close%20the%20coverage%20gap%20and%20confirm%20the%20import%20path%20is%20correct.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%3A448-452%0A**%60ThinkingPart%60%20end%20emits%20%60StreamTaskMessageDone%60%20%E2%80%94%20inconsistent%20with%20existing%20reasoning-channel%20contract**%0A%0A%60sync_provider.py%60%20%28the%20established%20OpenAI%20converter%29%20explicitly%20skips%20%60StreamTaskMessageDone%60%20for%20reasoning%2Fthinking%20channels%3A%20%60if%20message_type%20not%20in%20%28%22reasoning_content%22%2C%20%22reasoning_summary%22%29%3A%20yield%20StreamTaskMessageDone%28...%29%60.%20The%20%60pydantic_ai.py%60%20converter%20emits%20%60Done%60%20for%20**all**%20parts%20via%20the%20generic%20%60PartEndEvent%60%20branch%2C%20including%20%60ThinkingPart%60.%20If%20the%20Agentex%20server%20or%20client%20treats%20reasoning%20channels%20as%20never%20receiving%20a%20done%20event%20%28relying%20only%20on%20the%20last%20delta%20to%20close%20them%29%2C%20this%20extra%20%60Done%60%20for%20thinking%20parts%20will%20cause%20a%20behavioral%20mismatch.%20End-to-end%20tests%20are%20still%20pending%2C%20making%20this%20a%20silent%20risk.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%3A73-77%0A**Multiple%20consecutive%20dict-type%20%60args_delta%60%20values%20produce%20invalid%20concatenated%20JSON**%0A%0AWhen%20a%20provider%20emits%20more%20than%20one%20%60ToolCallPartDelta%60%20with%20a%20%60dict%60%20%60args_delta%60%2C%20each%20call%20to%20%60json.dumps%60%20produces%20a%20standalone%20JSON%20object%20%28e.g.%20%60'%7B%22a%22%3A1%7D'%60%29.%20These%20get%20concatenated%20server-side%20as%20%60'%7B%22a%22%3A1%7D%7B%22b%22%3A2%7D'%60%2C%20which%20is%20not%20valid%20JSON%20and%20will%20fail%20to%20parse%20on%20completion.%20The%20docstring%20says%20%22in%20practice%20dict%20deltas%20arrive%20as%20a%20single%20final%20fragment%22%2C%20but%20that%20assumption%20is%20not%20enforced.%20Adding%20a%20warning%20log%20makes%20the%20failure%20visible%20rather%20than%20silently%20corrupt.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20args_delta%20is%20None%3A%0A%20%20%20%20%20%20%20%20return%20%22%22%0A%20%20%20%20if%20isinstance%28args_delta%2C%20str%29%3A%0A%20%20%20%20%20%20%20%20return%20args_delta%0A%20%20%20%20%23%20Dict%20deltas%20are%20one-shot%3A%20multiple%20dicts%20would%20concatenate%20to%20invalid%20JSON.%0A%20%20%20%20%23%20Log%20a%20warning%20so%20callers%20are%20not%20silently%20surprised.%0A%20%20%20%20logger.warning%28%0A%20%20%20%20%20%20%20%20%22ToolCallPartDelta.args_delta%20is%20a%20dict%3B%20converting%20with%20json.dumps.%20%22%0A%20%20%20%20%20%20%20%20%22Multiple%20dict%20deltas%20will%20not%20compose%20to%20valid%20JSON.%22%0A%20%20%20%20%29%0A%20%20%20%20return%20json.dumps%28args_delta%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Flib%2Fadk%2Fproviders%2Ftest_pydantic_ai.py%3A820-853%0A**%60AgentRunResultEvent%60%20missing%20from%20ignored-events%20test%20suite**%0A%0AThe%20converter%20imports%20and%20explicitly%20handles%20%60AgentRunResultEvent%60%20in%20the%20%60FunctionToolCallEvent%20%7C%20FinalResultEvent%20%7C%20AgentRunResultEvent%60%20branch%2C%20but%20%60TestIgnoredEvents%60%20only%20verifies%20%60FunctionToolCallEvent%60%20and%20%60FinalResultEvent%60.%20Adding%20a%20test%20mirroring%20%60test_final_result_event_ignored%60%20for%20%60AgentRunResultEvent%60%20%28requiring%20%60from%20pydantic_ai.run%20import%20AgentRunResultEvent%60%29%20would%20close%20the%20coverage%20gap%20and%20confirm%20the%20import%20path%20is%20correct.%0A%0A&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%3A448-452%0A**%60ThinkingPart%60%20end%20emits%20%60StreamTaskMessageDone%60%20%E2%80%94%20inconsistent%20with%20existing%20reasoning-channel%20contract**%0A%0A%60sync_provider.py%60%20%28the%20established%20OpenAI%20converter%29%20explicitly%20skips%20%60StreamTaskMessageDone%60%20for%20reasoning%2Fthinking%20channels%3A%20%60if%20message_type%20not%20in%20%28%22reasoning_content%22%2C%20%22reasoning_summary%22%29%3A%20yield%20StreamTaskMessageDone%28...%29%60.%20The%20%60pydantic_ai.py%60%20converter%20emits%20%60Done%60%20for%20**all**%20parts%20via%20the%20generic%20%60PartEndEvent%60%20branch%2C%20including%20%60ThinkingPart%60.%20If%20the%20Agentex%20server%20or%20client%20treats%20reasoning%20channels%20as%20never%20receiving%20a%20done%20event%20%28relying%20only%20on%20the%20last%20delta%20to%20close%20them%29%2C%20this%20extra%20%60Done%60%20for%20thinking%20parts%20will%20cause%20a%20behavioral%20mismatch.%20End-to-end%20tests%20are%20still%20pending%2C%20making%20this%20a%20silent%20risk.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%3A73-77%0A**Multiple%20consecutive%20dict-type%20%60args_delta%60%20values%20produce%20invalid%20concatenated%20JSON**%0A%0AWhen%20a%20provider%20emits%20more%20than%20one%20%60ToolCallPartDelta%60%20with%20a%20%60dict%60%20%60args_delta%60%2C%20each%20call%20to%20%60json.dumps%60%20produces%20a%20standalone%20JSON%20object%20%28e.g.%20%60'%7B%22a%22%3A1%7D'%60%29.%20These%20get%20concatenated%20server-side%20as%20%60'%7B%22a%22%3A1%7D%7B%22b%22%3A2%7D'%60%2C%20which%20is%20not%20valid%20JSON%20and%20will%20fail%20to%20parse%20on%20completion.%20The%20docstring%20says%20%22in%20practice%20dict%20deltas%20arrive%20as%20a%20single%20final%20fragment%22%2C%20but%20that%20assumption%20is%20not%20enforced.%20Adding%20a%20warning%20log%20makes%20the%20failure%20visible%20rather%20than%20silently%20corrupt.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20args_delta%20is%20None%3A%0A%20%20%20%20%20%20%20%20return%20%22%22%0A%20%20%20%20if%20isinstance%28args_delta%2C%20str%29%3A%0A%20%20%20%20%20%20%20%20return%20args_delta%0A%20%20%20%20%23%20Dict%20deltas%20are%20one-shot%3A%20multiple%20dicts%20would%20concatenate%20to%20invalid%20JSON.%0A%20%20%20%20%23%20Log%20a%20warning%20so%20callers%20are%20not%20silently%20surprised.%0A%20%20%20%20logger.warning%28%0A%20%20%20%20%20%20%20%20%22ToolCallPartDelta.args_delta%20is%20a%20dict%3B%20converting%20with%20json.dumps.%20%22%0A%20%20%20%20%20%20%20%20%22Multiple%20dict%20deltas%20will%20not%20compose%20to%20valid%20JSON.%22%0A%20%20%20%20%29%0A%20%20%20%20return%20json.dumps%28args_delta%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Flib%2Fadk%2Fproviders%2Ftest_pydantic_ai.py%3A820-853%0A**%60AgentRunResultEvent%60%20missing%20from%20ignored-events%20test%20suite**%0A%0AThe%20converter%20imports%20and%20explicitly%20handles%20%60AgentRunResultEvent%60%20in%20the%20%60FunctionToolCallEvent%20%7C%20FinalResultEvent%20%7C%20AgentRunResultEvent%60%20branch%2C%20but%20%60TestIgnoredEvents%60%20only%20verifies%20%60FunctionToolCallEvent%60%20and%20%60FinalResultEvent%60.%20Adding%20a%20test%20mirroring%20%60test_final_result_event_ignored%60%20for%20%60AgentRunResultEvent%60%20%28requiring%20%60from%20pydantic_ai.run%20import%20AgentRunResultEvent%60%29%20would%20close%20the%20coverage%20gap%20and%20confirm%20the%20import%20path%20is%20correct.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22dm%2Fpydantic-ai-sync-streaming%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dm%2Fpydantic-ai-sync-streaming%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%3A448-452%0A**%60ThinkingPart%60%20end%20emits%20%60StreamTaskMessageDone%60%20%E2%80%94%20inconsistent%20with%20existing%20reasoning-channel%20contract**%0A%0A%60sync_provider.py%60%20%28the%20established%20OpenAI%20converter%29%20explicitly%20skips%20%60StreamTaskMessageDone%60%20for%20reasoning%2Fthinking%20channels%3A%20%60if%20message_type%20not%20in%20%28%22reasoning_content%22%2C%20%22reasoning_summary%22%29%3A%20yield%20StreamTaskMessageDone%28...%29%60.%20The%20%60pydantic_ai.py%60%20converter%20emits%20%60Done%60%20for%20**all**%20parts%20via%20the%20generic%20%60PartEndEvent%60%20branch%2C%20including%20%60ThinkingPart%60.%20If%20the%20Agentex%20server%20or%20client%20treats%20reasoning%20channels%20as%20never%20receiving%20a%20done%20event%20%28relying%20only%20on%20the%20last%20delta%20to%20close%20them%29%2C%20this%20extra%20%60Done%60%20for%20thinking%20parts%20will%20cause%20a%20behavioral%20mismatch.%20End-to-end%20tests%20are%20still%20pending%2C%20making%20this%20a%20silent%20risk.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentex%2Flib%2Fadk%2Fproviders%2F_modules%2Fpydantic_ai.py%3A73-77%0A**Multiple%20consecutive%20dict-type%20%60args_delta%60%20values%20produce%20invalid%20concatenated%20JSON**%0A%0AWhen%20a%20provider%20emits%20more%20than%20one%20%60ToolCallPartDelta%60%20with%20a%20%60dict%60%20%60args_delta%60%2C%20each%20call%20to%20%60json.dumps%60%20produces%20a%20standalone%20JSON%20object%20%28e.g.%20%60'%7B%22a%22%3A1%7D'%60%29.%20These%20get%20concatenated%20server-side%20as%20%60'%7B%22a%22%3A1%7D%7B%22b%22%3A2%7D'%60%2C%20which%20is%20not%20valid%20JSON%20and%20will%20fail%20to%20parse%20on%20completion.%20The%20docstring%20says%20%22in%20practice%20dict%20deltas%20arrive%20as%20a%20single%20final%20fragment%22%2C%20but%20that%20assumption%20is%20not%20enforced.%20Adding%20a%20warning%20log%20makes%20the%20failure%20visible%20rather%20than%20silently%20corrupt.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20args_delta%20is%20None%3A%0A%20%20%20%20%20%20%20%20return%20%22%22%0A%20%20%20%20if%20isinstance%28args_delta%2C%20str%29%3A%0A%20%20%20%20%20%20%20%20return%20args_delta%0A%20%20%20%20%23%20Dict%20deltas%20are%20one-shot%3A%20multiple%20dicts%20would%20concatenate%20to%20invalid%20JSON.%0A%20%20%20%20%23%20Log%20a%20warning%20so%20callers%20are%20not%20silently%20surprised.%0A%20%20%20%20logger.warning%28%0A%20%20%20%20%20%20%20%20%22ToolCallPartDelta.args_delta%20is%20a%20dict%3B%20converting%20with%20json.dumps.%20%22%0A%20%20%20%20%20%20%20%20%22Multiple%20dict%20deltas%20will%20not%20compose%20to%20valid%20JSON.%22%0A%20%20%20%20%29%0A%20%20%20%20return%20json.dumps%28args_delta%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Flib%2Fadk%2Fproviders%2Ftest_pydantic_ai.py%3A820-853%0A**%60AgentRunResultEvent%60%20missing%20from%20ignored-events%20test%20suite**%0A%0AThe%20converter%20imports%20and%20explicitly%20handles%20%60AgentRunResultEvent%60%20in%20the%20%60FunctionToolCallEvent%20%7C%20FinalResultEvent%20%7C%20AgentRunResultEvent%60%20branch%2C%20but%20%60TestIgnoredEvents%60%20only%20verifies%20%60FunctionToolCallEvent%60%20and%20%60FinalResultEvent%60.%20Adding%20a%20test%20mirroring%20%60test_final_result_event_ignored%60%20for%20%60AgentRunResultEvent%60%20%28requiring%20%60from%20pydantic_ai.run%20import%20AgentRunResultEvent%60%29%20would%20close%20the%20coverage%20gap%20and%20confirm%20the%20import%20path%20is%20correct.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/agentex/lib/adk/providers/_modules/pydantic_ai.py:448-452
**`ThinkingPart` end emits `StreamTaskMessageDone` — inconsistent with existing reasoning-channel contract**

`sync_provider.py` (the established OpenAI converter) explicitly skips `StreamTaskMessageDone` for reasoning/thinking channels: `if message_type not in ("reasoning_content", "reasoning_summary"): yield StreamTaskMessageDone(...)`. The `pydantic_ai.py` converter emits `Done` for **all** parts via the generic `PartEndEvent` branch, including `ThinkingPart`. If the Agentex server or client treats reasoning channels as never receiving a done event (relying only on the last delta to close them), this extra `Done` for thinking parts will cause a behavioral mismatch. End-to-end tests are still pending, making this a silent risk.

### Issue 2 of 3
src/agentex/lib/adk/providers/_modules/pydantic_ai.py:73-77
**Multiple consecutive dict-type `args_delta` values produce invalid concatenated JSON**

When a provider emits more than one `ToolCallPartDelta` with a `dict` `args_delta`, each call to `json.dumps` produces a standalone JSON object (e.g. `'{"a":1}'`). These get concatenated server-side as `'{"a":1}{"b":2}'`, which is not valid JSON and will fail to parse on completion. The docstring says "in practice dict deltas arrive as a single final fragment", but that assumption is not enforced. Adding a warning log makes the failure visible rather than silently corrupt.

```suggestion
    if args_delta is None:
        return ""
    if isinstance(args_delta, str):
        return args_delta
    # Dict deltas are one-shot: multiple dicts would concatenate to invalid JSON.
    # Log a warning so callers are not silently surprised.
    logger.warning(
        "ToolCallPartDelta.args_delta is a dict; converting with json.dumps. "
        "Multiple dict deltas will not compose to valid JSON."
    )
    return json.dumps(args_delta)
```

### Issue 3 of 3
tests/lib/adk/providers/test_pydantic_ai.py:820-853
**`AgentRunResultEvent` missing from ignored-events test suite**

The converter imports and explicitly handles `AgentRunResultEvent` in the `FunctionToolCallEvent | FinalResultEvent | AgentRunResultEvent` branch, but `TestIgnoredEvents` only verifies `FunctionToolCallEvent` and `FinalResultEvent`. Adding a test mirroring `test_final_result_event_ignored` for `AgentRunResultEvent` (requiring `from pydantic_ai.run import AgentRunResultEvent`) would close the coverage gap and confirm the import path is correct.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Pydantic AI sync streaming con..."](https://github.com/scaleapi/scale-agentex-python/commit/ea22edcc63666ed4b4a01886f2880185418c382e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31409196)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->