### PR TITLE
fix(tracing): make SGP processor stateless to stop dropping span closes

### DIFF
--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import override
+from typing import cast, override
 
 import scale_gp_beta.lib.tracing as tracing
 from scale_gp_beta import SGPClient, AsyncSGPClient
@@ -38,7 +38,6 @@ class SGPSyncTracingProcessor(SyncTracingProcessor):
             ),
             disabled=disabled,
         )
-        self._spans: dict[str, SGPSpan] = {}
         self.env_vars = EnvironmentVariables.refresh()
 
     def _add_source_to_span(self, span: Span) -> None:
@@ -53,48 +52,44 @@ class SGPSyncTracingProcessor(SyncTracingProcessor):
             if self.env_vars.AGENT_ID is not None:
                 span.data["__agent_id__"] = self.env_vars.AGENT_ID
 
-    @override
-    def on_span_start(self, span: Span) -> None:
+    def _build_sgp_span(self, span: Span) -> SGPSpan:
+        """Build an SGPSpan from an agentex Span. Idempotent on span_id at the SGP backend."""
         self._add_source_to_span(span)
-
-        sgp_span = create_span(
-            name=span.name,
-            span_type=_get_span_type(span),
-            span_id=span.id,
-            parent_id=span.parent_id,
-            trace_id=span.trace_id,
-            input=span.input,
-            output=span.output,
-            metadata=span.data,
+        sgp_span = cast(
+            SGPSpan,
+            create_span(
+                name=span.name,
+                span_type=_get_span_type(span),
+                span_id=span.id,
+                parent_id=span.parent_id,
+                trace_id=span.trace_id,
+                input=span.input,
+                output=span.output,
+                metadata=span.data,
+            ),
         )
         sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
-        sgp_span.flush(blocking=False)
+        return sgp_span
 
-        self._spans[span.id] = sgp_span
+    @override
+    def on_span_start(self, span: Span) -> None:
+        sgp_span = self._build_sgp_span(span)
+        sgp_span.flush(blocking=False)
 
     @override
     def on_span_end(self, span: Span) -> None:
-        sgp_span = self._spans.pop(span.id, None)
-        if sgp_span is None:
-            logger.warning(f"Span {span.id} not found in stored spans, skipping span end")
-            return
-
-        self._add_source_to_span(span)
-        sgp_span.output = span.output  # type: ignore[assignment]
-        sgp_span.metadata = span.data  # type: ignore[assignment]
+        sgp_span = self._build_sgp_span(span)
         sgp_span.end_time = span.end_time.isoformat()  # type: ignore[union-attr]
         sgp_span.flush(blocking=False)
 
     @override
     def shutdown(self) -> None:
-        self._spans.clear()
         flush_queue()
 
 
 class SGPAsyncTracingProcessor(AsyncTracingProcessor):
     def __init__(self, config: SGPTracingProcessorConfig):
         self.disabled = config.sgp_api_key == "" or config.sgp_account_id == ""
-        self._spans: dict[str, SGPSpan] = {}
         import httpx
 
         # Disable keepalive so each HTTP call gets a fresh TCP connection,
@@ -125,6 +120,25 @@ class SGPAsyncTracingProcessor(AsyncTracingProcessor):
             if self.env_vars.AGENT_ID is not None:
                 span.data["__agent_id__"] = self.env_vars.AGENT_ID
 
+    def _build_sgp_span(self, span: Span) -> SGPSpan:
+        """Build an SGPSpan from an agentex Span. Idempotent on span_id at the SGP backend."""
+        self._add_source_to_span(span)
+        sgp_span = cast(
+            SGPSpan,
+            create_span(
+                name=span.name,
+                span_type=_get_span_type(span),
+                span_id=span.id,
+                parent_id=span.parent_id,
+                trace_id=span.trace_id,
+                input=span.input,
+                output=span.output,
+                metadata=span.data,
+            ),
+        )
+        sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
+        return sgp_span
+
     @override
     async def on_span_start(self, span: Span) -> None:
         await self.on_spans_start([span])
@@ -138,22 +152,7 @@ class SGPAsyncTracingProcessor(AsyncTracingProcessor):
         if not spans:
             return
 
-        sgp_spans: list[SGPSpan] = []
-        for span in spans:
-            self._add_source_to_span(span)
-            sgp_span = create_span(
-                name=span.name,
-                span_type=_get_span_type(span),
-                span_id=span.id,
-                parent_id=span.parent_id,
-                trace_id=span.trace_id,
-                input=span.input,
-                output=span.output,
-                metadata=span.data,
-            )
-            sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
-            self._spans[span.id] = sgp_span
-            sgp_spans.append(sgp_span)
+        sgp_spans = [self._build_sgp_span(span) for span in spans]
 
         if self.disabled:
             logger.warning("SGP is disabled, skipping span upsert")
@@ -167,29 +166,18 @@ class SGPAsyncTracingProcessor(AsyncTracingProcessor):
         if not spans:
             return
 
-        to_upsert: list[SGPSpan] = []
+        sgp_spans: list[SGPSpan] = []
         for span in spans:
-            sgp_span = self._spans.pop(span.id, None)
-            if sgp_span is None:
-                logger.warning(f"Span {span.id} not found in stored spans, skipping span end")
-                continue
-
-            self._add_source_to_span(span)
-            sgp_span.input = span.input  # type: ignore[assignment]
-            sgp_span.output = span.output  # type: ignore[assignment]
-            sgp_span.metadata = span.data  # type: ignore[assignment]
+            sgp_span = self._build_sgp_span(span)
             sgp_span.end_time = span.end_time.isoformat()  # type: ignore[union-attr]
-            to_upsert.append(sgp_span)
+            sgp_spans.append(sgp_span)
 
-        if self.disabled or not to_upsert:
+        if self.disabled:
             return
         await self.sgp_async_client.spans.upsert_batch(  # type: ignore[union-attr]
-            items=[s.to_request_params() for s in to_upsert]
+            items=[s.to_request_params() for s in sgp_spans]
         )
 
     @override
     async def shutdown(self) -> None:
-        await self.sgp_async_client.spans.upsert_batch(  # type: ignore[union-attr]
-            items=[sgp_span.to_request_params() for sgp_span in self._spans.values()]
-        )
-        self._spans.clear()
+        pass

--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -27,6 +27,39 @@ def _get_span_type(span: Span) -> str:
     return "STANDALONE"
 
 
+def _add_source_to_span(span: Span, env_vars: EnvironmentVariables) -> None:
+    if span.data is None:
+        span.data = {}
+    if isinstance(span.data, dict):
+        span.data["__source__"] = "agentex"
+        if env_vars.ACP_TYPE is not None:
+            span.data["__acp_type__"] = env_vars.ACP_TYPE
+        if env_vars.AGENT_NAME is not None:
+            span.data["__agent_name__"] = env_vars.AGENT_NAME
+        if env_vars.AGENT_ID is not None:
+            span.data["__agent_id__"] = env_vars.AGENT_ID
+
+
+def _build_sgp_span(span: Span, env_vars: EnvironmentVariables) -> SGPSpan:
+    """Build an SGPSpan from an agentex Span. Idempotent on span_id at the SGP backend."""
+    _add_source_to_span(span, env_vars)
+    sgp_span = cast(
+        SGPSpan,
+        create_span(
+            name=span.name,
+            span_type=_get_span_type(span),
+            span_id=span.id,
+            parent_id=span.parent_id,
+            trace_id=span.trace_id,
+            input=span.input,
+            output=span.output,
+            metadata=span.data,
+        ),
+    )
+    sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
+    return sgp_span
+
+
 class SGPSyncTracingProcessor(SyncTracingProcessor):
     def __init__(self, config: SGPTracingProcessorConfig):
         disabled = config.sgp_api_key == "" or config.sgp_account_id == ""
@@ -40,45 +73,14 @@ class SGPSyncTracingProcessor(SyncTracingProcessor):
         )
         self.env_vars = EnvironmentVariables.refresh()
 
-    def _add_source_to_span(self, span: Span) -> None:
-        if span.data is None:
-            span.data = {}
-        if isinstance(span.data, dict):
-            span.data["__source__"] = "agentex"
-            if self.env_vars.ACP_TYPE is not None:
-                span.data["__acp_type__"] = self.env_vars.ACP_TYPE
-            if self.env_vars.AGENT_NAME is not None:
-                span.data["__agent_name__"] = self.env_vars.AGENT_NAME
-            if self.env_vars.AGENT_ID is not None:
-                span.data["__agent_id__"] = self.env_vars.AGENT_ID
-
-    def _build_sgp_span(self, span: Span) -> SGPSpan:
-        """Build an SGPSpan from an agentex Span. Idempotent on span_id at the SGP backend."""
-        self._add_source_to_span(span)
-        sgp_span = cast(
-            SGPSpan,
-            create_span(
-                name=span.name,
-                span_type=_get_span_type(span),
-                span_id=span.id,
-                parent_id=span.parent_id,
-                trace_id=span.trace_id,
-                input=span.input,
-                output=span.output,
-                metadata=span.data,
-            ),
-        )
-        sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
-        return sgp_span
-
     @override
     def on_span_start(self, span: Span) -> None:
-        sgp_span = self._build_sgp_span(span)
+        sgp_span = _build_sgp_span(span, self.env_vars)
         sgp_span.flush(blocking=False)
 
     @override
     def on_span_end(self, span: Span) -> None:
-        sgp_span = self._build_sgp_span(span)
+        sgp_span = _build_sgp_span(span, self.env_vars)
         sgp_span.end_time = span.end_time.isoformat()  # type: ignore[union-attr]
         sgp_span.flush(blocking=False)
 
@@ -108,37 +110,6 @@ class SGPAsyncTracingProcessor(AsyncTracingProcessor):
         )
         self.env_vars = EnvironmentVariables.refresh()
 
-    def _add_source_to_span(self, span: Span) -> None:
-        if span.data is None:
-            span.data = {}
-        if isinstance(span.data, dict):
-            span.data["__source__"] = "agentex"
-            if self.env_vars.ACP_TYPE is not None:
-                span.data["__acp_type__"] = self.env_vars.ACP_TYPE
-            if self.env_vars.AGENT_NAME is not None:
-                span.data["__agent_name__"] = self.env_vars.AGENT_NAME
-            if self.env_vars.AGENT_ID is not None:
-                span.data["__agent_id__"] = self.env_vars.AGENT_ID
-
-    def _build_sgp_span(self, span: Span) -> SGPSpan:
-        """Build an SGPSpan from an agentex Span. Idempotent on span_id at the SGP backend."""
-        self._add_source_to_span(span)
-        sgp_span = cast(
-            SGPSpan,
-            create_span(
-                name=span.name,
-                span_type=_get_span_type(span),
-                span_id=span.id,
-                parent_id=span.parent_id,
-                trace_id=span.trace_id,
-                input=span.input,
-                output=span.output,
-                metadata=span.data,
-            ),
-        )
-        sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
-        return sgp_span
-
     @override
     async def on_span_start(self, span: Span) -> None:
         await self.on_spans_start([span])
@@ -152,7 +123,7 @@ class SGPAsyncTracingProcessor(AsyncTracingProcessor):
         if not spans:
             return
 
-        sgp_spans = [self._build_sgp_span(span) for span in spans]
+        sgp_spans = [_build_sgp_span(span, self.env_vars) for span in spans]
 
         if self.disabled:
             logger.warning("SGP is disabled, skipping span upsert")
@@ -168,7 +139,7 @@ class SGPAsyncTracingProcessor(AsyncTracingProcessor):
 
         sgp_spans: list[SGPSpan] = []
         for span in spans:
-            sgp_span = self._build_sgp_span(span)
+            sgp_span = _build_sgp_span(span, self.env_vars)
             sgp_span.end_time = span.end_time.isoformat()  # type: ignore[union-attr]
             sgp_spans.append(sgp_span)
 

--- a/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
@@ -180,7 +180,8 @@ class TestSGPAsyncTracingProcessor:
             captured.append(sgp_span)
             return sgp_span
 
-        with patch(f"{MODULE}.create_span", side_effect=capture_create_span):
+        mock_create_span = MagicMock(side_effect=capture_create_span)
+        with patch(f"{MODULE}.create_span", mock_create_span):
             span = _make_span()
             span.input = {"messages": [{"role": "user", "content": "hello"}]}
             await processor.on_span_start(span)
@@ -199,6 +200,10 @@ class TestSGPAsyncTracingProcessor:
         # The end-time SGPSpan should have end_time populated.
         end_span = captured[-1]
         assert end_span.end_time is not None
+        # Verify the updated input/output reached create_span on the end call.
+        end_call_kwargs = mock_create_span.call_args_list[-1].kwargs
+        assert end_call_kwargs["input"]["messages"][-1]["role"] == "assistant"
+        assert end_call_kwargs["output"] == {"response": "hi"}
 
     async def test_on_spans_start_sends_single_upsert_for_batch(self):
         """Given N spans at once, on_spans_start should make ONE upsert_batch HTTP call."""

--- a/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
@@ -41,18 +41,16 @@ def _make_mock_sgp_span() -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-class TestSGPSyncTracingProcessorMemoryLeak:
+class TestSGPSyncTracingProcessor:
     @staticmethod
     def _make_processor():
         mock_env = MagicMock()
         mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None)
         mock_create_span = MagicMock(side_effect=lambda **kwargs: _make_mock_sgp_span())
 
-        with patch(f"{MODULE}.EnvironmentVariables", mock_env), \
-             patch(f"{MODULE}.SGPClient"), \
-             patch(f"{MODULE}.tracing"), \
-             patch(f"{MODULE}.flush_queue"), \
-             patch(f"{MODULE}.create_span", mock_create_span):
+        with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(f"{MODULE}.SGPClient"), patch(
+            f"{MODULE}.tracing"
+        ), patch(f"{MODULE}.flush_queue"), patch(f"{MODULE}.create_span", mock_create_span):
             from agentex.lib.core.tracing.processors.sgp_tracing_processor import (
                 SGPSyncTracingProcessor,
             )
@@ -61,41 +59,50 @@ class TestSGPSyncTracingProcessorMemoryLeak:
 
         return processor, mock_create_span
 
-    def test_spans_not_leaked_after_completed_lifecycle(self):
+    def test_processor_holds_no_per_span_state(self):
+        """Stateless processor must not retain any per-span dict between lifecycle events."""
+        processor, _ = self._make_processor()
+        assert not hasattr(processor, "_spans")
+
+    def test_span_lifecycle_produces_two_flushes(self):
+        """Each span produces one flush on start and one on end."""
         processor, _ = self._make_processor()
 
-        with patch(f"{MODULE}.create_span", side_effect=lambda **kw: _make_mock_sgp_span()):
+        with patch(f"{MODULE}.create_span", side_effect=lambda **kw: _make_mock_sgp_span()) as mock_cs:
             for _ in range(100):
                 span = _make_span()
                 processor.on_span_start(span)
                 span.end_time = datetime.now(UTC)
                 processor.on_span_end(span)
 
-        assert len(processor._spans) == 0, (
-            f"Expected 0 spans after 100 complete lifecycles, got {len(processor._spans)} — memory leak!"
-        )
+        # 100 spans × (1 start + 1 end) = 200 build calls.
+        assert mock_cs.call_count == 200
 
-    def test_spans_present_during_active_lifecycle(self):
+    def test_span_end_without_prior_start_still_flushes(self):
+        """Cross-pod Temporal case: END activity lands on a pod that never saw START.
+
+        Today this used to be a silent no-op. After the stateless refactor it
+        must still flush a complete span (start_time + end_time + payload).
+        """
         processor, _ = self._make_processor()
 
-        with patch(f"{MODULE}.create_span", side_effect=lambda **kw: _make_mock_sgp_span()):
+        captured_spans: list[MagicMock] = []
+
+        def capture_create_span(**kwargs):
+            sgp_span = _make_mock_sgp_span()
+            captured_spans.append(sgp_span)
+            return sgp_span
+
+        with patch(f"{MODULE}.create_span", side_effect=capture_create_span):
             span = _make_span()
-            processor.on_span_start(span)
-            assert len(processor._spans) == 1, "Span should be tracked while active"
-
             span.end_time = datetime.now(UTC)
+            # No on_span_start — END lands here for the first time.
             processor.on_span_end(span)
-            assert len(processor._spans) == 0, "Span should be removed after end"
 
-    def test_span_end_for_unknown_span_is_noop(self):
-        processor, _ = self._make_processor()
-
-        span = _make_span()
-        # End a span that was never started — should not raise
-        span.end_time = datetime.now(UTC)
-        processor.on_span_end(span)
-
-        assert len(processor._spans) == 0
+        assert len(captured_spans) == 1
+        assert captured_spans[0].flush.called
+        assert captured_spans[0].start_time is not None
+        assert captured_spans[0].end_time is not None
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +110,7 @@ class TestSGPSyncTracingProcessorMemoryLeak:
 # ---------------------------------------------------------------------------
 
 
-class TestSGPAsyncTracingProcessorMemoryLeak:
+class TestSGPAsyncTracingProcessor:
     @staticmethod
     def _make_processor():
         mock_env = MagicMock()
@@ -113,9 +120,9 @@ class TestSGPAsyncTracingProcessorMemoryLeak:
         mock_async_client = MagicMock()
         mock_async_client.spans.upsert_batch = AsyncMock()
 
-        with patch(f"{MODULE}.EnvironmentVariables", mock_env), \
-             patch(f"{MODULE}.create_span", mock_create_span), \
-             patch(f"{MODULE}.AsyncSGPClient", return_value=mock_async_client):
+        with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(f"{MODULE}.create_span", mock_create_span), patch(
+            f"{MODULE}.AsyncSGPClient", return_value=mock_async_client
+        ):
             from agentex.lib.core.tracing.processors.sgp_tracing_processor import (
                 SGPAsyncTracingProcessor,
             )
@@ -125,69 +132,73 @@ class TestSGPAsyncTracingProcessorMemoryLeak:
         # Wire up the mock client after construction (constructor stores it)
         processor.sgp_async_client = mock_async_client
 
-        # Keep create_span mock active for on_span_start calls
         return processor, mock_create_span
 
-    async def test_spans_not_leaked_after_completed_lifecycle(self):
+    def test_processor_holds_no_per_span_state(self):
+        """Stateless processor must not retain any per-span dict between lifecycle events."""
         processor, _ = self._make_processor()
+        assert not hasattr(processor, "_spans")
 
-        with patch(f"{MODULE}.create_span", side_effect=lambda **kw: _make_mock_sgp_span()):
-            for _ in range(100):
-                span = _make_span()
-                await processor.on_span_start(span)
-                span.end_time = datetime.now(UTC)
-                await processor.on_span_end(span)
-
-        assert len(processor._spans) == 0, (
-            f"Expected 0 spans after 100 complete lifecycles, got {len(processor._spans)} — memory leak!"
-        )
-
-    async def test_spans_present_during_active_lifecycle(self):
+    async def test_span_lifecycle_produces_two_upserts(self):
+        """Each span produces one upsert_batch call on start and one on end."""
         processor, _ = self._make_processor()
 
         with patch(f"{MODULE}.create_span", side_effect=lambda **kw: _make_mock_sgp_span()):
             span = _make_span()
             await processor.on_span_start(span)
-            assert len(processor._spans) == 1, "Span should be tracked while active"
-
             span.end_time = datetime.now(UTC)
             await processor.on_span_end(span)
-            assert len(processor._spans) == 0, "Span should be removed after end"
 
-    async def test_span_end_for_unknown_span_is_noop(self):
-        processor, _ = self._make_processor()
+        assert processor.sgp_async_client.spans.upsert_batch.call_count == 2
 
-        span = _make_span()
-        span.end_time = datetime.now(UTC)
-        await processor.on_span_end(span)
+    async def test_span_end_without_prior_start_still_upserts(self):
+        """Cross-pod Temporal case: END activity lands on a pod that never saw START.
 
-        assert len(processor._spans) == 0
-
-    async def test_sgp_span_input_updated_on_end(self):
-        """on_span_end should update sgp_span.input from the incoming span."""
+        Today this used to be a silent no-op. After the stateless refactor it
+        must still upsert a complete span via upsert_batch.
+        """
         processor, _ = self._make_processor()
 
         with patch(f"{MODULE}.create_span", side_effect=lambda **kw: _make_mock_sgp_span()):
+            span = _make_span()
+            span.end_time = datetime.now(UTC)
+            # No on_span_start — END lands here for the first time.
+            await processor.on_span_end(span)
+
+        assert processor.sgp_async_client.spans.upsert_batch.call_count == 1
+        items = processor.sgp_async_client.spans.upsert_batch.call_args.kwargs["items"]
+        assert len(items) == 1
+
+    async def test_sgp_span_input_and_output_propagated_on_end(self):
+        """on_span_end should send the span's current input and output via upsert_batch."""
+        processor, _ = self._make_processor()
+
+        captured: list[MagicMock] = []
+
+        def capture_create_span(**kwargs):
+            sgp_span = _make_mock_sgp_span()
+            captured.append(sgp_span)
+            return sgp_span
+
+        with patch(f"{MODULE}.create_span", side_effect=capture_create_span):
             span = _make_span()
             span.input = {"messages": [{"role": "user", "content": "hello"}]}
             await processor.on_span_start(span)
 
-        assert len(processor._spans) == 1
+            span.input = {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi"},
+                ]
+            }
+            span.output = {"response": "hi"}
+            span.end_time = datetime.now(UTC)
+            await processor.on_span_end(span)
 
-        # Simulate modified input at end time
-        updated_input: dict[str, object] = {"messages": [
-            {"role": "user", "content": "hello"},
-            {"role": "assistant", "content": "hi"},
-        ]}
-        span.input = updated_input
-        span.output = {"response": "hi"}
-        span.end_time = datetime.now(UTC)
-        await processor.on_span_end(span)
-
-        # Span should be removed after end
-        assert len(processor._spans) == 0
-        # The end upsert should have been called
         assert processor.sgp_async_client.spans.upsert_batch.call_count == 2  # start + end
+        # The end-time SGPSpan should have end_time populated.
+        end_span = captured[-1]
+        assert end_span.end_time is not None
 
     async def test_on_spans_start_sends_single_upsert_for_batch(self):
         """Given N spans at once, on_spans_start should make ONE upsert_batch HTTP call."""
@@ -203,8 +214,6 @@ class TestSGPAsyncTracingProcessorMemoryLeak:
         )
         items = processor.sgp_async_client.spans.upsert_batch.call_args.kwargs["items"]
         assert len(items) == n
-        # All spans should be tracked for the subsequent end call
-        assert len(processor._spans) == n
 
     async def test_on_spans_end_sends_single_upsert_for_batch(self):
         """Given N spans at once, on_spans_end should make ONE upsert_batch HTTP call."""
@@ -226,4 +235,3 @@ class TestSGPAsyncTracingProcessorMemoryLeak:
         )
         items = processor.sgp_async_client.spans.upsert_batch.call_args.kwargs["items"]
         assert len(items) == n
-        assert len(processor._spans) == 0


### PR DESCRIPTION
## Summary

- In multi-replica Temporal deployments, `START_SPAN` and `END_SPAN` are dispatched as **separate Temporal activities** ([`adk/_modules/tracing.py:184` and `:228`](../blob/next/src/agentex/lib/adk/_modules/tracing.py)). Temporal activity routing has no stickiness across the two, so they can land on different worker pods.
- `SGPAsyncTracingProcessor` stored started `SGPSpan` objects in a per-process `self._spans` dict. When `on_spans_end` ran on a pod that never saw the `START`, the lookup returned `None`, a warning was logged, and the close upsert was silently skipped. Spans appeared stuck on "Running" in the SGP UI forever.
- Bug also present on the sync `SGPSyncTracingProcessor` path; reported by TASMU (Government of Qatar), confirmed on `agentex-sdk` 0.9.6 and 0.11.0.

## Fix

Drop the `_spans` cache entirely on both sync and async processors. Both `on_spans_start` and `on_spans_end` build a fresh `SGPSpan` from the incoming agentex `Span`. SGP's `upsert_batch` is idempotent on `span_id`, so re-sending the start fields on close is safe.

This mirrors the design of `AgentexAsyncTracingProcessor`, which is already stateless.

### Why "fully stateless" instead of the originally-proposed cache-with-fallback

The Slack-proposed fix (keep the dict, fall back to reconstruction on cache miss) would have fixed the silent close drop but left a memory leak on the **START pod**: in multi-replica deployments, the dict entry on pod A is never reclaimed when `END` lands on pod B. Going fully stateless fixes both with one change, at the cost of one extra `create_span(...)` call per `on_spans_end` — negligible vs. the HTTP round-trip.

## Throughput impact on SGP

- **Single-replica deployments** (incl. all sync/async-ACP non-Temporal agents): no change. Two `upsert_batch` calls per span as before.
- **Multi-replica Temporal deployments**: same 2 calls per span. The closes that were previously silently dropped are now actually sent — i.e., load returns to the original design intent. Not a degradation.

## Tests

- Replaced `test_span_end_for_unknown_span_is_noop` (which **codified the bug** as expected behavior) with `test_span_end_without_prior_start_still_{flushes,upserts}` — asserts the close IS sent on a pod that never saw the start.
- Replaced `_spans`-dict assertions with `test_processor_holds_no_per_span_state` and lifecycle-call-count assertions.
- All other batching, propagation, and `MemoryLeak` test coverage retained (renamed and refactored).

## Test plan

- [x] `rye run pytest tests/lib/core/tracing` — 32 passed, 2 skipped
- [x] `rye run ruff check` on changed files — clean
- [x] `rye run pyright` on changed files — clean
- [ ] Verify in TASMU's Council of Ministers env that root spans no longer get stuck on "Running"
- [ ] Confirm no regression in the dev SGP dashboard with a Temporal agent at 1 replica

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Removes the per-process `_spans` dict from both `SGPSyncTracingProcessor` and `SGPAsyncTracingProcessor`, fixing a bug where span closes were silently dropped in multi-replica Temporal deployments when the `END` activity lands on a different pod than `START`.
- Introduces a module-level `_build_sgp_span` helper that reconstructs a fresh `SGPSpan` on every call (both start and end), relying on SGP's idempotent `upsert_batch` on `span_id` to safely re-send start-time fields on close.
- Tests are updated to replace the stale no-op assertions (which codified the bug) with cross-pod scenario tests verifying that `on_span_end` without a prior `on_span_start` still correctly flushes and upserts.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge; the fix is well-scoped, stateless design is already used elsewhere in the codebase, and the test suite covers the new behavior thoroughly.

No P0 or P1 issues found. The root cause (stale in-process cache incompatible with multi-replica routing) is correctly diagnosed and fixed with minimal blast radius. SGP's idempotent upsert semantics make the double-write safe. Throughput analysis in the PR description confirms no regression for single-replica deployments.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py | Drops the `_spans` dict from both processors, extracts `_build_sgp_span` as a stateless module-level helper, and simplifies `shutdown()` to `pass` (async) / `flush_queue()` (sync); logic is clean and the stateless design mirrors the existing `AgentexAsyncTracingProcessor` pattern. |
| tests/lib/core/tracing/processors/test_sgp_tracing_processor.py | Replaces `_spans`-dict assertions (which encoded the bug as expected behavior) with stateless behavior tests; cross-pod scenario tests correctly initialise the mock's `start_time`/`end_time` to `None` so the is-not-None assertions are meaningful. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TA as Temporal Activity START
    participant TB as Temporal Activity END
    participant P as SGP Processor stateless
    participant SGP as SGP Backend

    Note over TA,TB: Multi-replica Temporal deployment

    TA->>P: on_spans_start([span])
    P->>P: _build_sgp_span sets start_time
    P->>SGP: upsert_batch span Running

    Note over TB: END routed to different worker pod

    TB->>P: on_spans_end([span])
    P->>P: _build_sgp_span fresh build with start_time
    P->>P: sgp_span.end_time set
    P->>SGP: upsert_batch span Completed

    Note over SGP: span_id is idempotent key
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tracing): address greptile review fi..."](https://github.com/scaleapi/scale-agentex-python/commit/6a0cf236b84d349402bdc3ba8d77d01f24cf0a8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31632553)</sub>

<!-- /greptile_comment -->