### PR TITLE
fix(messages): stamp agent messages with workflow.now() for monotonic ordering

### DIFF
--- a/examples/tutorials/10_async/00_base/010_multiturn/tests/test_agent.py
+++ b/examples/tutorials/10_async/00_base/010_multiturn/tests/test_agent.py
@@ -145,6 +145,7 @@ class TestStreamingEvents:
         task = task_response.result
         assert task is not None
 
+        await asyncio.sleep(1)  # wait for state to be initialized
         # Check initial state
         states = await client.states.list(agent_id=agent_id, task_id=task.id)
         assert len(states) == 1

--- a/src/agentex/lib/adk/_modules/messages.py
+++ b/src/agentex/lib/adk/_modules/messages.py
@@ -1,7 +1,7 @@
 # ruff: noqa: I001
 # Import order matters - AsyncTracer must come after client import to avoid circular imports
 from __future__ import annotations
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from temporalio.common import RetryPolicy
 
@@ -22,7 +22,7 @@ from agentex.lib.core.temporal.activities.adk.messages_activities import (
 from agentex.lib.core.tracing.tracer import AsyncTracer
 from agentex.types.task_message import TaskMessage, TaskMessageContent
 from agentex.lib.utils.logging import make_logger
-from agentex.lib.utils.temporal import in_temporal_workflow
+from agentex.lib.utils.temporal import in_temporal_workflow, workflow_now_if_in_workflow
 
 logger = make_logger(__name__)
 
@@ -66,6 +66,7 @@ class MessagesModule:
         start_to_close_timeout: timedelta = timedelta(seconds=5),
         heartbeat_timeout: timedelta = timedelta(seconds=5),
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
+        created_at: datetime | None = None,
     ) -> TaskMessage:
         """
         Create a new message for a task.
@@ -82,12 +83,17 @@ class MessagesModule:
         Returns:
             TaskMessageEntity: The created message.
         """
+        # Default created_at to workflow.now() so two awaited adk.messages.create
+        # calls from the same workflow are guaranteed monotonic at the server.
+        if created_at is None and in_temporal_workflow():
+            created_at = workflow_now_if_in_workflow()
         params = CreateMessageParams(
             trace_id=trace_id,
             parent_span_id=parent_span_id,
             task_id=task_id,
             content=content,
             emit_updates=emit_updates,
+            created_at=created_at,
         )
         if in_temporal_workflow():
             return await ActivityHelpers.execute_activity(
@@ -103,6 +109,7 @@ class MessagesModule:
                 task_id=task_id,
                 content=content,
                 emit_updates=emit_updates,
+                created_at=created_at,
             )
 
     async def update(
@@ -163,6 +170,7 @@ class MessagesModule:
         start_to_close_timeout: timedelta = timedelta(seconds=5),
         heartbeat_timeout: timedelta = timedelta(seconds=5),
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
+        created_at: datetime | None = None,
     ) -> list[TaskMessage]:
         """
         Create a batch of messages for a task.
@@ -177,12 +185,15 @@ class MessagesModule:
         Returns:
             List[TaskMessageEntity]: The created messages.
         """
+        if created_at is None and in_temporal_workflow():
+            created_at = workflow_now_if_in_workflow()
         params = CreateMessagesBatchParams(
             task_id=task_id,
             contents=contents,
             emit_updates=emit_updates,
             trace_id=trace_id,
             parent_span_id=parent_span_id,
+            created_at=created_at,
         )
         if in_temporal_workflow():
             return await ActivityHelpers.execute_activity(
@@ -198,6 +209,7 @@ class MessagesModule:
                 task_id=task_id,
                 contents=contents,
                 emit_updates=emit_updates,
+                created_at=created_at,
             )
 
     async def update_batch(

--- a/src/agentex/lib/adk/_modules/messages.py
+++ b/src/agentex/lib/adk/_modules/messages.py
@@ -85,7 +85,7 @@ class MessagesModule:
         """
         # Default created_at to workflow.now() so two awaited adk.messages.create
         # calls from the same workflow are guaranteed monotonic at the server.
-        if created_at is None and in_temporal_workflow():
+        if created_at is None:
             created_at = workflow_now_if_in_workflow()
         params = CreateMessageParams(
             trace_id=trace_id,
@@ -185,7 +185,7 @@ class MessagesModule:
         Returns:
             List[TaskMessageEntity]: The created messages.
         """
-        if created_at is None and in_temporal_workflow():
+        if created_at is None:
             created_at = workflow_now_if_in_workflow()
         params = CreateMessagesBatchParams(
             task_id=task_id,

--- a/src/agentex/lib/adk/_modules/streaming.py
+++ b/src/agentex/lib/adk/_modules/streaming.py
@@ -1,6 +1,7 @@
 # ruff: noqa: I001
 # Import order matters - AsyncTracer must come after client import to avoid circular imports
 from __future__ import annotations
+from datetime import datetime
 from temporalio.common import RetryPolicy
 
 from agentex import AsyncAgentex  # noqa: F401
@@ -52,6 +53,7 @@ class StreamingModule:
         task_id: str,
         initial_content: TaskMessageContent,
         streaming_mode: StreamingMode = "coalesced",
+        created_at: datetime | None = None,
     ) -> StreamingTaskMessageContext:
         """
         Create a streaming context for managing TaskMessage lifecycle.
@@ -83,4 +85,5 @@ class StreamingModule:
             task_id=task_id,
             initial_content=initial_content,
             streaming_mode=streaming_mode,
+            created_at=created_at,
         )

--- a/src/agentex/lib/adk/providers/_modules/litellm.py
+++ b/src/agentex/lib/adk/providers/_modules/litellm.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator
 from temporalio.common import RetryPolicy
 
 from agentex.lib.utils.logging import make_logger
-from agentex.lib.utils.temporal import in_temporal_workflow
+from agentex.lib.utils.temporal import in_temporal_workflow, workflow_now_if_in_workflow
 from agentex.types.task_message import TaskMessage
 from agentex.lib.types.llm_messages import LLMConfig, Completion
 from agentex.lib.core.tracing.tracer import AsyncTracer
@@ -88,9 +88,7 @@ class LiteLLMModule:
             Completion: An OpenAI compatible Completion object
         """
         if in_temporal_workflow():
-            params = ChatCompletionParams(
-                trace_id=trace_id, parent_span_id=parent_span_id, llm_config=llm_config
-            )
+            params = ChatCompletionParams(trace_id=trace_id, parent_span_id=parent_span_id, llm_config=llm_config)
             return await ActivityHelpers.execute_activity(
                 activity_name=LiteLLMActivityName.CHAT_COMPLETION,
                 request=params,
@@ -138,6 +136,7 @@ class LiteLLMModule:
                 parent_span_id=parent_span_id,
                 task_id=task_id,
                 llm_config=llm_config,
+                created_at=workflow_now_if_in_workflow(),
             )
             return await ActivityHelpers.execute_activity(
                 activity_name=LiteLLMActivityName.CHAT_COMPLETION_AUTO_SEND,
@@ -222,6 +221,7 @@ class LiteLLMModule:
                 parent_span_id=parent_span_id,
                 task_id=task_id,
                 llm_config=llm_config,
+                created_at=workflow_now_if_in_workflow(),
             )
             return await ActivityHelpers.execute_activity(
                 activity_name=LiteLLMActivityName.CHAT_COMPLETION_STREAM_AUTO_SEND,

--- a/src/agentex/lib/adk/providers/_modules/openai.py
+++ b/src/agentex/lib/adk/providers/_modules/openai.py
@@ -20,7 +20,7 @@ else:
     from typing_extensions import deprecated
 
 from agentex.lib.utils.logging import make_logger
-from agentex.lib.utils.temporal import in_temporal_workflow
+from agentex.lib.utils.temporal import in_temporal_workflow, workflow_now_if_in_workflow
 from agentex.lib.core.tracing.tracer import AsyncTracer
 from agentex.lib.types.agent_results import (
     SerializableRunResult,
@@ -265,6 +265,7 @@ class OpenAIModule:
                 output_guardrails=output_guardrails,  # type: ignore[arg-type]
                 max_turns=max_turns,
                 previous_response_id=previous_response_id,
+                created_at=workflow_now_if_in_workflow(),
             )
             return await ActivityHelpers.execute_activity(
                 activity_name=OpenAIActivityName.RUN_AGENT_AUTO_SEND,
@@ -479,6 +480,7 @@ class OpenAIModule:
                 input_guardrails=input_guardrails,
                 output_guardrails=output_guardrails,
                 max_turns=max_turns,
+                created_at=workflow_now_if_in_workflow(),
             )
             return await ActivityHelpers.execute_activity(
                 activity_name=OpenAIActivityName.RUN_AGENT_STREAMED_AUTO_SEND,

--- a/src/agentex/lib/core/services/adk/messages.py
+++ b/src/agentex/lib/core/services/adk/messages.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, Coroutine
+from datetime import datetime
 
 from agentex import AsyncAgentex
+from agentex._types import omit
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.utils.temporal import heartbeat_if_in_workflow
 from agentex.types.task_message import TaskMessage, TaskMessageContent
@@ -32,6 +34,7 @@ class MessagesService:
         emit_updates: bool = True,
         trace_id: str | None = None,
         parent_span_id: str | None = None,
+        created_at: datetime | None = None,
     ) -> TaskMessage:
         trace = self._tracer.trace(trace_id)
         async with trace.span(
@@ -43,6 +46,7 @@ class MessagesService:
             task_message = await self._agentex_client.messages.create(
                 task_id=task_id,
                 content=content.model_dump(),
+                created_at=created_at if created_at is not None else omit,
             )
             if emit_updates:
                 await self._emit_updates([task_message])
@@ -85,6 +89,7 @@ class MessagesService:
         emit_updates: bool = True,
         trace_id: str | None = None,
         parent_span_id: str | None = None,
+        created_at: datetime | None = None,
     ) -> list[TaskMessage]:
         trace = self._tracer.trace(trace_id)
         async with trace.span(
@@ -96,6 +101,7 @@ class MessagesService:
             task_messages = await self._agentex_client.messages.batch.create(
                 task_id=task_id,
                 contents=[content.model_dump() for content in contents],
+                created_at=created_at if created_at is not None else omit,
             )
             if emit_updates:
                 await self._emit_updates(task_messages)
@@ -119,10 +125,7 @@ class MessagesService:
             heartbeat_if_in_workflow("update messages batch")
             task_messages = await self._agentex_client.messages.batch.update(
                 task_id=task_id,
-                updates={
-                    message_id: content.model_dump()
-                    for message_id, content in updates.items()
-                },
+                updates={message_id: content.model_dump() for message_id, content in updates.items()},
             )
             if span:
                 span.output = [task_message.model_dump() for task_message in task_messages]

--- a/src/agentex/lib/core/services/adk/providers/litellm.py
+++ b/src/agentex/lib/core/services/adk/providers/litellm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from collections.abc import AsyncGenerator
 
 from agentex import AsyncAgentex
@@ -63,6 +64,7 @@ class LiteLLMService:
         llm_config: LLMConfig,
         trace_id: str | None = None,
         parent_span_id: str | None = None,
+        created_at: datetime | None = None,
     ) -> TaskMessage | None:
         """
         Chat completion with automatic TaskMessage creation. This does not stream the completion. To stream use chat_completion_stream_auto_send.
@@ -98,13 +100,10 @@ class LiteLLMService:
                     content="",
                     format="markdown",
                 ),
+                created_at=created_at,
             ) as streaming_context:
                 completion = await self.llm_gateway.acompletion(**llm_config.model_dump())
-                if (
-                    completion.choices
-                    and len(completion.choices) > 0
-                    and completion.choices[0].message
-                ):
+                if completion.choices and len(completion.choices) > 0 and completion.choices[0].message:
                     final_content = TextContent(
                         author="agent",
                         content=completion.choices[0].message.content or "",
@@ -159,9 +158,7 @@ class LiteLLMService:
         ) as span:
             # Direct streaming outside temporal - yield each chunk as it comes
             chunks: list[Completion] = []
-            async for chunk in self.llm_gateway.acompletion_stream(
-                **llm_config.model_dump()
-            ):
+            async for chunk in self.llm_gateway.acompletion_stream(**llm_config.model_dump()):
                 chunks.append(chunk)
                 yield chunk
             if span:
@@ -173,6 +170,7 @@ class LiteLLMService:
         llm_config: LLMConfig,
         trace_id: str | None = None,
         parent_span_id: str | None = None,
+        created_at: datetime | None = None,
     ) -> TaskMessage | None:
         """
         Stream chat completion with automatic TaskMessage creation and streaming.
@@ -206,18 +204,13 @@ class LiteLLMService:
                     content="",
                     format="markdown",
                 ),
+                created_at=created_at,
             ) as streaming_context:
                 # Get the streaming response
                 chunks = []
-                async for response in self.llm_gateway.acompletion_stream(
-                    **llm_config.model_dump()
-                ):
+                async for response in self.llm_gateway.acompletion_stream(**llm_config.model_dump()):
                     heartbeat_if_in_workflow("chat completion streaming")
-                    if (
-                        response.choices
-                        and len(response.choices) > 0
-                        and response.choices[0].delta
-                    ):
+                    if response.choices and len(response.choices) > 0 and response.choices[0].delta:
                         delta = response.choices[0].delta.content
                         if delta:
                             # Stream the chunk via the context manager
@@ -235,11 +228,7 @@ class LiteLLMService:
 
                 # Update the final message content
                 complete_message = concat_completion_chunks(chunks)
-                if (
-                    complete_message
-                    and complete_message.choices
-                    and complete_message.choices[0].message
-                ):
+                if complete_message and complete_message.choices and complete_message.choices[0].message:
                     final_content = TextContent(
                         author="agent",
                         content=complete_message.choices[0].message.content or "",

--- a/src/agentex/lib/core/services/adk/providers/openai.py
+++ b/src/agentex/lib/core/services/adk/providers/openai.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Literal
+from datetime import datetime
 from contextlib import AsyncExitStack, asynccontextmanager
 
 from mcp import StdioServerParameters
@@ -233,10 +234,14 @@ class OpenAIService:
             heartbeat_if_in_workflow("run agent")
 
             async with mcp_server_context(mcp_server_params, mcp_timeout_seconds) as servers:
-                tools = [
-                    tool.to_oai_function_tool() if hasattr(tool, 'to_oai_function_tool') else tool  # type: ignore[attr-defined]
-                    for tool in tools
-                ] if tools else []
+                tools = (
+                    [
+                        tool.to_oai_function_tool() if hasattr(tool, "to_oai_function_tool") else tool  # type: ignore[attr-defined]
+                        for tool in tools
+                    ]
+                    if tools
+                    else []
+                )
                 handoffs = [Agent(**handoff.model_dump()) for handoff in handoffs] if handoffs else []  # type: ignore[misc]
 
                 agent_kwargs = {
@@ -252,7 +257,8 @@ class OpenAIService:
                 }
                 if model_settings is not None:
                     agent_kwargs["model_settings"] = (
-                        model_settings.to_oai_model_settings() if hasattr(model_settings, 'to_oai_model_settings')  # type: ignore[attr-defined]
+                        model_settings.to_oai_model_settings()  # type: ignore[attr-defined]
+                        if hasattr(model_settings, "to_oai_model_settings")
                         else model_settings
                     )
                 if input_guardrails is not None:
@@ -313,6 +319,7 @@ class OpenAIService:
         output_guardrails: list[OutputGuardrail] | None = None,
         max_turns: int | None = None,
         previous_response_id: str | None = None,  # noqa: ARG002
+        created_at: datetime | None = None,
     ) -> RunResult:
         """
         Run an agent with automatic TaskMessage creation.
@@ -370,11 +377,25 @@ class OpenAIService:
         ) as span:
             heartbeat_if_in_workflow("run agent auto send")
 
+            # See run_agent_streamed_auto_send for the rationale: only the
+            # first message opened in this turn carries the workflow-supplied
+            # created_at; the rest fall back to server wall clock.
+            _pending_created_at: list[datetime | None] = [created_at]
+
+            def _take_created_at() -> datetime | None:
+                value = _pending_created_at[0]
+                _pending_created_at[0] = None
+                return value
+
             async with mcp_server_context(mcp_server_params, mcp_timeout_seconds) as servers:
-                tools = [
-                    tool.to_oai_function_tool() if hasattr(tool, 'to_oai_function_tool') else tool  # type: ignore[attr-defined]
-                    for tool in tools
-                ] if tools else []
+                tools = (
+                    [
+                        tool.to_oai_function_tool() if hasattr(tool, "to_oai_function_tool") else tool  # type: ignore[attr-defined]
+                        for tool in tools
+                    ]
+                    if tools
+                    else []
+                )
                 handoffs = [Agent(**handoff.model_dump()) for handoff in handoffs] if handoffs else []  # type: ignore[misc]
                 agent_kwargs = {
                     "name": agent_name,
@@ -389,7 +410,8 @@ class OpenAIService:
                 }
                 if model_settings is not None:
                     agent_kwargs["model_settings"] = (
-                        model_settings.to_oai_model_settings() if hasattr(model_settings, 'to_oai_model_settings')  # type: ignore[attr-defined]
+                        model_settings.to_oai_model_settings()  # type: ignore[attr-defined]
+                        if hasattr(model_settings, "to_oai_model_settings")
                         else model_settings
                     )
                 if input_guardrails is not None:
@@ -437,6 +459,7 @@ class OpenAIService:
                         async with self.streaming_service.streaming_task_message_context(
                             task_id=task_id,
                             initial_content=text_content,
+                            created_at=_take_created_at(),
                         ) as streaming_context:
                             await streaming_context.stream_update(
                                 update=StreamTaskMessageFull(
@@ -464,6 +487,7 @@ class OpenAIService:
                         async with self.streaming_service.streaming_task_message_context(
                             task_id=task_id,
                             initial_content=tool_request_content,
+                            created_at=_take_created_at(),
                         ) as streaming_context:
                             await streaming_context.stream_update(
                                 update=StreamTaskMessageFull(
@@ -487,7 +511,9 @@ class OpenAIService:
                         )
                         # Create tool response using streaming context
                         async with self.streaming_service.streaming_task_message_context(
-                            task_id=task_id, initial_content=tool_response_content
+                            task_id=task_id,
+                            initial_content=tool_response_content,
+                            created_at=_take_created_at(),
                         ) as streaming_context:
                             await streaming_context.stream_update(
                                 update=StreamTaskMessageFull(
@@ -577,10 +603,14 @@ class OpenAIService:
             heartbeat_if_in_workflow("run agent streamed")
 
             async with mcp_server_context(mcp_server_params, mcp_timeout_seconds) as servers:
-                tools = [
-                    tool.to_oai_function_tool() if hasattr(tool, 'to_oai_function_tool') else tool  # type: ignore[attr-defined]
-                    for tool in tools
-                ] if tools else []
+                tools = (
+                    [
+                        tool.to_oai_function_tool() if hasattr(tool, "to_oai_function_tool") else tool  # type: ignore[attr-defined]
+                        for tool in tools
+                    ]
+                    if tools
+                    else []
+                )
                 handoffs = [Agent(**handoff.model_dump()) for handoff in handoffs] if handoffs else []  # type: ignore[misc]
                 agent_kwargs = {
                     "name": agent_name,
@@ -595,7 +625,8 @@ class OpenAIService:
                 }
                 if model_settings is not None:
                     agent_kwargs["model_settings"] = (
-                        model_settings.to_oai_model_settings() if hasattr(model_settings, 'to_oai_model_settings')  # type: ignore[attr-defined]
+                        model_settings.to_oai_model_settings()  # type: ignore[attr-defined]
+                        if hasattr(model_settings, "to_oai_model_settings")
                         else model_settings
                     )
                 if input_guardrails is not None:
@@ -656,6 +687,7 @@ class OpenAIService:
         output_guardrails: list[OutputGuardrail] | None = None,
         max_turns: int | None = None,
         previous_response_id: str | None = None,  # noqa: ARG002
+        created_at: datetime | None = None,
     ) -> RunResultStreaming:
         """
         Run an agent with streaming enabled and automatic TaskMessage creation.
@@ -720,11 +752,28 @@ class OpenAIService:
         ) as span:
             heartbeat_if_in_workflow("run agent streamed auto send")
 
+            # Consume the workflow-supplied created_at on the FIRST message
+            # opened by this activity (whichever streaming context opens first
+            # for this turn). That's the message that races the workflow's
+            # user-echo at the server. Subsequent messages in the same turn are
+            # separated by network/processing latency and rely on the server's
+            # wall clock.
+            _pending_created_at: list[datetime | None] = [created_at]
+
+            def _take_created_at() -> datetime | None:
+                value = _pending_created_at[0]
+                _pending_created_at[0] = None
+                return value
+
             async with mcp_server_context(mcp_server_params, mcp_timeout_seconds) as servers:
-                tools = [
-                    tool.to_oai_function_tool() if hasattr(tool, 'to_oai_function_tool') else tool  # type: ignore[attr-defined]
-                    for tool in tools
-                ] if tools else []
+                tools = (
+                    [
+                        tool.to_oai_function_tool() if hasattr(tool, "to_oai_function_tool") else tool  # type: ignore[attr-defined]
+                        for tool in tools
+                    ]
+                    if tools
+                    else []
+                )
                 handoffs = [Agent(**handoff.model_dump()) for handoff in handoffs] if handoffs else []  # type: ignore[misc]
                 agent_kwargs = {
                     "name": agent_name,
@@ -739,7 +788,8 @@ class OpenAIService:
                 }
                 if model_settings is not None:
                     agent_kwargs["model_settings"] = (
-                        model_settings.to_oai_model_settings() if hasattr(model_settings, 'to_oai_model_settings')  # type: ignore[attr-defined]
+                        model_settings.to_oai_model_settings()  # type: ignore[attr-defined]
+                        if hasattr(model_settings, "to_oai_model_settings")
                         else model_settings
                     )
                 if input_guardrails is not None:
@@ -784,6 +834,7 @@ class OpenAIService:
                                 async with self.streaming_service.streaming_task_message_context(
                                     task_id=task_id,
                                     initial_content=tool_request_content,
+                                    created_at=_take_created_at(),
                                 ) as streaming_context:
                                     # The message has already been persisted, but we still need to send an upda
                                     await streaming_context.stream_update(
@@ -811,7 +862,9 @@ class OpenAIService:
 
                                 # Create tool response using streaming context (immediate completion)
                                 async with self.streaming_service.streaming_task_message_context(
-                                    task_id=task_id, initial_content=tool_response_content
+                                    task_id=task_id,
+                                    initial_content=tool_response_content,
+                                    created_at=_take_created_at(),
                                 ) as streaming_context:
                                     # The message has already been persisted, but we still need to send an update
                                     await streaming_context.stream_update(
@@ -836,6 +889,7 @@ class OpenAIService:
                                             author="agent",
                                             content="",
                                         ),
+                                        created_at=_take_created_at(),
                                     )
                                     # Open the streaming context
                                     item_id_to_streaming_context[item_id] = await streaming_context.open()
@@ -855,10 +909,10 @@ class OpenAIService:
                             elif isinstance(event.data, ResponseReasoningSummaryPartAddedEvent):
                                 # We need to create a new streaming context for this reasoning item
                                 item_id = event.data.item_id
-                                
+
                                 # Reset the reasoning summary string
                                 current_reasoning_summary = ""
-                                
+
                                 streaming_context = self.streaming_service.streaming_task_message_context(
                                     task_id=task_id,
                                     initial_content=ReasoningContent(
@@ -868,13 +922,14 @@ class OpenAIService:
                                         type="reasoning",
                                         style="active",
                                     ),
+                                    created_at=_take_created_at(),
                                 )
 
                                 # Replace the existing streaming context (if it exists)
                                 # Why do we replace? Cause all the reasoning parts use the same item_id!
                                 item_id_to_streaming_context[item_id] = await streaming_context.open()
                                 unclosed_item_ids.add(item_id)
-                            
+
                             # Reasoning step two: handling summary text delta
                             elif isinstance(event.data, ResponseReasoningSummaryTextDeltaEvent):
                                 # Accumulate the delta into the string
@@ -898,7 +953,7 @@ class OpenAIService:
                             elif isinstance(event.data, ResponseReasoningSummaryPartDoneEvent):
                                 # Handle reasoning summary text completion
                                 streaming_context = item_id_to_streaming_context[item_id]
-                                
+
                                 # Create the complete reasoning content with the accumulated summary
                                 complete_reasoning_content = ReasoningContent(
                                     author="agent",
@@ -907,7 +962,7 @@ class OpenAIService:
                                     type="reasoning",
                                     style="static",
                                 )
-                                
+
                                 # Send a full message update with the complete reasoning content
                                 await streaming_context.stream_update(
                                     update=StreamTaskMessageFull(
@@ -916,10 +971,9 @@ class OpenAIService:
                                         type="full",
                                     ),
                                 )
-                                
+
                                 await streaming_context.close()
                                 unclosed_item_ids.discard(item_id)
-                                
 
                             elif isinstance(event.data, ResponseOutputItemDoneEvent):
                                 # Handle item completion
@@ -966,6 +1020,7 @@ class OpenAIService:
                             author="agent",
                             content=rejection_message,
                         ),
+                        created_at=_take_created_at(),
                     ) as streaming_context:
                         # Send the full message
                         await streaming_context.stream_update(
@@ -1004,6 +1059,7 @@ class OpenAIService:
                             author="agent",
                             content=rejection_message,
                         ),
+                        created_at=_take_created_at(),
                     ) as streaming_context:
                         # Send the full message
                         await streaming_context.stream_update(

--- a/src/agentex/lib/core/services/adk/providers/openai.py
+++ b/src/agentex/lib/core/services/adk/providers/openai.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, Literal
 from datetime import datetime
 from contextlib import AsyncExitStack, asynccontextmanager
+from collections.abc import Callable
 
 from mcp import StdioServerParameters
 from agents import Agent, Runner, RunResult, RunResultStreaming
@@ -72,6 +73,22 @@ async def mcp_server_context(
         for server in servers:
             await stack.enter_async_context(server)
         yield servers
+
+
+def _make_created_at_dispenser(initial: datetime | None) -> Callable[[], datetime | None]:
+    # Returns a closure that yields the workflow-supplied created_at exactly
+    # once (on the first call), then None forever after. Used to stamp the
+    # first agent message of a turn with workflow.now() while letting
+    # subsequent messages fall back to server wall-clock — see the call sites
+    # in run_agent_auto_send / run_agent_streamed_auto_send for context.
+    pending: list[datetime | None] = [initial]
+
+    def take() -> datetime | None:
+        value = pending[0]
+        pending[0] = None
+        return value
+
+    return take
 
 
 class OpenAIService:
@@ -377,15 +394,7 @@ class OpenAIService:
         ) as span:
             heartbeat_if_in_workflow("run agent auto send")
 
-            # See run_agent_streamed_auto_send for the rationale: only the
-            # first message opened in this turn carries the workflow-supplied
-            # created_at; the rest fall back to server wall clock.
-            _pending_created_at: list[datetime | None] = [created_at]
-
-            def _take_created_at() -> datetime | None:
-                value = _pending_created_at[0]
-                _pending_created_at[0] = None
-                return value
+            _take_created_at = _make_created_at_dispenser(created_at)
 
             async with mcp_server_context(mcp_server_params, mcp_timeout_seconds) as servers:
                 tools = (
@@ -758,12 +767,7 @@ class OpenAIService:
             # user-echo at the server. Subsequent messages in the same turn are
             # separated by network/processing latency and rely on the server's
             # wall clock.
-            _pending_created_at: list[datetime | None] = [created_at]
-
-            def _take_created_at() -> datetime | None:
-                value = _pending_created_at[0]
-                _pending_created_at[0] = None
-                return value
+            _take_created_at = _make_created_at_dispenser(created_at)
 
             async with mcp_server_context(mcp_server_params, mcp_timeout_seconds) as servers:
                 tools = (

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -4,8 +4,10 @@ import json
 import asyncio
 import contextlib
 from typing import Literal, Callable, Awaitable
+from datetime import datetime
 
 from agentex import AsyncAgentex
+from agentex._types import omit
 from agentex.lib.utils.logging import make_logger
 from agentex.types.data_content import DataContent
 from agentex.types.task_message import (
@@ -259,13 +261,9 @@ class DeltaAccumulator:
             # For reasoning, we allow both summary and content deltas
             if self._delta_type == "reasoning":
                 if delta.type not in ["reasoning_summary", "reasoning_content"]:
-                    raise ValueError(
-                        f"Expected reasoning delta but got: {delta.type}"
-                    )
+                    raise ValueError(f"Expected reasoning delta but got: {delta.type}")
             elif self._delta_type != delta.type:
-                raise ValueError(
-                    f"Delta type mismatch: {self._delta_type} != {delta.type}"
-                )
+                raise ValueError(f"Delta type mismatch: {self._delta_type} != {delta.type}")
 
         # Handle reasoning deltas specially
         if delta.type == "reasoning_summary":
@@ -285,9 +283,7 @@ class DeltaAccumulator:
         if self._delta_type == "text":
             # Type assertion: we know all deltas are TextDelta when _delta_type is TEXT
             text_deltas = [delta for delta in self._accumulated_deltas if isinstance(delta, TextDelta)]
-            text_content_str = "".join(
-                [delta.text_delta or "" for delta in text_deltas]
-            )
+            text_content_str = "".join([delta.text_delta or "" for delta in text_deltas])
             return TextContent(
                 author="agent",
                 content=text_content_str,
@@ -295,15 +291,11 @@ class DeltaAccumulator:
         elif self._delta_type == "data":
             # Type assertion: we know all deltas are DataDelta when _delta_type is DATA
             data_deltas = [delta for delta in self._accumulated_deltas if isinstance(delta, DataDelta)]
-            data_content_str = "".join(
-                [delta.data_delta or "" for delta in data_deltas]
-            )
+            data_content_str = "".join([delta.data_delta or "" for delta in data_deltas])
             try:
                 data = json.loads(data_content_str)
             except json.JSONDecodeError as e:
-                raise ValueError(
-                    f"Accumulated data content is not valid JSON: {data_content_str}"
-                ) from e
+                raise ValueError(f"Accumulated data content is not valid JSON: {data_content_str}") from e
             return DataContent(
                 author="agent",
                 data=data,
@@ -311,9 +303,7 @@ class DeltaAccumulator:
         elif self._delta_type == "tool_request":
             # Type assertion: we know all deltas are ToolRequestDelta when _delta_type is TOOL_REQUEST
             tool_request_deltas = [delta for delta in self._accumulated_deltas if isinstance(delta, ToolRequestDelta)]
-            arguments_content_str = "".join(
-                [delta.arguments_delta or "" for delta in tool_request_deltas]
-            )
+            arguments_content_str = "".join([delta.arguments_delta or "" for delta in tool_request_deltas])
             try:
                 arguments = json.loads(arguments_content_str)
             except json.JSONDecodeError as e:
@@ -329,9 +319,7 @@ class DeltaAccumulator:
         elif self._delta_type == "tool_response":
             # Type assertion: we know all deltas are ToolResponseDelta when _delta_type is TOOL_RESPONSE
             tool_response_deltas = [delta for delta in self._accumulated_deltas if isinstance(delta, ToolResponseDelta)]
-            tool_response_content_str = "".join(
-                [delta.content_delta or "" for delta in tool_response_deltas]
-            )
+            tool_response_content_str = "".join([delta.content_delta or "" for delta in tool_response_deltas])
             return ToolResponseContent(
                 author="agent",
                 tool_call_id=tool_response_deltas[0].tool_call_id,
@@ -341,9 +329,17 @@ class DeltaAccumulator:
         elif self._delta_type == "reasoning":
             # Convert accumulated reasoning deltas to ReasoningContent
             # Sort by index to maintain order
-            summary_list = [self._reasoning_summaries[i] for i in sorted(self._reasoning_summaries.keys()) if self._reasoning_summaries[i]]
-            content_list = [self._reasoning_contents[i] for i in sorted(self._reasoning_contents.keys()) if self._reasoning_contents[i]]
-            
+            summary_list = [
+                self._reasoning_summaries[i]
+                for i in sorted(self._reasoning_summaries.keys())
+                if self._reasoning_summaries[i]
+            ]
+            content_list = [
+                self._reasoning_contents[i]
+                for i in sorted(self._reasoning_contents.keys())
+                if self._reasoning_contents[i]
+            ]
+
             # Only return reasoning content if we have non-empty summaries or content
             if summary_list or content_list:
                 return ReasoningContent(
@@ -371,6 +367,7 @@ class StreamingTaskMessageContext:
         agentex_client: AsyncAgentex,
         streaming_service: "StreamingService",
         streaming_mode: StreamingMode = "coalesced",
+        created_at: datetime | None = None,
     ):
         self.task_id = task_id
         self.initial_content = initial_content
@@ -381,6 +378,7 @@ class StreamingTaskMessageContext:
         self._delta_accumulator = DeltaAccumulator()
         self._streaming_mode: StreamingMode = streaming_mode
         self._buffer: CoalescingBuffer | None = None
+        self._created_at = created_at
 
     async def __aenter__(self) -> "StreamingTaskMessageContext":
         return await self.open()
@@ -395,6 +393,7 @@ class StreamingTaskMessageContext:
             task_id=self.task_id,
             content=self.initial_content.model_dump(),
             streaming_status="IN_PROGRESS",
+            created_at=self._created_at if self._created_at is not None else omit,
         )
 
         # Send the START event
@@ -434,9 +433,9 @@ class StreamingTaskMessageContext:
 
         # Update the task message with the final content
         has_deltas = (
-            self._delta_accumulator._accumulated_deltas or
-            self._delta_accumulator._reasoning_summaries or
-            self._delta_accumulator._reasoning_contents
+            self._delta_accumulator._accumulated_deltas
+            or self._delta_accumulator._reasoning_summaries
+            or self._delta_accumulator._reasoning_contents
         )
         if has_deltas:
             self.task_message.content = self._delta_accumulator.convert_to_content()
@@ -452,9 +451,7 @@ class StreamingTaskMessageContext:
         self._is_closed = True
         return self.task_message
 
-    async def stream_update(
-        self, update: TaskMessageUpdate
-    ) -> TaskMessageUpdate | None:
+    async def stream_update(self, update: TaskMessageUpdate) -> TaskMessageUpdate | None:
         """Stream an update to the repository.
 
         Behavior depends on the context's ``streaming_mode``:
@@ -514,6 +511,7 @@ class StreamingService:
         task_id: str,
         initial_content: TaskMessageContent,
         streaming_mode: StreamingMode = "coalesced",
+        created_at: datetime | None = None,
     ) -> StreamingTaskMessageContext:
         return StreamingTaskMessageContext(
             task_id=task_id,
@@ -521,11 +519,10 @@ class StreamingService:
             agentex_client=self._agentex_client,
             streaming_service=self,
             streaming_mode=streaming_mode,
+            created_at=created_at,
         )
 
-    async def stream_update(
-        self, update: TaskMessageUpdate
-    ) -> TaskMessageUpdate | None:
+    async def stream_update(self, update: TaskMessageUpdate) -> TaskMessageUpdate | None:
         """
         Stream an update to the repository.
 
@@ -539,7 +536,8 @@ class StreamingService:
 
         try:
             await self._stream_repository.send_event(
-                topic=stream_topic, event=update.model_dump(mode="json")  # type: ignore
+                topic=stream_topic,
+                event=update.model_dump(mode="json"),  # type: ignore
             )
             return update
         except Exception as e:

--- a/src/agentex/lib/core/temporal/activities/adk/messages_activities.py
+++ b/src/agentex/lib/core/temporal/activities/adk/messages_activities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from datetime import datetime
 
 from temporalio import activity
 
@@ -25,6 +26,7 @@ class CreateMessageParams(BaseModelWithTraceParams):
     task_id: str
     content: TaskMessageContent
     emit_updates: bool = True
+    created_at: datetime | None = None
 
 
 class UpdateMessageParams(BaseModelWithTraceParams):
@@ -37,6 +39,7 @@ class CreateMessagesBatchParams(BaseModelWithTraceParams):
     task_id: str
     contents: list[TaskMessageContent]
     emit_updates: bool = True
+    created_at: datetime | None = None
 
 
 class UpdateMessagesBatchParams(BaseModelWithTraceParams):
@@ -59,6 +62,7 @@ class MessagesActivities:
             task_id=params.task_id,
             content=params.content,
             emit_updates=params.emit_updates,
+            created_at=params.created_at,
         )
 
     @activity.defn(name=MessagesActivityName.UPDATE_MESSAGE)
@@ -70,19 +74,16 @@ class MessagesActivities:
         )
 
     @activity.defn(name=MessagesActivityName.CREATE_MESSAGES_BATCH)
-    async def create_messages_batch(
-        self, params: CreateMessagesBatchParams
-    ) -> list[TaskMessage]:
+    async def create_messages_batch(self, params: CreateMessagesBatchParams) -> list[TaskMessage]:
         return await self._messages_service.create_messages_batch(
             task_id=params.task_id,
             contents=params.contents,
             emit_updates=params.emit_updates,
+            created_at=params.created_at,
         )
 
     @activity.defn(name=MessagesActivityName.UPDATE_MESSAGES_BATCH)
-    async def update_messages_batch(
-        self, params: UpdateMessagesBatchParams
-    ) -> list[TaskMessage]:
+    async def update_messages_batch(self, params: UpdateMessagesBatchParams) -> list[TaskMessage]:
         return await self._messages_service.update_messages_batch(
             task_id=params.task_id,
             updates=params.updates,

--- a/src/agentex/lib/core/temporal/activities/adk/providers/litellm_activities.py
+++ b/src/agentex/lib/core/temporal/activities/adk/providers/litellm_activities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from datetime import datetime
 
 from temporalio import activity
 
@@ -27,11 +28,13 @@ class ChatCompletionParams(BaseModelWithTraceParams):
 class ChatCompletionAutoSendParams(BaseModelWithTraceParams):
     task_id: str
     llm_config: LLMConfig
+    created_at: datetime | None = None
 
 
 class ChatCompletionStreamAutoSendParams(BaseModelWithTraceParams):
     task_id: str
     llm_config: LLMConfig
+    created_at: datetime | None = None
 
 
 class LiteLLMActivities:
@@ -56,12 +59,11 @@ class LiteLLMActivities:
             llm_config=params.llm_config,
             trace_id=params.trace_id,
             parent_span_id=params.parent_span_id,
+            created_at=params.created_at,
         )
 
     @activity.defn(name=LiteLLMActivityName.CHAT_COMPLETION_STREAM_AUTO_SEND)
-    async def chat_completion_stream_auto_send(
-        self, params: ChatCompletionStreamAutoSendParams
-    ) -> TaskMessage | None:
+    async def chat_completion_stream_auto_send(self, params: ChatCompletionStreamAutoSendParams) -> TaskMessage | None:
         """
         Activity for streaming chat completion with automatic TaskMessage creation.
         """
@@ -70,4 +72,5 @@ class LiteLLMActivities:
             llm_config=params.llm_config,
             trace_id=params.trace_id,
             parent_span_id=params.parent_span_id,
+            created_at=params.created_at,
         )

--- a/src/agentex/lib/core/temporal/activities/adk/providers/openai_activities.py
+++ b/src/agentex/lib/core/temporal/activities/adk/providers/openai_activities.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 from enum import Enum
 from typing import Any, Literal, Optional
+from datetime import datetime
 from contextlib import AsyncExitStack, asynccontextmanager
 from collections.abc import Callable
 
@@ -455,12 +456,14 @@ class RunAgentAutoSendParams(RunAgentParams):
     """Parameters for running an agent with automatic TaskMessage creation."""
 
     task_id: str
+    created_at: datetime | None = None
 
 
 class RunAgentStreamedAutoSendParams(RunAgentParams):
     """Parameters for running an agent with streaming and automatic TaskMessage creation."""
 
     task_id: str
+    created_at: datetime | None = None
 
 
 @asynccontextmanager
@@ -555,6 +558,7 @@ class OpenAIActivities:
                 mcp_timeout_seconds=params.mcp_timeout_seconds,
                 max_turns=params.max_turns,
                 previous_response_id=params.previous_response_id,
+                created_at=params.created_at,
             )
             return self._to_serializable_run_result(result)
         except InputGuardrailTripwireTriggered as e:
@@ -628,6 +632,7 @@ class OpenAIActivities:
                 mcp_timeout_seconds=params.mcp_timeout_seconds,
                 max_turns=params.max_turns,
                 previous_response_id=params.previous_response_id,
+                created_at=params.created_at,
             )
             return self._to_serializable_run_result_streaming(result)
         except InputGuardrailTripwireTriggered as e:

--- a/src/agentex/lib/utils/temporal.py
+++ b/src/agentex/lib/utils/temporal.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from datetime import datetime
+
 from temporalio import activity, workflow
 
 
@@ -11,3 +15,14 @@ def in_temporal_workflow():
 def heartbeat_if_in_workflow(heartbeat_name: str):
     if in_temporal_workflow():
         activity.heartbeat(heartbeat_name)
+
+
+def workflow_now_if_in_workflow() -> datetime | None:
+    # Returns Temporal's deterministic workflow clock when called from inside a
+    # workflow, otherwise None. Used to stamp messages with a monotonic
+    # `created_at` so two awaited messages.create calls from the same workflow
+    # cannot collide at the server. Outside a workflow (sync agents, plain
+    # async activities) the server's wall clock is fine.
+    if in_temporal_workflow():
+        return workflow.now()
+    return None

--- a/tests/lib/adk/test_messages_module.py
+++ b/tests/lib/adk/test_messages_module.py
@@ -1,0 +1,126 @@
+"""Tests for MessagesModule's workflow.now() auto-injection on create/create_batch.
+
+Verifies that inside a Temporal workflow context, MessagesModule.create and
+create_batch default `created_at` to workflow.now(), threading it through both
+the activity dispatch branch and the direct service-call branch. Outside a
+workflow, created_at remains None and the server's wall clock applies.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import agentex.lib.adk._modules.messages as _messages_mod
+from agentex.types.task_message import TaskMessage
+from agentex.types.text_content import TextContent
+from agentex.lib.adk._modules.messages import MessagesModule
+from agentex.lib.core.services.adk.messages import MessagesService
+
+_FIXED_NOW = datetime(2026, 5, 13, 18, 30, 0, tzinfo=timezone.utc)
+
+
+def _make_task_message() -> TaskMessage:
+    return TaskMessage(
+        id="m1",
+        task_id="t1",
+        content=TextContent(author="agent", content="hi", format="markdown"),
+        streaming_status="DONE",
+    )
+
+
+def _make_module() -> tuple[AsyncMock, MessagesModule]:
+    mock_service = AsyncMock(spec=MessagesService)
+    module = MessagesModule(messages_service=mock_service)
+    return mock_service, module
+
+
+class TestMessagesModuleCreate:
+    @pytest.mark.asyncio
+    async def test_outside_workflow_does_not_inject_created_at(self) -> None:
+        mock_service, module = _make_module()
+        mock_service.create_message.return_value = _make_task_message()
+
+        with patch.object(_messages_mod, "in_temporal_workflow", return_value=False):
+            await module.create(
+                task_id="t1",
+                content=TextContent(author="user", content="hi", format="markdown"),
+            )
+
+        kwargs = mock_service.create_message.call_args.kwargs
+        assert kwargs["created_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_inside_workflow_auto_injects_workflow_now(self) -> None:
+        mock_service, module = _make_module()
+        mock_service.create_message.return_value = _make_task_message()
+
+        # Stub the activity helper so we don't try to actually dispatch.
+        # Capture the params object so we can assert created_at.
+        captured: dict = {}
+
+        async def fake_execute_activity(**call_kwargs):
+            captured.update(call_kwargs)
+            return _make_task_message()
+
+        with patch.object(_messages_mod, "in_temporal_workflow", return_value=True), patch.object(
+            _messages_mod, "workflow_now_if_in_workflow", return_value=_FIXED_NOW
+        ), patch.object(
+            _messages_mod.ActivityHelpers,
+            "execute_activity",
+            side_effect=fake_execute_activity,
+        ):
+            await module.create(
+                task_id="t1",
+                content=TextContent(author="user", content="hi", format="markdown"),
+            )
+
+        params = captured["request"]
+        assert params.created_at == _FIXED_NOW
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_created_at_is_respected(self) -> None:
+        mock_service, module = _make_module()
+        mock_service.create_message.return_value = _make_task_message()
+        caller_ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        # Caller already supplied a timestamp: don't overwrite.
+        with patch.object(_messages_mod, "in_temporal_workflow", return_value=False):
+            await module.create(
+                task_id="t1",
+                content=TextContent(author="user", content="hi", format="markdown"),
+                created_at=caller_ts,
+            )
+
+        kwargs = mock_service.create_message.call_args.kwargs
+        assert kwargs["created_at"] == caller_ts
+
+
+class TestMessagesModuleCreateBatch:
+    @pytest.mark.asyncio
+    async def test_inside_workflow_auto_injects_workflow_now(self) -> None:
+        mock_service, module = _make_module()
+        mock_service.create_messages_batch.return_value = [_make_task_message()]
+
+        captured: dict = {}
+
+        async def fake_execute_activity(**call_kwargs):
+            captured.update(call_kwargs)
+            return [_make_task_message()]
+
+        with patch.object(_messages_mod, "in_temporal_workflow", return_value=True), patch.object(
+            _messages_mod, "workflow_now_if_in_workflow", return_value=_FIXED_NOW
+        ), patch.object(
+            _messages_mod.ActivityHelpers,
+            "execute_activity",
+            side_effect=fake_execute_activity,
+        ):
+            await module.create_batch(
+                task_id="t1",
+                contents=[TextContent(author="user", content="hi", format="markdown")],
+            )
+
+        params = captured["request"]
+        assert params.created_at == _FIXED_NOW

--- a/tests/lib/adk/test_messages_module.py
+++ b/tests/lib/adk/test_messages_module.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
-import pytest
-
 import agentex.lib.adk._modules.messages as _messages_mod
 from agentex.types.task_message import TaskMessage
 from agentex.types.text_content import TextContent
@@ -38,7 +36,6 @@ def _make_module() -> tuple[AsyncMock, MessagesModule]:
 
 
 class TestMessagesModuleCreate:
-    @pytest.mark.asyncio
     async def test_outside_workflow_does_not_inject_created_at(self) -> None:
         mock_service, module = _make_module()
         mock_service.create_message.return_value = _make_task_message()
@@ -52,7 +49,6 @@ class TestMessagesModuleCreate:
         kwargs = mock_service.create_message.call_args.kwargs
         assert kwargs["created_at"] is None
 
-    @pytest.mark.asyncio
     async def test_inside_workflow_auto_injects_workflow_now(self) -> None:
         mock_service, module = _make_module()
         mock_service.create_message.return_value = _make_task_message()
@@ -80,7 +76,6 @@ class TestMessagesModuleCreate:
         params = captured["request"]
         assert params.created_at == _FIXED_NOW
 
-    @pytest.mark.asyncio
     async def test_caller_supplied_created_at_is_respected(self) -> None:
         mock_service, module = _make_module()
         mock_service.create_message.return_value = _make_task_message()
@@ -99,7 +94,6 @@ class TestMessagesModuleCreate:
 
 
 class TestMessagesModuleCreateBatch:
-    @pytest.mark.asyncio
     async def test_inside_workflow_auto_injects_workflow_now(self) -> None:
         mock_service, module = _make_module()
         mock_service.create_messages_batch.return_value = [_make_task_message()]

--- a/tests/lib/adk/test_messages_service.py
+++ b/tests/lib/adk/test_messages_service.py
@@ -1,0 +1,98 @@
+"""Tests for MessagesService created_at forwarding to the SDK client."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import Mock, AsyncMock
+
+from agentex._types import omit
+from agentex.types.task_message import TaskMessage
+from agentex.types.text_content import TextContent
+from agentex.lib.core.services.adk.messages import MessagesService
+
+_TS = datetime(2026, 5, 13, 18, 30, 0, tzinfo=timezone.utc)
+
+
+def _make_task_message() -> TaskMessage:
+    return TaskMessage(
+        id="m1",
+        task_id="t1",
+        content=TextContent(author="agent", content="hi", format="markdown"),
+        streaming_status="DONE",
+    )
+
+
+def _mock_span():
+    span = Mock()
+    span.output = None
+
+    async def __aenter__(_self):
+        return span
+
+    async def __aexit__(_self, *args):
+        return None
+
+    span.__aenter__ = __aenter__
+    span.__aexit__ = __aexit__
+    return span
+
+
+def _make_service() -> tuple[AsyncMock, MessagesService]:
+    client = AsyncMock()
+    streaming = AsyncMock()
+    tracer = Mock()
+    trace = Mock()
+    trace.span.return_value = _mock_span()
+    tracer.trace.return_value = trace
+    svc = MessagesService(
+        agentex_client=client,
+        streaming_service=streaming,
+        tracer=tracer,
+    )
+    return client, svc
+
+
+class TestCreateMessageForwardsCreatedAt:
+    async def test_forwards_when_provided(self) -> None:
+        client, svc = _make_service()
+        client.messages.create.return_value = _make_task_message()
+
+        await svc.create_message(
+            task_id="t1",
+            content=TextContent(author="user", content="hi", format="markdown"),
+            emit_updates=False,
+            created_at=_TS,
+        )
+
+        kwargs = client.messages.create.call_args.kwargs
+        assert kwargs["created_at"] == _TS
+
+    async def test_omits_when_none(self) -> None:
+        client, svc = _make_service()
+        client.messages.create.return_value = _make_task_message()
+
+        await svc.create_message(
+            task_id="t1",
+            content=TextContent(author="user", content="hi", format="markdown"),
+            emit_updates=False,
+        )
+
+        kwargs = client.messages.create.call_args.kwargs
+        # The SDK uses an `omit` sentinel for "leave it to the server".
+        assert kwargs["created_at"] is omit
+
+
+class TestBatchForwardsCreatedAt:
+    async def test_forwards_when_provided(self) -> None:
+        client, svc = _make_service()
+        client.messages.batch.create.return_value = [_make_task_message()]
+
+        await svc.create_messages_batch(
+            task_id="t1",
+            contents=[TextContent(author="user", content="hi", format="markdown")],
+            emit_updates=False,
+            created_at=_TS,
+        )
+
+        kwargs = client.messages.batch.create.call_args.kwargs
+        assert kwargs["created_at"] == _TS

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -5,6 +5,7 @@ These exercise the in-process behavior of the streaming layer without hitting
 Redis or any AgentEx HTTP endpoints — everything below the
 ``StreamingService.stream_update`` boundary is mocked.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -53,9 +54,7 @@ def _text(tm: TaskMessage, s: str) -> StreamTaskMessageDelta:
 def _reasoning_summary(tm: TaskMessage, idx: int, s: str) -> StreamTaskMessageDelta:
     return StreamTaskMessageDelta(
         parent_task_message=tm,
-        delta=ReasoningSummaryDelta(
-            type="reasoning_summary", summary_index=idx, summary_delta=s
-        ),
+        delta=ReasoningSummaryDelta(type="reasoning_summary", summary_index=idx, summary_delta=s),
         type="delta",
     )
 
@@ -89,12 +88,7 @@ class TestDeltaCharLen:
 
     def test_reasoning_summary_delta(self) -> None:
         assert (
-            _delta_char_len(
-                ReasoningSummaryDelta(
-                    type="reasoning_summary", summary_index=0, summary_delta="abc"
-                )
-            )
-            == 3
+            _delta_char_len(ReasoningSummaryDelta(type="reasoning_summary", summary_index=0, summary_delta="abc")) == 3
         )
 
     def test_none_delta_is_zero(self) -> None:
@@ -147,12 +141,8 @@ class TestMergePair:
 
     def test_reasoning_summary_concatenates_and_keeps_index(self) -> None:
         merged = _merge_pair(
-            ReasoningSummaryDelta(
-                type="reasoning_summary", summary_index=2, summary_delta="hello "
-            ),
-            ReasoningSummaryDelta(
-                type="reasoning_summary", summary_index=2, summary_delta="world"
-            ),
+            ReasoningSummaryDelta(type="reasoning_summary", summary_index=2, summary_delta="hello "),
+            ReasoningSummaryDelta(type="reasoning_summary", summary_index=2, summary_delta="world"),
         )
         assert isinstance(merged, ReasoningSummaryDelta)
         assert merged.summary_index == 2
@@ -160,12 +150,8 @@ class TestMergePair:
 
     def test_tool_response_concatenates_and_keeps_call_id(self) -> None:
         merged = _merge_pair(
-            ToolResponseDelta(
-                type="tool_response", tool_call_id="c1", name="t", content_delta="part1 "
-            ),
-            ToolResponseDelta(
-                type="tool_response", tool_call_id="c1", name="t", content_delta="part2"
-            ),
+            ToolResponseDelta(type="tool_response", tool_call_id="c1", name="t", content_delta="part1 "),
+            ToolResponseDelta(type="tool_response", tool_call_id="c1", name="t", content_delta="part2"),
         )
         assert isinstance(merged, ToolResponseDelta)
         assert merged.tool_call_id == "c1"
@@ -199,9 +185,7 @@ class TestMergeConsecutive:
         assert len(merged) == 1
         assert merged[0] is deltas[0]  # same object, no merge happened
 
-    def test_cross_channel_order_preserved_for_reasoning(
-        self, task_message: TaskMessage
-    ) -> None:
+    def test_cross_channel_order_preserved_for_reasoning(self, task_message: TaskMessage) -> None:
         """Consecutive same-(type, index) merges; distinct channels never reorder."""
         deltas = [
             _reasoning_summary(task_message, 0, "Let me "),
@@ -213,15 +197,9 @@ class TestMergeConsecutive:
         merged = _merge_consecutive(deltas)
         # Three groups: idx=0 run, idx=1 single, idx=0 run again — order preserved.
         assert len(merged) == 3
-        assert merged[0].delta is not None and isinstance(
-            merged[0].delta, ReasoningSummaryDelta
-        )
-        assert merged[1].delta is not None and isinstance(
-            merged[1].delta, ReasoningSummaryDelta
-        )
-        assert merged[2].delta is not None and isinstance(
-            merged[2].delta, ReasoningSummaryDelta
-        )
+        assert merged[0].delta is not None and isinstance(merged[0].delta, ReasoningSummaryDelta)
+        assert merged[1].delta is not None and isinstance(merged[1].delta, ReasoningSummaryDelta)
+        assert merged[2].delta is not None and isinstance(merged[2].delta, ReasoningSummaryDelta)
         assert merged[0].delta.summary_index == 0
         assert merged[0].delta.summary_delta == "Let me think..."
         assert merged[1].delta.summary_index == 1
@@ -229,9 +207,7 @@ class TestMergeConsecutive:
         assert merged[2].delta.summary_index == 0
         assert merged[2].delta.summary_delta == " Actually, yes."
 
-    def test_per_channel_concat_matches_per_token_semantics(
-        self, task_message: TaskMessage
-    ) -> None:
+    def test_per_channel_concat_matches_per_token_semantics(self, task_message: TaskMessage) -> None:
         """Reconstructing per-channel content from the merged stream must match
         what a per-token consumer would have seen."""
         deltas = [
@@ -246,18 +222,14 @@ class TestMergeConsecutive:
         for u in merged:
             d = u.delta
             assert isinstance(d, ReasoningSummaryDelta)
-            per_index[d.summary_index] = per_index.get(d.summary_index, "") + (
-                d.summary_delta or ""
-            )
+            per_index[d.summary_index] = per_index.get(d.summary_index, "") + (d.summary_delta or "")
 
         assert per_index == {0: "Hello!", 1: "World"}
 
 
 class TestCoalescingBufferTimeWindow:
     @pytest.mark.asyncio
-    async def test_first_delta_flushes_immediately(
-        self, task_message: TaskMessage
-    ) -> None:
+    async def test_first_delta_flushes_immediately(self, task_message: TaskMessage) -> None:
         """The first-delta-immediate optimization should trip a flush in <=20ms,
         well below the 50ms time window, so consumers see ``something started``."""
         flushed: list[StreamTaskMessageDelta] = []
@@ -272,17 +244,13 @@ class TestCoalescingBufferTimeWindow:
             # Give the ticker a single tick to drain the signal.
             await asyncio.sleep(0.020)
             assert len(flushed) == 1
-            assert flushed[0].delta is not None and isinstance(
-                flushed[0].delta, TextDelta
-            )
+            assert flushed[0].delta is not None and isinstance(flushed[0].delta, TextDelta)
             assert flushed[0].delta.text_delta == "hi"
         finally:
             await buf.close()
 
     @pytest.mark.asyncio
-    async def test_size_threshold_triggers_early_flush(
-        self, task_message: TaskMessage
-    ) -> None:
+    async def test_size_threshold_triggers_early_flush(self, task_message: TaskMessage) -> None:
         """Adding more than MAX_BUFFERED_CHARS in one shot should flush within
         a single asyncio tick, well before the 50ms timer would fire."""
         flushed: list[StreamTaskMessageDelta] = []
@@ -302,17 +270,13 @@ class TestCoalescingBufferTimeWindow:
             await buf.add(_text(task_message, "A" * 200))
             await asyncio.sleep(0.010)  # half the timer interval; only size can fire here
             assert len(flushed) == 1
-            assert flushed[0].delta is not None and isinstance(
-                flushed[0].delta, TextDelta
-            )
+            assert flushed[0].delta is not None and isinstance(flushed[0].delta, TextDelta)
             assert flushed[0].delta.text_delta == "A" * 200
         finally:
             await buf.close()
 
     @pytest.mark.asyncio
-    async def test_subsequent_deltas_coalesce_within_window(
-        self, task_message: TaskMessage
-    ) -> None:
+    async def test_subsequent_deltas_coalesce_within_window(self, task_message: TaskMessage) -> None:
         """Three small deltas added inside one timer window should publish as
         one merged delta (after the initial first-flush burns)."""
         flushed: list[StreamTaskMessageDelta] = []
@@ -333,9 +297,7 @@ class TestCoalescingBufferTimeWindow:
             await asyncio.sleep(0.080)
             # All three small deltas merge into a single publish.
             assert len(flushed) == 1
-            assert flushed[0].delta is not None and isinstance(
-                flushed[0].delta, TextDelta
-            )
+            assert flushed[0].delta is not None and isinstance(flushed[0].delta, TextDelta)
             assert flushed[0].delta.text_delta == "abcdef"
         finally:
             await buf.close()
@@ -343,9 +305,7 @@ class TestCoalescingBufferTimeWindow:
 
 class TestCoalescingBufferClose:
     @pytest.mark.asyncio
-    async def test_close_drains_remaining_buffered_items(
-        self, task_message: TaskMessage
-    ) -> None:
+    async def test_close_drains_remaining_buffered_items(self, task_message: TaskMessage) -> None:
         """Items added after the last timer tick must still flush before close()
         completes — the persisted message body and the stream contract both
         require it."""
@@ -395,9 +355,7 @@ class TestCoalescingBufferClose:
 
 class TestCoalescingBufferCancelDuringFlush:
     @pytest.mark.asyncio
-    async def test_cancel_during_flush_recovers_remaining_items(
-        self, task_message: TaskMessage
-    ) -> None:
+    async def test_cancel_during_flush_recovers_remaining_items(self, task_message: TaskMessage) -> None:
         """Regression: when ``close()`` cancels the ticker mid-flush, items in
         the local ``drained`` list must be re-enqueued so the final drain in
         ``close()`` can recover them. Otherwise the last coalesced batch is
@@ -431,11 +389,7 @@ class TestCoalescingBufferCancelDuringFlush:
         # All five chunks must appear at least once across all publishes.
         # (The first-flushed item may duplicate; that's the documented
         # trade-off — duplicate > silent loss.)
-        full = "".join(
-            u.delta.text_delta or ""
-            for u in flushed
-            if isinstance(u.delta, TextDelta)
-        )
+        full = "".join(u.delta.text_delta or "" for u in flushed if isinstance(u.delta, TextDelta))
         for i in range(5):
             assert f"chunk{i}" in full, (
                 f"chunk{i} missing — silent data loss across cancel-during-flush boundary. "
@@ -452,9 +406,7 @@ class TestStreamingTaskMessageContextModes:
             await ctx.stream_update(_text(tm, chunk))
         # Plenty of time for any background ticker — none should exist.
         await asyncio.sleep(0.080)
-        assert svc.stream_update.call_count == 0, (
-            "off mode must publish zero per-delta updates"
-        )
+        assert svc.stream_update.call_count == 0, "off mode must publish zero per-delta updates"
 
         await ctx.close()
         # The persisted message body must still contain the full assembled text,
@@ -492,6 +444,68 @@ class TestStreamingTaskMessageContextModes:
             if isinstance(call.args[0] if call.args else None, StreamTaskMessageDelta)
         ]
         assert len(delta_publishes) >= 1, "coalesced mode should publish at least one delta"
-        assert len(delta_publishes) < 4, (
-            "coalesced mode should batch at least some of the four chunks"
+        assert len(delta_publishes) < 4, "coalesced mode should batch at least some of the four chunks"
+
+
+class TestStreamingTaskMessageContextCreatedAt:
+    """Verifies the workflow-supplied created_at is forwarded to messages.create
+    on open(), and omitted (server default) when no timestamp is supplied."""
+
+    @pytest.mark.asyncio
+    async def test_open_forwards_created_at(self) -> None:
+        from datetime import datetime, timezone
+
+        from agentex._types import omit
+
+        ts = datetime(2026, 5, 13, 18, 30, 0, tzinfo=timezone.utc)
+        tm = TaskMessage(
+            id="m1",
+            task_id="t1",
+            content=TextContent(author="agent", content="", format="markdown"),
+            streaming_status="IN_PROGRESS",
         )
+        svc = MagicMock()
+        svc.stream_update = AsyncMock()
+        client = MagicMock()
+        client.messages.create = AsyncMock(return_value=tm)
+        client.messages.update = AsyncMock()
+        ctx = StreamingTaskMessageContext(
+            task_id="t1",
+            initial_content=TextContent(author="agent", content="", format="markdown"),
+            agentex_client=client,
+            streaming_service=svc,
+            streaming_mode="off",
+            created_at=ts,
+        )
+        await ctx.open()
+
+        kwargs = client.messages.create.call_args.kwargs
+        assert kwargs["created_at"] == ts
+        assert kwargs["created_at"] is not omit
+
+    @pytest.mark.asyncio
+    async def test_open_without_created_at_passes_omit(self) -> None:
+        from agentex._types import omit
+
+        tm = TaskMessage(
+            id="m1",
+            task_id="t1",
+            content=TextContent(author="agent", content="", format="markdown"),
+            streaming_status="IN_PROGRESS",
+        )
+        svc = MagicMock()
+        svc.stream_update = AsyncMock()
+        client = MagicMock()
+        client.messages.create = AsyncMock(return_value=tm)
+        client.messages.update = AsyncMock()
+        ctx = StreamingTaskMessageContext(
+            task_id="t1",
+            initial_content=TextContent(author="agent", content="", format="markdown"),
+            agentex_client=client,
+            streaming_service=svc,
+            streaming_mode="off",
+        )
+        await ctx.open()
+
+        kwargs = client.messages.create.call_args.kwargs
+        assert kwargs["created_at"] is omit

--- a/tests/lib/test_auto_send_params_created_at.py
+++ b/tests/lib/test_auto_send_params_created_at.py
@@ -1,0 +1,101 @@
+"""Smoke tests confirming the auto-send activity param models accept the new
+`created_at` field added for workflow-driven monotonic message ordering.
+
+These don't exercise the workflow dispatch path (which requires a Temporal
+test environment); they just verify the param surface so callers can rely on
+it being available without runtime errors.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+_TS = datetime(2026, 5, 13, 18, 30, 0, tzinfo=timezone.utc)
+
+
+def test_chat_completion_stream_auto_send_params_accepts_created_at() -> None:
+    from agentex.lib.types.llm_messages import LLMConfig
+    from agentex.lib.core.temporal.activities.adk.providers.litellm_activities import (
+        ChatCompletionStreamAutoSendParams,
+    )
+
+    params = ChatCompletionStreamAutoSendParams(
+        task_id="t1",
+        llm_config=LLMConfig(model="gpt-4o", messages=[]),
+        created_at=_TS,
+    )
+    assert params.created_at == _TS
+
+
+def test_chat_completion_auto_send_params_accepts_created_at() -> None:
+    from agentex.lib.types.llm_messages import LLMConfig
+    from agentex.lib.core.temporal.activities.adk.providers.litellm_activities import (
+        ChatCompletionAutoSendParams,
+    )
+
+    params = ChatCompletionAutoSendParams(
+        task_id="t1",
+        llm_config=LLMConfig(model="gpt-4o", messages=[]),
+        created_at=_TS,
+    )
+    assert params.created_at == _TS
+
+
+def test_run_agent_auto_send_params_accepts_created_at() -> None:
+    from agentex.lib.core.temporal.activities.adk.providers.openai_activities import (
+        RunAgentAutoSendParams,
+    )
+
+    params = RunAgentAutoSendParams(
+        task_id="t1",
+        input_list=[{"role": "user", "content": "hi"}],
+        mcp_server_params=[],
+        agent_name="x",
+        agent_instructions="y",
+        created_at=_TS,
+    )
+    assert params.created_at == _TS
+
+
+def test_run_agent_streamed_auto_send_params_accepts_created_at() -> None:
+    from agentex.lib.core.temporal.activities.adk.providers.openai_activities import (
+        RunAgentStreamedAutoSendParams,
+    )
+
+    params = RunAgentStreamedAutoSendParams(
+        task_id="t1",
+        input_list=[{"role": "user", "content": "hi"}],
+        mcp_server_params=[],
+        agent_name="x",
+        agent_instructions="y",
+        created_at=_TS,
+    )
+    assert params.created_at == _TS
+
+
+def test_create_message_params_accepts_created_at() -> None:
+    from agentex.types.text_content import TextContent
+    from agentex.lib.core.temporal.activities.adk.messages_activities import (
+        CreateMessageParams,
+    )
+
+    params = CreateMessageParams(
+        task_id="t1",
+        content=TextContent(author="user", content="hi", format="markdown"),
+        created_at=_TS,
+    )
+    assert params.created_at == _TS
+
+
+def test_create_messages_batch_params_accepts_created_at() -> None:
+    from agentex.types.text_content import TextContent
+    from agentex.lib.core.temporal.activities.adk.messages_activities import (
+        CreateMessagesBatchParams,
+    )
+
+    params = CreateMessagesBatchParams(
+        task_id="t1",
+        contents=[TextContent(author="user", content="hi", format="markdown")],
+        created_at=_TS,
+    )
+    assert params.created_at == _TS

--- a/tests/lib/test_temporal_utils.py
+++ b/tests/lib/test_temporal_utils.py
@@ -1,0 +1,30 @@
+"""Tests for agentex.lib.utils.temporal helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+from agentex.lib.utils import temporal as _temporal_mod
+from agentex.lib.utils.temporal import (
+    in_temporal_workflow,
+    workflow_now_if_in_workflow,
+)
+
+
+def test_in_temporal_workflow_returns_false_outside_workflow() -> None:
+    # Calling outside a workflow context raises RuntimeError internally, which
+    # the helper swallows.
+    assert in_temporal_workflow() is False
+
+
+def test_workflow_now_if_in_workflow_returns_none_outside_workflow() -> None:
+    assert workflow_now_if_in_workflow() is None
+
+
+def test_workflow_now_if_in_workflow_returns_workflow_now_when_inside() -> None:
+    fixed = datetime(2026, 5, 13, 18, 30, 0)
+    with patch.object(_temporal_mod, "in_temporal_workflow", return_value=True), patch.object(
+        _temporal_mod.workflow, "now", return_value=fixed
+    ):
+        assert workflow_now_if_in_workflow() == fixed


### PR DESCRIPTION
## Summary

Pairs with scaleapi/scale-agentex#233 (server now respects caller-supplied `created_at`). Without an SDK-side timestamp, the workflow-side user-echo and the activity-side assistant-shell `messages.create` calls can land at the server within the same millisecond, and the assistant turn sorts before the user message that triggered it on reload. This PR closes the gap on the SDK side.

- `MessagesModule.create` / `create_batch` auto-inject `workflow.now()` inside a Temporal workflow; caller-supplied values are respected; outside workflows the value stays `None` so the server wall-clock applies (sync / plain-async agents are unaffected).
- `CreateMessageParams` / `CreateMessagesBatchParams` and `MessagesService` thread `created_at` to the SDK client (`omit` sentinel when `None`).
- `StreamingTaskMessageContext` + `streaming_task_message_context` factory accept `created_at` and forward to the initial `messages.create` in `open()`.
- Auto-send dispatchers (`adk.providers.litellm` / `.openai`) capture `workflow.now()` at the workflow→activity boundary and thread it through `ChatCompletion*AutoSendParams` / `RunAgent(Streamed)AutoSendParams`. Inside the activity the timestamp is consumed once on the first streaming context per turn — later contexts in the same turn naturally separate via network/processing latency plus PR 233's ms-stagger.
- `workflow_now_if_in_workflow()` helper in `lib.utils.temporal`.

## Test plan

- [x] `rye run pytest tests/lib --ignore=tests/lib/test_payload_codec.py` — 266 passed, 2 skipped (the ignored file has pre-existing failures unrelated to this change)
- [x] `rye run ruff check` on every touched file — clean
- [x] `rye run pyright` on every touched src file — clean (fixed an unrelated ruff-format regression that had moved 4 `# type: ignore` comments off-target in `providers/openai.py`)
- New tests:
  - `tests/lib/test_temporal_utils.py` — `workflow_now_if_in_workflow` helper, inside/outside workflow
  - `tests/lib/test_auto_send_params_created_at.py` — every auto-send + messages activity param model accepts `created_at`
  - `tests/lib/adk/test_messages_module.py` — `MessagesModule` auto-injects `workflow.now()` inside workflow, respects caller-supplied values, omits outside workflow
  - `tests/lib/adk/test_messages_service.py` — service forwards `created_at` to the SDK client and passes `omit` when `None`
  - extends `tests/lib/core/services/adk/test_streaming.py` with two `StreamingTaskMessageContext.open()` cases (with and without `created_at`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Introduces `workflow_now_if_in_workflow()` to stamp messages with Temporal's deterministic clock at the workflow→activity boundary, fixing a race condition where assistant messages could sort before user messages on reload.
- Threads `created_at` through `MessagesModule`, `MessagesService`, `StreamingTaskMessageContext`, and all auto-send provider paths (LiteLLM and OpenAI); uses an `omit` sentinel when `None` so outside-workflow agents are unaffected.
- Uses a single-fire `_make_created_at_dispenser` closure in the OpenAI service so only the first streaming context per activity invocation receives the workflow timestamp; subsequent messages rely on server wall-clock + server-side ms-stagger from PR #233.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no correctness, security, or data-integrity issues found.

The change is a clean, layered threading of an optional created_at field. The helper correctly delegates to workflow.now() only inside a Temporal workflow, the omit sentinel is applied consistently so outside-workflow agents are unaffected, and the single-fire dispenser in the OpenAI service correctly stamps only the first message per turn. Tests cover all key branches. No P1 or P0 findings.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/utils/temporal.py | Adds workflow_now_if_in_workflow() — returns workflow.now() inside a Temporal workflow, None elsewhere. Simple, correct, well-tested. |
| src/agentex/lib/adk/_modules/messages.py | Auto-injects workflow_now_if_in_workflow() into created_at for both create and create_batch; respects caller-supplied values; correctly threads through both the activity-dispatch and direct-service-call branches. |
| src/agentex/lib/core/services/adk/providers/openai.py | Adds _make_created_at_dispenser closure to stamp only the first streaming context per turn; correctly applied across all streaming context creation sites in both run_agent_auto_send and run_agent_streamed_auto_send. |
| src/agentex/lib/core/services/adk/streaming.py | Adds created_at to StreamingTaskMessageContext.__init__ and forwards it via the omit sentinel in open(). |
| src/agentex/lib/core/services/adk/messages.py | Forwards created_at to the SDK client with omit sentinel when None; logic is consistent across create_message and create_messages_batch. |
| src/agentex/lib/core/temporal/activities/adk/messages_activities.py | Adds created_at: datetime | None = None to CreateMessageParams and CreateMessagesBatchParams, and threads it to the service layer. |
| tests/lib/adk/test_messages_module.py | New tests covering auto-injection inside workflow, no injection outside workflow, and respect for caller-supplied timestamps. |
| tests/lib/core/services/adk/test_streaming.py | Extends existing streaming tests with two new cases validating created_at forwarding and omit sentinel in StreamingTaskMessageContext.open(). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Temporal Workflow
    participant MM as MessagesModule
    participant AA as ActivityHelpers
    participant MA as MessagesActivities
    participant MS as MessagesService
    participant SDK as Agentex SDK Client

    W->>MM: messages.create(task_id, content)
    MM->>MM: "created_at = workflow_now_if_in_workflow()"
    MM->>AA: "execute_activity(CreateMessageParams{created_at})"
    AA->>MA: create_message(params)
    MA->>MS: create_message(task_id, content, created_at)
    MS->>SDK: messages.create(task_id, content, created_at)
    SDK-->>W: TaskMessage

    Note over W,SDK: LiteLLM/OpenAI auto-send path
    W->>W: "params = AutoSendParams(created_at=workflow_now_if_in_workflow())"
    W->>AA: execute_activity(params)
    AA->>MS: chat_completion_auto_send(created_at)
    MS->>MS: _make_created_at_dispenser(created_at)
    MS->>SDK: "messages.create(created_at=workflow_now) [first msg]"
    MS->>SDK: "messages.create(created_at=omit) [subsequent msgs]"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: address PR review comments on ..."](https://github.com/scaleapi/scale-agentex-python/commit/a83ed87ae35832d21958ed9fedc291c58c55a3ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32031240)</sub>

<!-- /greptile_comment -->