### PR TITLE
fix: resolve lint and test failures from new endpoints

### DIFF
--- a/src/agentex/resources/agents/agents.py
+++ b/src/agentex/resources/agents/agents.py
@@ -38,7 +38,14 @@ from .deployments import (
 )
 from ...types.agent import Agent
 from ..._base_client import make_request_options
-from ...types.agent_rpc_response import AgentRpcResponse
+from ...types.agent_rpc_response import (
+    AgentRpcResponse,
+    CancelTaskResponse,
+    CreateTaskResponse,
+    SendEventResponse,
+    SendMessageResponse,
+    SendMessageStreamResponse,
+)
 from ...types.agent_list_response import AgentListResponse
 from ...types.shared.delete_response import DeleteResponse
 

--- a/src/agentex/resources/agents/agents.py
+++ b/src/agentex/resources/agents/agents.py
@@ -10,7 +10,7 @@ import httpx
 from pydantic import ValidationError
 
 from ...types import agent_rpc_params, agent_list_params, agent_rpc_by_name_params
-from ..._types import Body, Omit, Query, Headers, NotGiven, omit, not_given
+from ..._types import NOT_GIVEN, Body, Omit, Query, Headers, NotGiven, omit, not_given
 from ..._utils import path_template, maybe_transform, async_maybe_transform
 from ..._compat import cached_property
 from .schedules import (

--- a/src/agentex/resources/agents/agents.py
+++ b/src/agentex/resources/agents/agents.py
@@ -40,9 +40,9 @@ from ...types.agent import Agent
 from ..._base_client import make_request_options
 from ...types.agent_rpc_response import (
     AgentRpcResponse,
+    SendEventResponse,
     CancelTaskResponse,
     CreateTaskResponse,
-    SendEventResponse,
     SendMessageResponse,
     SendMessageStreamResponse,
 )

--- a/src/agentex/types/agent_rpc_response.py
+++ b/src/agentex/types/agent_rpc_response.py
@@ -11,7 +11,14 @@ from .task_message import TaskMessage
 from .agent_rpc_result import AgentRpcResult
 from .task_message_update import TaskMessageUpdate
 
-__all__ = ["AgentRpcResponse"]
+__all__ = [
+    "AgentRpcResponse",
+    "CancelTaskResponse",
+    "CreateTaskResponse",
+    "SendEventResponse",
+    "SendMessageResponse",
+    "SendMessageStreamResponse",
+]
 
 
 class BaseAgentRpcResponse(BaseModel):

--- a/tests/api_resources/agents/test_deployments.py
+++ b/tests/api_resources/agents/test_deployments.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 import pytest
 
 from agentex import Agentex, AsyncAgentex
-from tests.utils import assert_matches_type
 from agentex.types import AgentRpcResponse
 from agentex.types.agents import (
     DeploymentListResponse,
@@ -17,6 +16,8 @@ from agentex.types.agents import (
     DeploymentRetrieveResponse,
 )
 from agentex.types.shared import DeleteResponse
+
+from ...utils import assert_matches_type
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 

--- a/tests/api_resources/agents/test_schedules.py
+++ b/tests/api_resources/agents/test_schedules.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 import pytest
 
 from agentex import Agentex, AsyncAgentex
-from tests.utils import assert_matches_type
 from agentex._utils import parse_datetime
 from agentex.types.agents import (
     ScheduleListResponse,
@@ -19,6 +18,8 @@ from agentex.types.agents import (
     ScheduleRetrieveResponse,
 )
 from agentex.types.shared import DeleteResponse
+
+from ...utils import assert_matches_type
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 

--- a/tests/api_resources/test_checkpoints.py
+++ b/tests/api_resources/test_checkpoints.py
@@ -8,12 +8,13 @@ from typing import Any, Optional, cast
 import pytest
 
 from agentex import Agentex, AsyncAgentex
-from tests.utils import assert_matches_type
 from agentex.types import (
     CheckpointPutResponse,
     CheckpointListResponse,
     CheckpointGetTupleResponse,
 )
+
+from ..utils import assert_matches_type
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 


### PR DESCRIPTION
## Summary
- Add `NOT_GIVEN` to the `_types` import in `src/agentex/resources/agents/agents.py` to fix `NameError: name 'NOT_GIVEN' is not defined` raised by the custom `create_task`/`cancel_task` helpers (which surfaced in `tests/test_client.py::test_retrying_timeout_errors_doesnt_leak`).
- Convert `from tests.utils import assert_matches_type` to relative imports in the new test files for checkpoints, deployments, and schedules so pyright can resolve them (matches the convention used by every other generated test).

## Test plan
- [x] `rye run pytest tests/test_client.py tests/api_resources/test_checkpoints.py tests/api_resources/agents/` — 145 passed, 392 skipped
- [x] `rye run lint` — All checks passed
- [x] `rye run pyright tests/api_resources/test_checkpoints.py tests/api_resources/agents/test_deployments.py tests/api_resources/agents/test_schedules.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves two categories of lint/test failures introduced by recently added custom RPC helper endpoints. It adds the missing `NOT_GIVEN` sentinel import and expands the `agent_rpc_response` import block in `agents.py`, and converts three test files from absolute `tests.utils` imports to relative imports matching the project convention.

- **`NOT_GIVEN` import fix**: The custom helpers (`create_task`, `cancel_task`, `send_message`, etc.) already used `NOT_GIVEN` as a default value, but it was never imported — causing a `NameError` at module load time. Adding it to the `_types` import line resolves this.
- **`agent_rpc_response` expansion**: The six specific response type aliases (`CreateTaskResponse`, `CancelTaskResponse`, etc.) are now imported by name and added to `__all__` so they are properly accessible and re-exportable.
- **Test relative imports**: `test_checkpoints.py`, `test_deployments.py`, and `test_schedules.py` are each updated to use the correct relative import path that matches every other generated test in the repo and satisfies pyright's module resolution.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All changes are targeted import fixes with no logic changes; the custom RPC helper methods themselves are untouched and tests pass.

The diff is entirely mechanical: one missing sentinel is added to an import line, six names are added to an __all__ list, and three test files switch from absolute to relative imports. No behaviour changes are introduced, the test suite and pyright both pass per the PR description, and the patterns used match the rest of the codebase.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/resources/agents/agents.py | Adds NOT_GIVEN to the _types import (fixing NameError) and expands the agent_rpc_response import to pull in the five typed helper response classes used by the custom RPC methods. |
| src/agentex/types/agent_rpc_response.py | Extends __all__ to expose the five new response type aliases (CreateTaskResponse, CancelTaskResponse, SendMessageResponse, SendMessageStreamResponse, SendEventResponse) alongside the existing AgentRpcResponse. |
| tests/api_resources/test_checkpoints.py | Switches assert_matches_type import from absolute (tests.utils) to relative (..utils) to match project convention and fix pyright resolution. |
| tests/api_resources/agents/test_deployments.py | Switches assert_matches_type import from absolute to relative (...utils) to match project convention and fix pyright resolution. |
| tests/api_resources/agents/test_schedules.py | Switches assert_matches_type import from absolute to relative (...utils) to match project convention and fix pyright resolution. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant AgentsResource
    participant rpc / rpc_by_name
    participant agent_rpc_response

    Caller->>AgentsResource: create_task(agent_id, params)
    AgentsResource->>rpc / rpc_by_name: method="task/create", id=NOT_GIVEN, jsonrpc=NOT_GIVEN
    rpc / rpc_by_name-->>AgentsResource: AgentRpcResponse
    AgentsResource->>agent_rpc_response: CreateTaskResponse.model_validate(...)
    agent_rpc_response-->>Caller: CreateTaskResponse

    Caller->>AgentsResource: cancel_task(agent_name, params)
    AgentsResource->>rpc / rpc_by_name: method="task/cancel"
    rpc / rpc_by_name-->>AgentsResource: AgentRpcResponse
    AgentsResource->>agent_rpc_response: CancelTaskResponse.model_validate(...)
    agent_rpc_response-->>Caller: CancelTaskResponse

    Caller->>AgentsResource: send_message(agent_id, params)
    AgentsResource->>rpc / rpc_by_name: method="message/send" (streaming)
    rpc / rpc_by_name-->>AgentsResource: SSE stream
    AgentsResource->>agent_rpc_response: SendMessageResponse / SendMessageStreamResponse
    agent_rpc_response-->>Caller: SendMessageResponse
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: sort imports in agents resource"](https://github.com/scaleapi/scale-agentex-python/commit/1e3219beb27618771c965e7811ad8416ea9ad487) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32711749)</sub>

<!-- /greptile_comment -->