### PR TITLE
feat(observability): add instrumented_chat_stream for LiteLLM streaming metrics

### DIFF
--- a/src/agentex/lib/core/observability/instrumented_chat_stream.py
+++ b/src/agentex/lib/core/observability/instrumented_chat_stream.py
@@ -1,0 +1,173 @@
+"""Async-generator wrapper that instruments a ChatCompletions stream with OTel metrics.
+
+Agents using LiteLLM's ``acompletion(stream=True)`` paired with the
+openai-agents-sdk ``ChatCmplStreamHandler`` can wrap their stream with
+:func:`instrumented_chat_stream` to get TTFT, TTAT, TPS, cached-token,
+and reasoning-token metrics automatically — no per-agent boilerplate.
+
+Usage::
+
+    from agentex.lib.core.observability.instrumented_chat_stream import instrumented_chat_stream
+
+    stream = await litellm.acompletion(**kwargs, stream=True)
+    response = Response(...)  # placeholder for ChatCmplStreamHandler
+    async for event in instrumented_chat_stream(stream, response, model_name):
+        yield event
+"""
+
+from __future__ import annotations
+
+import time
+import logging
+from typing import Any
+from collections.abc import AsyncIterator
+
+from agents.items import TResponseStreamEvent
+from openai.types.responses import (
+    Response,
+    ResponseCompletedEvent,
+    ResponseTextDeltaEvent,
+    ResponseReasoningTextDeltaEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+)
+from agents.models.chatcmpl_stream_handler import ChatCmplStreamHandler
+
+from agentex.lib.core.observability.llm_metrics import get_llm_metrics
+from agentex.lib.core.observability.llm_metrics_hooks import record_llm_failure
+
+logger = logging.getLogger(__name__)
+
+# Event types that produce tokens (for first_token_at / last_token_at).
+_TOKEN_EVENTS = (
+    ResponseTextDeltaEvent,
+    ResponseReasoningTextDeltaEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+)
+
+# Event types that produce *answer* tokens — excludes reasoning (for first_answer_at).
+_ANSWER_EVENTS = (
+    ResponseTextDeltaEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+)
+
+
+async def instrumented_chat_stream(
+    raw_stream: AsyncIterator,
+    response: Response,
+    model_name: str,
+) -> AsyncIterator[TResponseStreamEvent]:
+    """Wrap a LiteLLM ChatCompletions stream with OTel metrics instrumentation.
+
+    Yields every ``TResponseStreamEvent`` unchanged while recording:
+
+    * ``agentex.llm.ttft`` — time to first content token (ms)
+    * ``agentex.llm.ttat`` — time to first answering token, excludes reasoning (ms)
+    * ``agentex.llm.tps``  — output tokens / second over the generation window
+    * ``agentex.llm.cached_input_tokens`` — prompt-cache hits
+    * ``agentex.llm.reasoning_tokens``    — reasoning output tokens
+
+    On exception the ``agentex.llm.requests`` failure counter is bumped via
+    :func:`record_llm_failure`.
+
+    Parameters
+    ----------
+    raw_stream:
+        The async iterator returned by ``litellm.acompletion(stream=True)``.
+    response:
+        A placeholder ``Response`` object required by ``ChatCmplStreamHandler``.
+    model_name:
+        Model identifier used as the ``model`` metric attribute.
+    """
+    # --- Usage capture wrapper ---------------------------------------------------
+    # LiteLLM's CustomStreamWrapper strips prompt_tokens_details and
+    # completion_tokens_details from outgoing chunks.  After the stream ends,
+    # stream_chunk_builder() reconstructs the full Usage and writes it back
+    # into the *same* _hidden_params dict (shared by reference).  We capture
+    # both the raw per-chunk usage and the _hidden_params reference so we can
+    # read the complete Usage after iteration.
+    raw_usage: Any = None
+    _last_hidden_params: dict[str, Any] | None = None
+
+    async def _usage_capturing_stream():  # type: ignore[return]
+        nonlocal raw_usage, _last_hidden_params
+        async for chunk in raw_stream:
+            if hasattr(chunk, "usage") and chunk.usage is not None:
+                raw_usage = chunk.usage
+            hp = getattr(chunk, "_hidden_params", None)
+            if isinstance(hp, dict):
+                _last_hidden_params = hp
+            yield chunk
+
+    # --- Timing bookmarks --------------------------------------------------------
+    stream_start = time.perf_counter()
+    first_token_at: float | None = None
+    first_answer_at: float | None = None
+    last_token_at: float | None = None
+    output_tokens_count = 0
+
+    try:
+        async for event in ChatCmplStreamHandler.handle_stream(response, _usage_capturing_stream()):
+            if isinstance(event, _TOKEN_EVENTS):
+                now = time.perf_counter()
+                if first_token_at is None:
+                    first_token_at = now
+                if first_answer_at is None and isinstance(event, _ANSWER_EVENTS):
+                    first_answer_at = now
+                last_token_at = now
+            elif isinstance(event, ResponseCompletedEvent):
+                try:
+                    if event.response and event.response.usage:
+                        output_tokens_count = event.response.usage.output_tokens or 0
+                except Exception:
+                    pass
+            yield event
+    except Exception as exc:
+        record_llm_failure(model_name, exc)
+        raise
+    finally:
+        try:
+            m = get_llm_metrics()
+            attrs = {"model": model_name}
+
+            # --- Timing metrics --------------------------------------------------
+            if first_token_at is not None:
+                m.ttft_ms.record((first_token_at - stream_start) * 1000, attrs)
+            if first_answer_at is not None:
+                m.ttat_ms.record((first_answer_at - stream_start) * 1000, attrs)
+            if (
+                first_token_at is not None
+                and last_token_at is not None
+                and last_token_at > first_token_at
+                and output_tokens_count > 0
+            ):
+                m.tps.record(output_tokens_count / (last_token_at - first_token_at), attrs)
+
+            # --- Token detail counters -------------------------------------------
+            # Prefer _hidden_params["usage"] (reconstructed by stream_chunk_builder
+            # with all detail fields) over raw per-chunk usage.
+            if _last_hidden_params is not None:
+                hp_usage = _last_hidden_params.get("usage")
+                if hp_usage is not None:
+                    raw_usage = hp_usage
+
+            cached_tokens = 0
+            reasoning_tokens = 0
+            if raw_usage is not None:
+                # prompt_tokens_details.cached_tokens (standard OpenAI field)
+                ptd = getattr(raw_usage, "prompt_tokens_details", None)
+                if ptd is not None:
+                    cached_tokens = getattr(ptd, "cached_tokens", 0) or 0
+                # Fallback: LiteLLM PrivateAttr _cache_read_input_tokens
+                if not cached_tokens:
+                    cached_tokens = getattr(raw_usage, "_cache_read_input_tokens", 0) or 0
+
+                ctd = getattr(raw_usage, "completion_tokens_details", None)
+                if ctd is not None:
+                    reasoning_tokens = getattr(ctd, "reasoning_tokens", 0) or 0
+
+            if cached_tokens > 0:
+                m.cached_input_tokens.add(cached_tokens, attrs)
+            if reasoning_tokens > 0:
+                m.reasoning_tokens.add(reasoning_tokens, attrs)
+        except Exception:
+            pass


### PR DESCRIPTION
Summary: Adds instrumented_chat_stream, an async generator wrapper that instruments a LiteLLM ChatCompletions stream with OTel metrics (TTFT, TTAT, TPS, cached input tokens, reasoning tokens)

Context:
Currently we have two LLM streaming paths:

1. OpenAI Responses API: handled by `TemporalStreamingModel`, which has inline ttft/ttat/tps instrumentation (done in #347)
2. LiteLLM ChatCompletions: used by custom agents (DUA, etc.) via `ChatCmplStreamHandler`, with no SDK-level streaming metrics

For the second path, the existing metrics infrastructure covers token counters but not streaming latency:

Problem:
- `LLMMetricsHooks.on_llm_end` fires after the Runner fully consumes the stream and assembles a final ModelResponse. It records requests, input_tokens, output_tokens, cached_input_tokens, and reasoning_token, but it cannot record TTFT/TTAT/TPS because it never sees individual chunks or their arrival times.
- TemporalStreamingModel records ttft/ttat/tps inline during its own stream iteration, but this only applies to the Responses API path. Agents using LiteLLM don't go through this class.

Solution:
This PR introduces a reusable SDK helper for agents using LiteLLM streaming

Usage Example (DUA):
https://github.com/scaleapi/agentex-agents/pull/1556

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `instrumented_chat_stream`, an async generator wrapper that augments LiteLLM ChatCompletions streaming calls with OTel metrics (TTFT, TTAT, TPS, cached-token, and reasoning-token counts), filling the gap left by `LLMMetricsHooks.on_llm_end` which cannot observe individual streaming chunks.

- The wrapper interposes on `ChatCmplStreamHandler.handle_stream`, capturing `time.perf_counter()` timestamps on each `ResponseTextDeltaEvent`, `ResponseReasoningTextDeltaEvent`, and `ResponseFunctionCallArgumentsDeltaEvent` to derive per-request TTFT, TTAT, and TPS histograms.
- Token-detail counters (`cached_input_tokens`, `reasoning_tokens`) are extracted from LiteLLM's `_hidden_params` dict — a shared-by-reference object that `stream_chunk_builder` populates after the stream ends — rather than from the assembled ModelResponse, where LiteLLM strips these fields.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the new file is additive and only fires when callers explicitly wrap their stream with it, leaving all existing paths unchanged.

The core instrumentation logic is sound: timing bookmarks are captured in the right order, `_hidden_params` is accessed after iteration completes, and the fallback chain for token-detail extraction is well-documented. Two concerns: the `model_name` label must match what `agent.model` produces or latency and request/token metrics will diverge in dashboards; and the no-double-count guarantee for cached/reasoning tokens relies on an undocumented LiteLLM internal behavior that could change across upgrades.

src/agentex/lib/core/observability/instrumented_chat_stream.py — verify the model_name convention matches agent.model and consider adding a comment or test to protect the no-double-count invariant.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/observability/instrumented_chat_stream.py | New async generator wrapper for LiteLLM streaming metrics. Well-structured with careful LiteLLM internals handling, but callers must ensure `model_name` matches `agent.model` or timing and request metrics will be unjoined in dashboards. Potential future double-counting of cached/reasoning tokens if LiteLLM behavior changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant instrumented_chat_stream
    participant _usage_capturing_stream
    participant ChatCmplStreamHandler
    participant LiteLLM raw_stream

    Agent->>instrumented_chat_stream: async for event in ...
    Note over instrumented_chat_stream: stream_start = perf_counter()
    instrumented_chat_stream->>ChatCmplStreamHandler: handle_stream(response, _usage_capturing_stream())
    loop Each chunk
        ChatCmplStreamHandler->>_usage_capturing_stream: __anext__()
        _usage_capturing_stream->>LiteLLM raw_stream: __anext__()
        LiteLLM raw_stream-->>_usage_capturing_stream: chunk (usage + _hidden_params captured)
        _usage_capturing_stream-->>ChatCmplStreamHandler: chunk
        ChatCmplStreamHandler-->>instrumented_chat_stream: TResponseStreamEvent
        alt TOKEN event (Text/Reasoning/FnCall delta)
            Note over instrumented_chat_stream: first_token_at / first_answer_at / last_token_at updated
        else ResponseCompletedEvent
            Note over instrumented_chat_stream: output_tokens_count captured
        end
        instrumented_chat_stream-->>Agent: yield event (unchanged)
    end
    Note over instrumented_chat_stream: finally block runs
    Note over instrumented_chat_stream: record ttft_ms, ttat_ms, tps
    Note over instrumented_chat_stream: extract cached/reasoning tokens from _hidden_params["usage"]
    Note over instrumented_chat_stream: record cached_input_tokens, reasoning_tokens
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fobservability%2Finstrumented_chat_stream.py%3A54-58%0A**%60model_name%60%20vs%20%60agent.model%60%20metric%20attribute%20mismatch**%0A%0A%60instrumented_chat_stream%60%20records%20TTFT%2FTTAT%2FTPS%20under%20%60%7B%22model%22%3A%20model_name%7D%60%2C%20while%20%60LLMMetricsHooks.on_llm_end%60%20records%20requests%20and%20token%20counters%20under%20%60%7B%22model%22%3A%20str%28agent.model%29%20if%20agent.model%20else%20%22unknown%22%7D%60.%20If%20callers%20pass%20the%20model%20identifier%20in%20a%20different%20format%20than%20what%20%60agent.model%60%20produces%20%28e.g.%2C%20%60%22openai%2Fgpt-4%22%60%20vs%20%60%22gpt-4%22%60%29%2C%20the%20two%20metric%20families%20will%20have%20a%20different%20%60model%60%20label%20value%20and%20cannot%20be%20correlated%20in%20dashboards.%20The%20docstring%20should%20specify%20the%20expected%20format%20%E2%80%94%20or%20accept%20the%20model%20from%20the%20same%20source%20as%20%60agent.model%60%20to%20guarantee%20alignment.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fobservability%2Finstrumented_chat_stream.py%3A145-171%0A**Potential%20double-counting%20of%20%60cached_input_tokens%60%20and%20%60reasoning_tokens%60**%0A%0A%60LLMMetricsHooks.on_llm_end%60%20also%20calls%20%60m.cached_input_tokens.add%28usage.input_tokens_details.cached_tokens%20or%200%2C%20attrs%29%60%20and%20%60m.reasoning_tokens.add%28usage.output_tokens_details.reasoning_tokens%20or%200%2C%20attrs%29%60.%20The%20PR's%20invariant%20%E2%80%94%20that%20LiteLLM%20strips%20these%20detail%20fields%20from%20the%20assembled%20%60ModelResponse%60%20so%20%60on_llm_end%60%20will%20always%20see%20%60None%60%20and%20skip%20them%20%E2%80%94%20is%20not%20codified%20in%20the%20code%20or%20tests.%20If%20a%20future%20LiteLLM%20version%20or%20a%20different%20provider%20does%20populate%20%60input_tokens_details%60%20in%20the%20assembled%20response%2C%20both%20paths%20will%20%60.add%28%29%60%20to%20the%20same%20OTel%20counter%20for%20the%20same%20request%2C%20doubling%20the%20values.%20Adding%20a%20brief%20inline%20comment%20%28or%20an%20integration%20test%20assertion%29%20that%20documents%20why%20double-counting%20cannot%20occur%20would%20make%20this%20assumption%20explicit%20and%20catch%20regressions%20early.%0A%0A&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fobservability%2Finstrumented_chat_stream.py%3A54-58%0A**%60model_name%60%20vs%20%60agent.model%60%20metric%20attribute%20mismatch**%0A%0A%60instrumented_chat_stream%60%20records%20TTFT%2FTTAT%2FTPS%20under%20%60%7B%22model%22%3A%20model_name%7D%60%2C%20while%20%60LLMMetricsHooks.on_llm_end%60%20records%20requests%20and%20token%20counters%20under%20%60%7B%22model%22%3A%20str%28agent.model%29%20if%20agent.model%20else%20%22unknown%22%7D%60.%20If%20callers%20pass%20the%20model%20identifier%20in%20a%20different%20format%20than%20what%20%60agent.model%60%20produces%20%28e.g.%2C%20%60%22openai%2Fgpt-4%22%60%20vs%20%60%22gpt-4%22%60%29%2C%20the%20two%20metric%20families%20will%20have%20a%20different%20%60model%60%20label%20value%20and%20cannot%20be%20correlated%20in%20dashboards.%20The%20docstring%20should%20specify%20the%20expected%20format%20%E2%80%94%20or%20accept%20the%20model%20from%20the%20same%20source%20as%20%60agent.model%60%20to%20guarantee%20alignment.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fobservability%2Finstrumented_chat_stream.py%3A145-171%0A**Potential%20double-counting%20of%20%60cached_input_tokens%60%20and%20%60reasoning_tokens%60**%0A%0A%60LLMMetricsHooks.on_llm_end%60%20also%20calls%20%60m.cached_input_tokens.add%28usage.input_tokens_details.cached_tokens%20or%200%2C%20attrs%29%60%20and%20%60m.reasoning_tokens.add%28usage.output_tokens_details.reasoning_tokens%20or%200%2C%20attrs%29%60.%20The%20PR's%20invariant%20%E2%80%94%20that%20LiteLLM%20strips%20these%20detail%20fields%20from%20the%20assembled%20%60ModelResponse%60%20so%20%60on_llm_end%60%20will%20always%20see%20%60None%60%20and%20skip%20them%20%E2%80%94%20is%20not%20codified%20in%20the%20code%20or%20tests.%20If%20a%20future%20LiteLLM%20version%20or%20a%20different%20provider%20does%20populate%20%60input_tokens_details%60%20in%20the%20assembled%20response%2C%20both%20paths%20will%20%60.add%28%29%60%20to%20the%20same%20OTel%20counter%20for%20the%20same%20request%2C%20doubling%20the%20values.%20Adding%20a%20brief%20inline%20comment%20%28or%20an%20integration%20test%20assertion%29%20that%20documents%20why%20double-counting%20cannot%20occur%20would%20make%20this%20assumption%20explicit%20and%20catch%20regressions%20early.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22jchen%2Finstrumented-chat-stream%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jchen%2Finstrumented-chat-stream%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fobservability%2Finstrumented_chat_stream.py%3A54-58%0A**%60model_name%60%20vs%20%60agent.model%60%20metric%20attribute%20mismatch**%0A%0A%60instrumented_chat_stream%60%20records%20TTFT%2FTTAT%2FTPS%20under%20%60%7B%22model%22%3A%20model_name%7D%60%2C%20while%20%60LLMMetricsHooks.on_llm_end%60%20records%20requests%20and%20token%20counters%20under%20%60%7B%22model%22%3A%20str%28agent.model%29%20if%20agent.model%20else%20%22unknown%22%7D%60.%20If%20callers%20pass%20the%20model%20identifier%20in%20a%20different%20format%20than%20what%20%60agent.model%60%20produces%20%28e.g.%2C%20%60%22openai%2Fgpt-4%22%60%20vs%20%60%22gpt-4%22%60%29%2C%20the%20two%20metric%20families%20will%20have%20a%20different%20%60model%60%20label%20value%20and%20cannot%20be%20correlated%20in%20dashboards.%20The%20docstring%20should%20specify%20the%20expected%20format%20%E2%80%94%20or%20accept%20the%20model%20from%20the%20same%20source%20as%20%60agent.model%60%20to%20guarantee%20alignment.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Fobservability%2Finstrumented_chat_stream.py%3A145-171%0A**Potential%20double-counting%20of%20%60cached_input_tokens%60%20and%20%60reasoning_tokens%60**%0A%0A%60LLMMetricsHooks.on_llm_end%60%20also%20calls%20%60m.cached_input_tokens.add%28usage.input_tokens_details.cached_tokens%20or%200%2C%20attrs%29%60%20and%20%60m.reasoning_tokens.add%28usage.output_tokens_details.reasoning_tokens%20or%200%2C%20attrs%29%60.%20The%20PR's%20invariant%20%E2%80%94%20that%20LiteLLM%20strips%20these%20detail%20fields%20from%20the%20assembled%20%60ModelResponse%60%20so%20%60on_llm_end%60%20will%20always%20see%20%60None%60%20and%20skip%20them%20%E2%80%94%20is%20not%20codified%20in%20the%20code%20or%20tests.%20If%20a%20future%20LiteLLM%20version%20or%20a%20different%20provider%20does%20populate%20%60input_tokens_details%60%20in%20the%20assembled%20response%2C%20both%20paths%20will%20%60.add%28%29%60%20to%20the%20same%20OTel%20counter%20for%20the%20same%20request%2C%20doubling%20the%20values.%20Adding%20a%20brief%20inline%20comment%20%28or%20an%20integration%20test%20assertion%29%20that%20documents%20why%20double-counting%20cannot%20occur%20would%20make%20this%20assumption%20explicit%20and%20catch%20regressions%20early.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/agentex/lib/core/observability/instrumented_chat_stream.py:54-58
**`model_name` vs `agent.model` metric attribute mismatch**

`instrumented_chat_stream` records TTFT/TTAT/TPS under `{"model": model_name}`, while `LLMMetricsHooks.on_llm_end` records requests and token counters under `{"model": str(agent.model) if agent.model else "unknown"}`. If callers pass the model identifier in a different format than what `agent.model` produces (e.g., `"openai/gpt-4"` vs `"gpt-4"`), the two metric families will have a different `model` label value and cannot be correlated in dashboards. The docstring should specify the expected format — or accept the model from the same source as `agent.model` to guarantee alignment.

### Issue 2 of 2
src/agentex/lib/core/observability/instrumented_chat_stream.py:145-171
**Potential double-counting of `cached_input_tokens` and `reasoning_tokens`**

`LLMMetricsHooks.on_llm_end` also calls `m.cached_input_tokens.add(usage.input_tokens_details.cached_tokens or 0, attrs)` and `m.reasoning_tokens.add(usage.output_tokens_details.reasoning_tokens or 0, attrs)`. The PR's invariant — that LiteLLM strips these detail fields from the assembled `ModelResponse` so `on_llm_end` will always see `None` and skip them — is not codified in the code or tests. If a future LiteLLM version or a different provider does populate `input_tokens_details` in the assembled response, both paths will `.add()` to the same OTel counter for the same request, doubling the values. Adding a brief inline comment (or an integration test assertion) that documents why double-counting cannot occur would make this assumption explicit and catch regressions early.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["instrumented chat stream for observabili..."](https://github.com/scaleapi/scale-agentex-python/commit/b91f6d6185001ccd26f593d87c1d700c5c944e41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32720346)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->