### PR TITLE
chore: relax requires-python floor to >= 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ filterwarnings = [
 [tool.pyright]
 # Default to basic type checking, but override for specific directories
 typeCheckingMode = "basic"
-pythonVersion = "3.11"
+pythonVersion = "3.12"
 
 exclude = [
     "_dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ filterwarnings = [
 [tool.pyright]
 # Default to basic type checking, but override for specific directories
 typeCheckingMode = "basic"
-pythonVersion = "3.12"
+pythonVersion = "3.11"
 
 exclude = [
     "_dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,11 @@ dependencies = [
     "opentelemetry-api>=1.20.0",
 ]
 
-requires-python = ">= 3.12,<4"
+requires-python = ">= 3.11,<4"
 classifiers = [
   "Typing :: Typed",
   "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
## Summary
- Lower `requires-python` from `>= 3.12,<4` → `>= 3.11,<4`.
- Add `Python :: 3.11` to the classifiers.

## Why
[scaleapi/scaleapi](https://github.com/scaleapi/scaleapi)'s `packages/egp-api-backend` (and 7 other monorepo packages) are pinned to `>=3.11,<3.12`, blocking adoption of this SDK there. Specifically, [SGP-5968](https://linear.app/scale-epd/issue/SGP-5968/swap-ig-path-sdk-from-scale-gp-agents-to-agentex-sdk-fixes-sgp-5675) (Insights Generator backend) is swapping from `scale-gp-agents` to `agentex-sdk` and Poetry version resolution fails on the current `>= 3.12` floor.

## Safety
The SDK source parses cleanly at Python 3.11 grammar — no PEP 695 type parameters, no `type` statement, no other 3.12-only syntax.

Verified with:
```python
import ast, os
for root, _, files in os.walk('agentex'):
    for f in files:
        if not f.endswith('.py'): continue
        with open(os.path.join(root, f)) as fh:
            ast.parse(fh.read(), feature_version=(3, 11))
# 0 syntax errors across all 200+ .py files
```

The Stainless-generated 3.12 floor appears to be a default, not a real syntactic constraint.

## Coordination
Declan pre-approved this relax in conversation with @max-parke-scale.

## Test plan
- [ ] CI green
- [ ] After merge, cut a patch release (v0.11.4) so consumers can update their pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes the `requires-python` floor from `>=3.12,<4` to `>=3.11,<4` and adds the `Programming Language :: Python :: 3.11` PyPI classifier, unblocking adoption in monorepo packages pinned to `>=3.11,<3.12`.

- **`requires-python` + classifier**: Single-line change in `pyproject.toml`; the PR's AST-parse verification confirms no 3.12-only syntax is used across the 200+ source files.
- **Pyright config**: `[tool.pyright] pythonVersion` remains at `3.12` (flagged in a prior review pass), so type-level 3.11/3.12 differences won't be caught by static analysis until that is updated.
- **CI coverage**: The test job has no Python version matrix, so runtime compatibility on 3.11 is unvalidated beyond the AST check.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line metadata relaxation with no modifications to SDK logic.

The diff touches only the `requires-python` specifier and a PyPI classifier. The author verified zero syntax errors against the 3.11 grammar across all source files, and the Stainless-generated 3.12 floor was a tooling default rather than a real language constraint. No runtime logic, dependencies, or build steps are affected.

No files require special attention; the only changed file is `pyproject.toml` with a two-line metadata edit.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pyproject.toml | Lowers `requires-python` floor from `>=3.12` to `>=3.11` and adds the corresponding PyPI classifier; syntactically clean, but `[tool.pyright] pythonVersion` remains at `3.12` and CI has no 3.11 matrix job. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Consumer project\n(pinned to Python >=3.11,<3.12)"] -->|"Before: Poetry resolution fails"| B["agentex-sdk\nrequires-python >= 3.12"]
    A -->|"After: resolves ✓"| C["agentex-sdk\nrequires-python >= 3.11"]
    C --> D["Python 3.11 runtime"]
    C --> E["Python 3.12 runtime"]
    C --> F["Python 3.13 runtime"]
    B -.->|"blocked"| D
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pyproject.toml`, line 193-196 ([link](https://github.com/scaleapi/scale-agentex-python/blob/f3b35c4e17a5c8697e0741027086d29ee3994f0b/pyproject.toml#L193-L196)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `requires-python` floor was lowered to 3.11, but `pythonVersion` in the pyright config still targets 3.12. This means pyright validates stdlib types and overloads against 3.12 semantics, so any type-level incompatibilities between 3.11 and 3.12 (e.g., `tomllib` being stdlib in 3.11 vs not, `ExceptionGroup` stdlib availability differences in stub resolution, or any `sys.version_info`-gated overloads) won't be caught by CI when running on a 3.11 host.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: pyproject.toml
   Line: 193-196

   Comment:
   The `requires-python` floor was lowered to 3.11, but `pythonVersion` in the pyright config still targets 3.12. This means pyright validates stdlib types and overloads against 3.12 semantics, so any type-level incompatibilities between 3.11 and 3.12 (e.g., `tomllib` being stdlib in 3.11 vs not, `ExceptionGroup` stdlib availability differences in stub resolution, or any `sys.version_info`-gated overloads) won't be caught by CI when running on a 3.11 host.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pyproject.toml%0ALine%3A%20193-196%0A%0AComment%3A%0AThe%20%60requires-python%60%20floor%20was%20lowered%20to%203.11%2C%20but%20%60pythonVersion%60%20in%20the%20pyright%20config%20still%20targets%203.12.%20This%20means%20pyright%20validates%20stdlib%20types%20and%20overloads%20against%203.12%20semantics%2C%20so%20any%20type-level%20incompatibilities%20between%203.11%20and%203.12%20%28e.g.%2C%20%60tomllib%60%20being%20stdlib%20in%203.11%20vs%20not%2C%20%60ExceptionGroup%60%20stdlib%20availability%20differences%20in%20stub%20resolution%2C%20or%20any%20%60sys.version_info%60-gated%20overloads%29%20won't%20be%20caught%20by%20CI%20when%20running%20on%20a%203.11%20host.%0A%0A%60%60%60suggestion%0A%5Btool.pyright%5D%0A%23%20Default%20to%20basic%20type%20checking%2C%20but%20override%20for%20specific%20directories%0AtypeCheckingMode%20%3D%20%22basic%22%0ApythonVersion%20%3D%20%223.11%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pyproject.toml%0ALine%3A%20193-196%0A%0AComment%3A%0AThe%20%60requires-python%60%20floor%20was%20lowered%20to%203.11%2C%20but%20%60pythonVersion%60%20in%20the%20pyright%20config%20still%20targets%203.12.%20This%20means%20pyright%20validates%20stdlib%20types%20and%20overloads%20against%203.12%20semantics%2C%20so%20any%20type-level%20incompatibilities%20between%203.11%20and%203.12%20%28e.g.%2C%20%60tomllib%60%20being%20stdlib%20in%203.11%20vs%20not%2C%20%60ExceptionGroup%60%20stdlib%20availability%20differences%20in%20stub%20resolution%2C%20or%20any%20%60sys.version_info%60-gated%20overloads%29%20won't%20be%20caught%20by%20CI%20when%20running%20on%20a%203.11%20host.%0A%0A%60%60%60suggestion%0A%5Btool.pyright%5D%0A%23%20Default%20to%20basic%20type%20checking%2C%20but%20override%20for%20specific%20directories%0AtypeCheckingMode%20%3D%20%22basic%22%0ApythonVersion%20%3D%20%223.11%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22mparke%2Frelax-python-floor-to-3.11%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mparke%2Frelax-python-floor-to-3.11%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pyproject.toml%0ALine%3A%20193-196%0A%0AComment%3A%0AThe%20%60requires-python%60%20floor%20was%20lowered%20to%203.11%2C%20but%20%60pythonVersion%60%20in%20the%20pyright%20config%20still%20targets%203.12.%20This%20means%20pyright%20validates%20stdlib%20types%20and%20overloads%20against%203.12%20semantics%2C%20so%20any%20type-level%20incompatibilities%20between%203.11%20and%203.12%20%28e.g.%2C%20%60tomllib%60%20being%20stdlib%20in%203.11%20vs%20not%2C%20%60ExceptionGroup%60%20stdlib%20availability%20differences%20in%20stub%20resolution%2C%20or%20any%20%60sys.version_info%60-gated%20overloads%29%20won't%20be%20caught%20by%20CI%20when%20running%20on%20a%203.11%20host.%0A%0A%60%60%60suggestion%0A%5Btool.pyright%5D%0A%23%20Default%20to%20basic%20type%20checking%2C%20but%20override%20for%20specific%20directories%0AtypeCheckingMode%20%3D%20%22basic%22%0ApythonVersion%20%3D%20%223.11%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apyproject.toml%3A56%0A**No%20CI%20matrix%20job%20validates%20Python%203.11%20at%20runtime**%0A%0AThe%20CI%20%60test%60%20job%20uses%20Rye's%20default%20Python%20%28pulled%20from%20%60pyproject.toml%60's%20%60%5Btool.rye%5D%20python%60%20or%20the%20runner%20default%2C%20not%20a%20version%20matrix%29%2C%20so%20no%20job%20actually%20installs%20and%20runs%20the%20test%20suite%20under%20Python%203.11.%20The%20%60ast.parse%60%20check%20in%20the%20PR%20description%20only%20validates%20syntax%20%E2%80%94%20it%20won't%20catch%20usage%20of%203.12-only%20stdlib%20additions%20%28e.g.%2C%20%60itertools.batched%60%2C%20%60pathlib.Path.is_junction%60%2C%20%60os.process_cpu_affinity%60%29%20or%20behaviour%20differences.%20Adding%20a%20%60python-version%3A%20%5B%223.11%22%2C%20%223.12%22%5D%60%20matrix%20entry%20to%20the%20%60test%60%20job%20in%20%60.github%2Fworkflows%2Fci.yml%60%20would%20give%20true%20confidence%20for%20the%20lowered%20floor.%0A%0A&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apyproject.toml%3A56%0A**No%20CI%20matrix%20job%20validates%20Python%203.11%20at%20runtime**%0A%0AThe%20CI%20%60test%60%20job%20uses%20Rye's%20default%20Python%20%28pulled%20from%20%60pyproject.toml%60's%20%60%5Btool.rye%5D%20python%60%20or%20the%20runner%20default%2C%20not%20a%20version%20matrix%29%2C%20so%20no%20job%20actually%20installs%20and%20runs%20the%20test%20suite%20under%20Python%203.11.%20The%20%60ast.parse%60%20check%20in%20the%20PR%20description%20only%20validates%20syntax%20%E2%80%94%20it%20won't%20catch%20usage%20of%203.12-only%20stdlib%20additions%20%28e.g.%2C%20%60itertools.batched%60%2C%20%60pathlib.Path.is_junction%60%2C%20%60os.process_cpu_affinity%60%29%20or%20behaviour%20differences.%20Adding%20a%20%60python-version%3A%20%5B%223.11%22%2C%20%223.12%22%5D%60%20matrix%20entry%20to%20the%20%60test%60%20job%20in%20%60.github%2Fworkflows%2Fci.yml%60%20would%20give%20true%20confidence%20for%20the%20lowered%20floor.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22mparke%2Frelax-python-floor-to-3.11%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mparke%2Frelax-python-floor-to-3.11%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apyproject.toml%3A56%0A**No%20CI%20matrix%20job%20validates%20Python%203.11%20at%20runtime**%0A%0AThe%20CI%20%60test%60%20job%20uses%20Rye's%20default%20Python%20%28pulled%20from%20%60pyproject.toml%60's%20%60%5Btool.rye%5D%20python%60%20or%20the%20runner%20default%2C%20not%20a%20version%20matrix%29%2C%20so%20no%20job%20actually%20installs%20and%20runs%20the%20test%20suite%20under%20Python%203.11.%20The%20%60ast.parse%60%20check%20in%20the%20PR%20description%20only%20validates%20syntax%20%E2%80%94%20it%20won't%20catch%20usage%20of%203.12-only%20stdlib%20additions%20%28e.g.%2C%20%60itertools.batched%60%2C%20%60pathlib.Path.is_junction%60%2C%20%60os.process_cpu_affinity%60%29%20or%20behaviour%20differences.%20Adding%20a%20%60python-version%3A%20%5B%223.11%22%2C%20%223.12%22%5D%60%20matrix%20entry%20to%20the%20%60test%60%20job%20in%20%60.github%2Fworkflows%2Fci.yml%60%20would%20give%20true%20confidence%20for%20the%20lowered%20floor.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pyproject.toml:56
**No CI matrix job validates Python 3.11 at runtime**

The CI `test` job uses Rye's default Python (pulled from `pyproject.toml`'s `[tool.rye] python` or the runner default, not a version matrix), so no job actually installs and runs the test suite under Python 3.11. The `ast.parse` check in the PR description only validates syntax — it won't catch usage of 3.12-only stdlib additions (e.g., `itertools.batched`, `pathlib.Path.is_junction`, `os.process_cpu_affinity`) or behaviour differences. Adding a `python-version: ["3.11", "3.12"]` matrix entry to the `test` job in `.github/workflows/ci.yml` would give true confidence for the lowered floor.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Revert &quot;chore: align pyright pythonVersi..."](https://github.com/scaleapi/scale-agentex-python/commit/4d60895b72be5ba120c1df663938a1cbd9e5b377) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33974859)</sub>

<!-- /greptile_comment -->