### PR TITLE
chore(deps): drop unused runtime deps and exclude tests from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "rich>=13.9.2,<14",
     "fastapi>=0.115.0",
     "starlette>=0.49.1",
-    "tornado>=6.5.5",
     "uvicorn>=0.31.1",
     "watchfiles>=0.24.0,<1.0",
     "python-on-whales>=0.73.0,<0.74",
@@ -33,24 +32,17 @@ dependencies = [
     "litellm>=1.83.7,<2",
     "kubernetes>=25.0.0,<36.0.0",
     "jinja2>=3.1.3,<4",
-    "mcp[cli]>=1.4.1",
+    "mcp>=1.4.1",
     "scale-gp>=0.1.0a59",
     "openai-agents==0.14.1",
     "pydantic-ai-slim>=1.0,<2",
-    "tzlocal>=5.3.1",
-    "tzdata>=2025.2",
-    "pytest>=8.4.0",
     "json_log_formatter>=1.1.1",
-    "pytest-asyncio>=1.0.0",
     "scale-gp-beta>=0.2.0",
-    "ipykernel>=6.29.5",
     "openai>=2.2,<3", # Required by openai-agents; litellm now supports openai 2.x (issue #13711 resolved: https://github.com/BerriAI/litellm/issues/13711)
     "cloudpickle>=3.1.1",
-    "datadog>=0.52.1",
     "ddtrace>=3.13.0",
     "yaspin>=3.1.0",
     "claude-agent-sdk>=0.1.0",
-    "anthropic>=0.40.0",
     "langgraph-checkpoint>=2.0.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-api>=1.20.0",
@@ -152,6 +144,14 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agentex"]
+# Don't ship internal test files in the wheel. `lib/cli/templates/**/test_agent.py.j2`
+# is intentionally kept — those render into user projects.
+exclude = [
+  "src/agentex/lib/**/tests/**",
+  "src/agentex/lib/**/test_*.py",
+  "src/agentex/lib/**/conftest.py",
+  "src/agentex/lib/**/pytest.ini",
+]
 
 [tool.hatch.build.targets.sdist]
 # Basically everything except hidden files/directories (such as .github, .devcontainers, .python-version, etc)


### PR DESCRIPTION
## Summary

First of a planned set under [AGX1-292](https://linear.app/scale-epd/issue/AGX1-292/reduce-agentex-sdk-runtime-deps-47-6-base-move-adkserver-deps-to). Zero-risk wins.

The published `agentex-sdk` wheel declares 44 required runtime deps. Audit found that **8 of them are imported nowhere in `src/`** and **2 more (`pytest`, `pytest-asyncio`) are only used by test files we accidentally ship inside the wheel**.

### Dropped (zero imports anywhere in `src/agentex/**`)

| Dep | Notes |
|---|---|
| `anthropic>=0.40.0` | Transitively pulled by `claude-agent-sdk` if a consumer actually uses it. |
| `datadog>=0.52.1` | Likely confused with `ddtrace` (kept). |
| `tornado>=6.5.5` | Was a security pin transitively pulled by `ipykernel`; both unused. |
| `ipykernel>=6.29.5` | |
| `tzlocal>=5.3.1` | |
| `tzdata>=2025.2` | `temporalio` will pull what it needs. |

### Tests stop shipping in the wheel

`hatchling`'s `packages = ["src/agentex"]` was including 24 test files (`tests/`, `conftest.py`, `pytest.ini`, `test_*.py`) under `src/agentex/lib/`. Those forced `pytest` + `pytest-asyncio` into the runtime metadata. Added an `exclude` to the wheel target so they stop shipping; dropped both deps.

The Jinja templates at `lib/cli/templates/**/test_agent.py.j2` are intentionally preserved — those render into scaffolded user projects and don't end in `.py`.

### `mcp[cli]` → `mcp`

The `[cli]` extra of `mcp` pulls `typer`/`rich`/`pyperclip` for the `mcp dev` CLI; the SDK only uses `from mcp import StdioServerParameters`.

## Verification

```sh
python -m build --wheel
unzip -p dist/agentex_sdk-*.whl '*.dist-info/METADATA' | grep -c '^Requires-Dist'
# before: 47    after: 40 (37 required + 3 extras)

unzip -l dist/agentex_sdk-*.whl | grep -cE '(tests/|conftest|pytest\.ini|test_[^/]+\.py$)'
# before: 24    after: 0

unzip -l dist/agentex_sdk-*.whl | grep -c 'test_agent.py.j2'
# 10 (preserved — these are templates, not tests)
```

## Test plan

- [ ] CI builds the wheel and `Validate PR title` passes.
- [ ] No `Requires-Dist` regression in the published wheel after release.
- [ ] Downstream `agentex-server` install (in `scaleapi/scale-agentex`) still resolves — the deps dropped here either weren't used or are transitively available via siblings (e.g. `temporalio` brings tz data).

## Follow-ups (separate PRs)

- Move ADK/server-side deps to opt-in extras (`[adk]`, `[cli]`, `[server]`, `[temporal]`, `[provider-*]`, `[observability]`).
- Lazify provider imports in `src/agentex/lib/adk/__init__.py` so the extras split is safe.

Both tracked in [AGX1-292](https://linear.app/scale-epd/issue/AGX1-292/reduce-agentex-sdk-runtime-deps-47-6-base-move-adkserver-deps-to).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This maintenance PR removes 8 runtime dependencies that have zero imports anywhere in `src/agentex/`, downgrades `mcp[cli]` to `mcp` (since only `StdioServerParameters` is imported), and adds hatchling `exclude` rules to stop test infrastructure files from shipping inside the published wheel.

- All removed packages (`tornado`, `ipykernel`, `tzlocal`, `tzdata`, `datadog`, `anthropic`, `pytest`, `pytest-asyncio`) were confirmed to have no direct imports in `src/agentex/**` — grep returns zero matches for each.
- The four `from mcp import StdioServerParameters` call sites are all in the core `mcp` namespace, unaffected by dropping the `[cli]` extra.
- Wheel `exclude` patterns (`lib/**/tests/**`, `lib/**/test_*.py`, `lib/**/conftest.py`, `lib/**/pytest.ini`) correctly cover every test file currently present under `src/agentex/lib/`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all removed packages are confirmed unused in src/ and the wheel exclude patterns cover every test file in the current codebase.

Every dropped dependency was verified to have zero direct imports in src/agentex. The mcp[cli]→mcp narrowing is backed by four call sites that exclusively import StdioServerParameters from the core namespace. The wheel exclude globs match all test files present under src/agentex/lib/, and the Jinja templates are correctly left untouched.

No files require special attention. pyproject.toml is the only changed file and the edits are straightforward.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Drops 8 unused runtime dependencies, narrows mcp[cli] to mcp, and adds wheel exclude patterns to prevent test files shipping in the published package. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[agentex-sdk wheel] --> B[Runtime deps kept]
    A --> C[Deps removed]
    A --> D[Wheel build target]

    B --> B1[mcp - StdioServerParameters only]
    B --> B2[claude-agent-sdk - transitively pulls anthropic]
    B --> B3[temporalio - transitively pulls tzdata]
    B --> B4[ddtrace - replaced datadog]

    C --> C1[tornado - security pin, unused]
    C --> C2[ipykernel - unused]
    C --> C3[tzlocal / tzdata - transitive via temporalio]
    C --> C4[datadog - confused with ddtrace]
    C --> C5[anthropic - transitive via claude-agent-sdk]
    C --> C6[pytest / pytest-asyncio - test-only]

    D --> E[packages = src/agentex]
    D --> F[exclude patterns added]
    F --> F1[lib/**/tests/**]
    F --> F2[lib/**/test_*.py]
    F --> F3[lib/**/conftest.py]
    F --> F4[lib/**/pytest.ini]
    F --> G[Jinja templates test_agent.py.j2 preserved]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): drop unused runtime deps an..."](https://github.com/scaleapi/scale-agentex-python/commit/b100da29a97b44289be48e8d406c2ec836a8344a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34036777)</sub>

<!-- /greptile_comment -->