### PR TITLE
feat(deps)!: split ADK/server deps into optional [adk]/[cli]/[observability] extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ authors = [
 { name = "Agentex", email = "roxanne.farhad@scale.com" },
 ]
 
+# Bare client surface only — the Stainless-generated REST client
+# (`from agentex import Agentex, AsyncAgentex`). Everything else lives
+# under the `[adk]` extra; see [project.optional-dependencies] below.
 dependencies = [
     "httpx>=0.28.1,<0.29",
     "pydantic>=2.0.0, <3",
@@ -15,37 +18,6 @@ dependencies = [
     "anyio>=3.5.0, <5",
     "distro>=1.7.0, <2",
     "sniffio",
-    "typer>=0.16,<0.17",
-    "questionary>=2.0.1,<3",
-    "rich>=13.9.2,<14",
-    "fastapi>=0.115.0",
-    "starlette>=0.49.1",
-    "uvicorn>=0.31.1",
-    "watchfiles>=0.24.0,<1.0",
-    "python-on-whales>=0.73.0,<0.74",
-    "pyyaml>=6.0.2,<7",
-    "jsonschema>=4.23.0,<5",
-    "jsonref>=1.1.0,<2",
-    "temporalio>=1.26.0,<2",
-    "aiohttp>=3.10.10,<4",
-    "redis>=5.2.0,<8",
-    "litellm>=1.83.7,<2",
-    "kubernetes>=25.0.0,<36.0.0",
-    "jinja2>=3.1.3,<4",
-    "mcp>=1.4.1",
-    "scale-gp>=0.1.0a59",
-    "openai-agents==0.14.1",
-    "pydantic-ai-slim>=1.0,<2",
-    "json_log_formatter>=1.1.1",
-    "scale-gp-beta>=0.2.0",
-    "openai>=2.2,<3", # Required by openai-agents; litellm now supports openai 2.x (issue #13711 resolved: https://github.com/BerriAI/litellm/issues/13711)
-    "cloudpickle>=3.1.1",
-    "ddtrace>=3.13.0",
-    "yaspin>=3.1.0",
-    "claude-agent-sdk>=0.1.0",
-    "langgraph-checkpoint>=2.0.0",
-    "opentelemetry-sdk>=1.20.0",
-    "opentelemetry-api>=1.20.0",
 ]
 
 requires-python = ">= 3.11,<4"
@@ -70,7 +42,64 @@ Homepage = "https://github.com/scaleapi/scale-agentex-python"
 Repository = "https://github.com/scaleapi/scale-agentex-python"
 
 [project.optional-dependencies]
-aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
+# httpx-aiohttp transport. Independent from `[adk]`.
+aiohttp = ["aiohttp>=3.10.10,<4", "httpx_aiohttp>=0.1.9"]
+
+# CLI surface — what `agentex.lib.cli.*` and `agentex.lib.sdk.config.*` need.
+# Consumers that import only `agentex.lib.cli.handlers`, `agentex.lib.sdk.config`,
+# or use the `agentex` CLI entry point can pin `agentex-sdk[cli]` instead of the
+# full `[adk]` extra.
+cli = [
+    "typer>=0.16,<0.17",
+    "questionary>=2.0.1,<3",
+    "rich>=13.9.2,<14",
+    "yaspin>=3.1.0",
+    "pyyaml>=6.0.2,<7",
+    "python-on-whales>=0.73.0,<0.74",
+    "kubernetes>=25.0.0,<36.0.0",
+    "jsonref>=1.1.0,<2",
+    "jsonschema>=4.23.0,<5",
+    "jinja2>=3.1.3,<4",
+    "watchfiles>=0.24.0,<1.0",
+]
+
+# Tracing / observability — what `agentex.lib.core.tracing.*` and
+# `agentex.lib.core.observability.*` need. Consumers that only attach the
+# SGP/Datadog/OTel tracing processors can pin `agentex-sdk[observability]`.
+observability = [
+    "ddtrace>=3.13.0",
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "json_log_formatter>=1.1.1",
+]
+
+# Full ADK surface — everything under `agentex.lib.*`. Includes [cli] +
+# [observability] plus the ACP server, Temporal, Redis streaming, LLM provider
+# integrations, and MCP. Required for full agent authoring.
+adk = [
+    "agentex-sdk[cli,observability]",
+    # ACP server (FastAPI app surface)
+    "fastapi>=0.115.0",
+    "starlette>=0.49.1",
+    "uvicorn>=0.31.1",
+    "aiohttp>=3.10.10,<4",
+    # Temporal workflows
+    "temporalio>=1.26.0,<2",
+    "cloudpickle>=3.1.1",
+    # Async streaming infra
+    "redis>=5.2.0,<8",
+    # LLM provider integrations
+    "litellm>=1.83.7,<2",
+    "openai-agents==0.14.1",
+    "openai>=2.2,<3", # Required by openai-agents; litellm now supports openai 2.x (issue #13711 resolved: https://github.com/BerriAI/litellm/issues/13711)
+    "claude-agent-sdk>=0.1.0",
+    "pydantic-ai-slim>=1.0,<2",
+    "langgraph-checkpoint>=2.0.0",
+    "scale-gp>=0.1.0a59",
+    "scale-gp-beta>=0.2.0",
+    "mcp>=1.4.1",
+]
+
 dev = [
     "ruff>=0.3.4",
 ]

--- a/src/agentex/lib/cli/templates/default-langgraph/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
     "langgraph",
     "langchain-openai",

--- a/src/agentex/lib/cli/templates/default-langgraph/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/requirements.txt.j2
@@ -1,5 +1,5 @@
 # Install agentex-sdk from local path
-agentex-sdk
+agentex-sdk[adk]
 
 # Scale GenAI Platform Python SDK
 scale-gp

--- a/src/agentex/lib/cli/templates/default-pydantic-ai/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/default-pydantic-ai/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
     "pydantic-ai-slim[openai]>=1.0,<2",
     "python-dotenv",

--- a/src/agentex/lib/cli/templates/default-pydantic-ai/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/default-pydantic-ai/requirements.txt.j2
@@ -1,5 +1,5 @@
 # Install agentex-sdk from local path
-agentex-sdk
+agentex-sdk[adk]
 
 # Scale GenAI Platform Python SDK
 scale-gp

--- a/src/agentex/lib/cli/templates/default/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/default/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
 ]
 

--- a/src/agentex/lib/cli/templates/default/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/default/requirements.txt.j2
@@ -1,5 +1,5 @@
 # Install agentex-sdk from local path
-agentex-sdk
+agentex-sdk[adk]
 
 # Scale GenAI Platform Python SDK
 scale-gp

--- a/src/agentex/lib/cli/templates/sync-langgraph/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
     "langgraph",
     "langchain-openai",

--- a/src/agentex/lib/cli/templates/sync-langgraph/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/requirements.txt.j2
@@ -1,5 +1,5 @@
 # Install agentex-sdk from local path
-agentex-sdk
+agentex-sdk[adk]
 
 # Scale GenAI Platform Python SDK
 scale-gp

--- a/src/agentex/lib/cli/templates/sync-openai-agents/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
 ]
 

--- a/src/agentex/lib/cli/templates/sync-openai-agents/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/requirements.txt.j2
@@ -1,5 +1,5 @@
 # Install agentex-sdk from local path
-agentex-sdk
+agentex-sdk[adk]
 
 # Scale GenAI Platform Python SDK
 scale-gp

--- a/src/agentex/lib/cli/templates/sync-pydantic-ai/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/sync-pydantic-ai/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
     "pydantic-ai-slim[openai]>=1.0,<2",
 ]

--- a/src/agentex/lib/cli/templates/sync-pydantic-ai/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/sync-pydantic-ai/requirements.txt.j2
@@ -1,5 +1,5 @@
 # Install agentex-sdk from local path
-agentex-sdk
+agentex-sdk[adk]
 
 # Scale GenAI Platform Python SDK
 scale-gp

--- a/src/agentex/lib/cli/templates/sync/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/sync/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
 ]
 

--- a/src/agentex/lib/cli/templates/sync/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/sync/requirements.txt.j2
@@ -1,5 +1,5 @@
 # Install agentex-sdk from local path
-agentex-sdk
+agentex-sdk[adk]
 
 # Scale GenAI Platform Python SDK
 scale-gp

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
     "temporalio",
     "openai-agents>=0.4.2",

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/requirements.txt.j2
@@ -1,4 +1,4 @@
-agentex-sdk
+agentex-sdk[adk]
 scale-gp
 temporalio
 openai-agents>=0.4.2

--- a/src/agentex/lib/cli/templates/temporal-pydantic-ai/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/temporal-pydantic-ai/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
     "temporalio>=1.18.2",
     "pydantic-ai-slim[openai]>=1.0,<2",

--- a/src/agentex/lib/cli/templates/temporal-pydantic-ai/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/temporal-pydantic-ai/requirements.txt.j2
@@ -1,4 +1,4 @@
-agentex-sdk
+agentex-sdk[adk]
 scale-gp
 temporalio>=1.18.2
 pydantic-ai-slim[openai]>=1.0,<2

--- a/src/agentex/lib/cli/templates/temporal/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/temporal/pyproject.toml.j2
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "{{ description }}"
 requires-python = ">=3.12"
 dependencies = [
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "scale-gp",
     "temporalio",
 ]

--- a/src/agentex/lib/cli/templates/temporal/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/temporal/requirements.txt.j2
@@ -1,5 +1,5 @@
 # Install agentex-sdk from local path
-agentex-sdk
+agentex-sdk[adk]
 
 # Scale GenAI Platform Python SDK
 scale-gp


### PR DESCRIPTION
## Summary

Stacked on #367. Second PR under [AGX1-292](https://linear.app/scale-epd/issue/AGX1-292/reduce-agentex-sdk-runtime-deps-47-6-base-move-adkserver-deps-to). **Do not merge before #367 lands.**

Splits the SDK into a 6-dep bare client plus three opt-in extras:

| Install command | Deps | Use case |
|---|---|---|
| `pip install agentex-sdk` | **6** | REST client only (`from agentex import Agentex, AsyncAgentex`) |
| `pip install agentex-sdk[cli]` | 6 + **11** | Just CLI helpers (`agentex.lib.cli.*`, `agentex.lib.sdk.config.*`) + the `agentex` CLI |
| `pip install agentex-sdk[observability]` | 6 + **4** | Just tracing processors (`agentex.lib.core.tracing.*`) |
| `pip install agentex-sdk[adk]` | 6 + **31** | Full ADK: includes `[cli] + [observability]` + ACP server + Temporal + Redis + MCP + LLM providers |

`[cli]` and `[observability]` are deliberately scoped to keep client-side tools (e.g. `sgpctl`, voice-agent tracing setup) from pulling temporal/fastapi/redis just to use a few helpers.

Also updates all 10 CLI scaffolding templates (`agentex init`) to pin `agentex-sdk[adk]` so newly bootstrapped agent projects work out of the box.

## Why

`agentex.lib` is import-lazy (empty `__init__.py`), so a pure REST consumer never touches the heavy deps at import time. But `pip` still installs all of them today, dragging in `temporalio`, `fastapi`, `redis`, `kubernetes`, `litellm`, `anthropic`, `openai-agents`, `claude-agent-sdk`, observability stacks, etc. — for consumers who just want to make API calls or use a small slice of `lib`.

Audit: [AGX1-292](https://linear.app/scale-epd/issue/AGX1-292/reduce-agentex-sdk-runtime-deps-47-6-base-move-adkserver-deps-to).

## BREAKING CHANGE

Consumers who use `agentex.lib.*` must switch from `agentex-sdk` to one of:

- `agentex-sdk[cli]` if they only use `agentex.lib.cli.*` or `agentex.lib.sdk.config.*`
- `agentex-sdk[observability]` if they only use `agentex.lib.core.tracing.*` / `.observability.*`
- `agentex-sdk[adk]` for full agent authoring (FastACP + Temporal + providers + …)

The REST client (`from agentex import Agentex, AsyncAgentex`) is **unchanged** and works with a bare install.

### Known internal consumer blast radius

GitHub code-search across the `scaleapi` org. Migration PRs being opened in parallel:

| Repo | pyproject.toml pins | Migration | PR |
|---|---|---|---|
| `scaleapi/agentex-agents` | 117 (~106 after excluding stuck/local pins) | `[adk]` | _(coming)_ |
| `scaleapi/models` | 10 (9 after excluding capped pins) | `[adk]` | [scaleapi/models#18648](https://github.com/scaleapi/models/pull/18648) |
| `scaleapi/sgp` | 3 | `[cli]` for sgpctl, `[observability]` for voice-agents | [scaleapi/sgp#3114](https://github.com/scaleapi/sgp/pull/3114) (being revised) |
| `scaleapi/scale-agentex` | 2 | `[adk]` | [scaleapi/scale-agentex#251](https://github.com/scaleapi/scale-agentex/pull/251) |
| `scaleapi/fna1-ops` | 0 toml / 1 requirements.txt | `[adk]` | _(coming)_ |

The CLI templates inside this repo are fixed in this PR so the `agentex init` flow stays working.

## Verification

```sh
python -m build --wheel

unzip -p dist/agentex_sdk-*.whl '*.dist-info/METADATA' | grep -E '^Requires-Dist:' | grep -vc 'extra =='
# 6

unzip -p dist/agentex_sdk-*.whl '*.dist-info/METADATA' | grep '^Provides-Extra:'
# Provides-Extra: adk
# Provides-Extra: aiohttp
# Provides-Extra: cli
# Provides-Extra: dev
# Provides-Extra: observability

# per-extra dep counts
for x in cli observability adk; do
  echo "[$x]: $(unzip -p dist/agentex_sdk-*.whl '*.dist-info/METADATA' | grep -c "extra == '$x'") deps"
done
# [cli]: 11 deps
# [observability]: 4 deps
# [adk]: 31 deps
```

## Test plan

- [ ] CI builds the wheel and `Validate PR title` passes (note the `!` — breaking change).
- [ ] Smoke-test `pip install agentex-sdk` in a clean env → `from agentex import Agentex` works; `import agentex.lib.adk` fails with `ModuleNotFoundError` (expected).
- [ ] Smoke-test `pip install agentex-sdk[adk]` → both work.
- [ ] Smoke-test `pip install agentex-sdk[cli]` → `from agentex.lib.cli.handlers.agent_handlers import prepare_cloud_build_context` works.
- [ ] CHANGELOG / release notes call out the install-time change.
- [ ] Internal consumer sweep PRs land alongside or after this PR.
- [ ] `agentex init` against an updated template produces a project that imports successfully.

## Rollout note

Worth a minor or major version bump to flag the install-time break in release notes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits `agentex-sdk`'s runtime dependencies into a lean base install (6 deps, REST client only) and a `[adk]` optional extra (6 + 31 deps, full agent development kit), with intermediate `[cli]` and `[observability]` extras as sub-components of `[adk]`. All 10 CLI scaffolding templates generated by `agentex init` are updated to pin `agentex-sdk[adk]` so newly scaffolded projects continue to work out of the box.

- **`pyproject.toml`**: Moves 31 ADK/server dependencies (Temporal, FastAPI, Redis, LLM providers, CLI tools, observability) out of bare `dependencies` into `[adk]`, which composes `[cli]` + `[observability]` sub-extras using the self-referential PEP 508 syntax.
- **CLI templates** (`*.j2`): Uniform `agentex-sdk` → `agentex-sdk[adk]` substitution across all 10 template pairs (`pyproject.toml.j2` + `requirements.txt.j2`).

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The dep split is mechanically correct, but the `agentex` binary remains registered unconditionally while its runtime imports land exclusively in the new optional extras, breaking the CLI on a bare install.

The packaging restructuring is logically sound — the self-referential extra syntax is valid PEP 508, all 10 templates are consistently updated, and the `[cli]` extra is correctly scoped (CLI handlers verified to not import `scale-gp` or ADK-only deps). The one outstanding defect is the unconditional `[project.scripts]` entry point for `agentex` that invokes `agentex.lib.cli.commands.main:app`, which immediately imports `typer` — a dep now living only in `[cli]`/`[adk]`. Any bare `pip install agentex-sdk` user who runs `agentex` will get a `ModuleNotFoundError` with no actionable guidance.

pyproject.toml — the `[project.scripts]` entry point at line 107 registers the `agentex` CLI unconditionally regardless of which extras are installed.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Core packaging change: moves 31 ADK deps into optional extras ([cli], [observability], [adk]); the `agentex` console-script entry point remains unconditionally registered while its runtime imports (typer, etc.) are now only in the [cli]/[adk] extras, causing a ModuleNotFoundError on a bare install. |
| src/agentex/lib/cli/templates/default/pyproject.toml.j2 | Uniform agentex-sdk → agentex-sdk[adk] substitution; correct and consistent with the packaging change. |
| src/agentex/lib/cli/templates/default/requirements.txt.j2 | Uniform agentex-sdk → agentex-sdk[adk] substitution in requirements.txt template; correct. |
| src/agentex/lib/cli/templates/temporal-openai-agents/pyproject.toml.j2 | Updated to agentex-sdk[adk]; retains explicit openai-agents>=0.4.2 and temporalio pins which are satisfied by the [adk] extra's strict openai-agents==0.14.1 pin. |
| src/agentex/lib/cli/templates/default-langgraph/pyproject.toml.j2 | Updated to agentex-sdk[adk]; correct — langgraph-checkpoint is now provided transitively via [adk]. |
| src/agentex/lib/cli/templates/sync-openai-agents/pyproject.toml.j2 | Updated to agentex-sdk[adk]; correct and consistent with other template updates. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pip install agentex-sdk"] --> B["Base deps (6)\nhttpx, pydantic,\ntyping-extensions, anyio,\ndistro, sniffio"]
    
    C["pip install agentex-sdk[adk]"] --> D["[cli] extra (11)\ntyper, questionary, rich,\nkubernetes, jinja2, pyyaml,\npython-on-whales, etc."]
    C --> E["[observability] extra (4)\nddtrace, opentelemetry-api,\nopentelemetry-sdk,\njson_log_formatter"]
    C --> F["[adk]-only deps (16)\nfastapi, starlette, uvicorn,\ntemporalio, redis, litellm,\nopenai-agents, claude-agent-sdk,\nscale-gp, mcp, etc."]
    C --> B

    G["pip install agentex-sdk[aiohttp]"] --> H["aiohttp>=3.10.10,<4\nhttpx_aiohttp"]
    G --> B

    I["agentex init (CLI templates)"] --> J["Generated pyproject.toml\nagentex-sdk[adk]"]

    style B fill:#d4edda,stroke:#28a745
    style D fill:#cce5ff,stroke:#007bff
    style E fill:#cce5ff,stroke:#007bff
    style F fill:#cce5ff,stroke:#007bff
    style H fill:#fff3cd,stroke:#ffc107
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(deps)!: split ADK/server deps into ..."](https://github.com/scaleapi/scale-agentex-python/commit/d40200b1d0876fcf49349f962870037a59fbff27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34037903)</sub>

<!-- /greptile_comment -->