### PR TITLE
refactor(types): promote protocol types to agentex.protocol.*

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,27 @@ The package provides the `agentex` CLI with these main commands:
 
 ### Code Structure
 - `/src/agentex/` - Core SDK and generated API client code
+- `/src/agentex/protocol/` - **Canonical** location for wire-protocol shapes
+  (JSON-RPC envelopes, ACP method-param types). Depends only on `pydantic`
+  and the Stainless-generated `agentex.types.*` surface, so it is safe to
+  import from a future slim REST-only install.
+  - `acp.py` - `RPCMethod`, `CreateTaskParams`, `SendMessageParams`,
+    `SendEventParams`, `CancelTaskParams`, `RPC_SYNC_METHODS`,
+    `PARAMS_MODEL_BY_METHOD`
+  - `json_rpc.py` - `JSONRPCRequest`, `JSONRPCResponse`, `JSONRPCError`
 - `/src/agentex/lib/` - Custom library code (not modified by code generator)
   - `/cli/` - Command-line interface implementation
   - `/core/` - Core services, adapters, and temporal workflows
   - `/sdk/` - SDK utilities and FastACP implementation
   - `/types/` - Custom type definitions
+    - `acp.py`, `json_rpc.py` - **back-compat shims** re-exporting from
+      `agentex.protocol.*`. Existing `from agentex.lib.types.{acp,json_rpc}
+      import ...` keeps working; new code should import from the canonical
+      `agentex.protocol.*` paths.
+    - Other modules (`tracing`, `agent_card`, `credentials`, `fastacp`,
+      `llm_messages`, `converters`, etc.) stay here — they have heavier
+      transitive deps (temporal, openai-agents, model_utils/yaml) and
+      aren't slim-safe.
   - `/utils/` - Utility functions
 - `/examples/` - Example implementations and tutorials
 - `/tests/` - Test suites

--- a/src/agentex/lib/cli/templates/default-langgraph/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/project/acp.py.j2
@@ -18,7 +18,7 @@ import agentex.lib.adk as adk
 from agentex.lib.adk import create_langgraph_tracing_handler, stream_langgraph_events
 from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
 from agentex.lib.sdk.fastacp.fastacp import FastACP
-from agentex.lib.types.acp import SendEventParams, CancelTaskParams, CreateTaskParams
+from agentex.protocol.acp import SendEventParams, CancelTaskParams, CreateTaskParams
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger

--- a/src/agentex/lib/cli/templates/default-pydantic-ai/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-pydantic-ai/project/acp.py.j2
@@ -28,7 +28,7 @@ from agentex.lib.adk import (
     stream_pydantic_ai_events,
     create_pydantic_ai_tracing_handler,
 )
-from agentex.lib.types.acp import SendEventParams, CancelTaskParams, CreateTaskParams
+from agentex.protocol.acp import SendEventParams, CancelTaskParams, CreateTaskParams
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger

--- a/src/agentex/lib/cli/templates/default/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default/project/acp.py.j2
@@ -1,6 +1,6 @@
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.lib.types.fastacp import AsyncACPConfig
-from agentex.lib.types.acp import SendEventParams, CancelTaskParams, CreateTaskParams
+from agentex.protocol.acp import SendEventParams, CancelTaskParams, CreateTaskParams
 from agentex.lib.utils.logging import make_logger
 from agentex.types.text_content import TextContent
 from agentex.lib import adk

--- a/src/agentex/lib/cli/templates/sync-langgraph/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/project/acp.py.j2
@@ -11,7 +11,7 @@ import agentex.lib.adk as adk
 from agentex.lib.adk import create_langgraph_tracing_handler, convert_langgraph_to_agentex_events
 from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
 from agentex.lib.sdk.fastacp.fastacp import FastACP
-from agentex.lib.types.acp import SendMessageParams
+from agentex.protocol.acp import SendMessageParams
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
 from agentex.types.task_message_content import TaskMessageContent

--- a/src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2
@@ -4,7 +4,7 @@ from typing import AsyncGenerator, List
 from agentex.lib import adk
 from agentex.lib.adk.providers._modules.sync_provider import SyncStreamingProvider, convert_openai_to_agentex_events
 from agentex.lib.sdk.fastacp.fastacp import FastACP
-from agentex.lib.types.acp import SendMessageParams
+from agentex.protocol.acp import SendMessageParams
 from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.model_utils import BaseModel

--- a/src/agentex/lib/cli/templates/sync-pydantic-ai/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-pydantic-ai/project/acp.py.j2
@@ -22,7 +22,7 @@ from agentex.lib.adk import (
     create_pydantic_ai_tracing_handler,
     convert_pydantic_ai_to_agentex_events,
 )
-from agentex.lib.types.acp import SendMessageParams
+from agentex.protocol.acp import SendMessageParams
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.sdk.fastacp.fastacp import FastACP

--- a/src/agentex/lib/cli/templates/sync/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync/project/acp.py.j2
@@ -1,6 +1,6 @@
 from typing import AsyncGenerator, Union
 from agentex.lib.sdk.fastacp.fastacp import FastACP
-from agentex.lib.types.acp import SendMessageParams
+from agentex.protocol.acp import SendMessageParams
 
 from agentex.types.task_message_update import TaskMessageUpdate
 from agentex.types.task_message_content import TaskMessageContent

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2
@@ -4,7 +4,7 @@ import os
 from temporalio import workflow
 
 from agentex.lib import adk
-from agentex.lib.types.acp import CreateTaskParams, SendEventParams
+from agentex.protocol.acp import CreateTaskParams, SendEventParams
 from agentex.lib.core.temporal.workflows.workflow import BaseWorkflow
 from agentex.lib.core.temporal.types.workflow import SignalName
 from agentex.lib.utils.logging import make_logger

--- a/src/agentex/lib/cli/templates/temporal-pydantic-ai/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-pydantic-ai/project/workflow.py.j2
@@ -23,7 +23,7 @@ from temporalio import workflow
 from project.agent import TaskDeps, temporal_agent
 
 from agentex.lib import adk
-from agentex.lib.types.acp import SendEventParams, CreateTaskParams
+from agentex.protocol.acp import SendEventParams, CreateTaskParams
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
 from agentex.types.text_content import TextContent

--- a/src/agentex/lib/cli/templates/temporal/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal/project/workflow.py.j2
@@ -3,7 +3,7 @@ import json
 from temporalio import workflow
 
 from agentex.lib import adk
-from agentex.lib.types.acp import CreateTaskParams, SendEventParams
+from agentex.protocol.acp import CreateTaskParams, SendEventParams
 from agentex.lib.core.temporal.workflows.workflow import BaseWorkflow
 from agentex.lib.core.temporal.types.workflow import SignalName
 from agentex.lib.utils.logging import make_logger

--- a/src/agentex/lib/core/temporal/services/temporal_task_service.py
+++ b/src/agentex/lib/core/temporal/services/temporal_task_service.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from agentex.types.task import Task
 from agentex.types.agent import Agent
 from agentex.types.event import Event
-from agentex.lib.types.acp import SendEventParams, CreateTaskParams
+from agentex.protocol.acp import SendEventParams, CreateTaskParams
 from agentex.lib.environment_variables import EnvironmentVariables
 from agentex.lib.core.clients.temporal.types import WorkflowState
 from agentex.lib.core.temporal.types.workflow import SignalName

--- a/src/agentex/lib/core/temporal/workflows/workflow.py
+++ b/src/agentex/lib/core/temporal/workflows/workflow.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 
 from temporalio import workflow
 
-from agentex.lib.types.acp import SendEventParams, CreateTaskParams
+from agentex.protocol.acp import SendEventParams, CreateTaskParams
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.core.temporal.types.workflow import SignalName
 

--- a/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
+++ b/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
@@ -14,7 +14,7 @@ from pydantic import TypeAdapter, ValidationError
 from starlette.types import Send, Scope, ASGIApp, Receive
 from fastapi.responses import StreamingResponse
 
-from agentex.lib.types.acp import (
+from agentex.protocol.acp import (
     RPC_SYNC_METHODS,
     PARAMS_MODEL_BY_METHOD,
     RPCMethod,
@@ -24,7 +24,7 @@ from agentex.lib.types.acp import (
     SendMessageParams,
 )
 from agentex.lib.utils.logging import make_logger, ctx_var_request_id
-from agentex.lib.types.json_rpc import JSONRPCError, JSONRPCRequest, JSONRPCResponse
+from agentex.protocol.json_rpc import JSONRPCError, JSONRPCRequest, JSONRPCResponse
 from agentex.lib.utils.model_utils import BaseModel
 from agentex.lib.utils.registration import register_agent
 

--- a/src/agentex/lib/sdk/fastacp/impl/async_base_acp.py
+++ b/src/agentex/lib/sdk/fastacp/impl/async_base_acp.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing_extensions import override
 
-from agentex.lib.types.acp import (
+from agentex.protocol.acp import (
     SendEventParams,
     CancelTaskParams,
     CreateTaskParams,

--- a/src/agentex/lib/sdk/fastacp/impl/sync_acp.py
+++ b/src/agentex/lib/sdk/fastacp/impl/sync_acp.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, override
 from collections.abc import AsyncGenerator
 
-from agentex.lib.types.acp import SendMessageParams
+from agentex.protocol.acp import SendMessageParams
 from agentex.lib.utils.logging import make_logger
 from agentex.types.task_message_delta import TextDelta
 from agentex.types.task_message_update import (

--- a/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
+++ b/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from temporalio.converter import PayloadCodec
 
-from agentex.lib.types.acp import (
+from agentex.protocol.acp import (
     SendEventParams,
     CancelTaskParams,
     CreateTaskParams,

--- a/src/agentex/lib/sdk/fastacp/tests/conftest.py
+++ b/src/agentex/lib/sdk/fastacp/tests/conftest.py
@@ -13,12 +13,12 @@ import pytest_asyncio
 
 from agentex.types.task import Task
 from agentex.types.agent import Agent
-from agentex.lib.types.acp import (
+from agentex.protocol.acp import (
     CancelTaskParams,
     CreateTaskParams,
     SendMessageParams,
 )
-from agentex.lib.types.json_rpc import JSONRPCRequest
+from agentex.protocol.json_rpc import JSONRPCRequest
 from agentex.types.task_message import TaskMessageContent
 from agentex.types.task_message_content import TextContent
 from agentex.lib.sdk.fastacp.impl.sync_acp import SyncACP

--- a/src/agentex/lib/sdk/fastacp/tests/test_base_acp_server.py
+++ b/src/agentex/lib/sdk/fastacp/tests/test_base_acp_server.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from agentex.lib.types.acp import (
+from agentex.protocol.acp import (
     RPCMethod,
     SendEventParams,
     CancelTaskParams,

--- a/src/agentex/lib/sdk/fastacp/tests/test_integration.py
+++ b/src/agentex/lib/sdk/fastacp/tests/test_integration.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from agentex.lib.types.acp import (
+from agentex.protocol.acp import (
     RPCMethod,
     SendEventParams,
     CancelTaskParams,

--- a/src/agentex/lib/types/acp.py
+++ b/src/agentex/lib/types/acp.py
@@ -1,116 +1,13 @@
-from __future__ import annotations
+"""Back-compat shim. The canonical location is :mod:`agentex.protocol.acp`.
 
-from enum import Enum
-from typing import Any
+Kept here so existing ``from agentex.lib.types.acp import ...`` imports
+continue to work. New code should import from the canonical path.
+"""
 
-from pydantic import Field, BaseModel
-
-from agentex.types.task import Task
-from agentex.types.agent import Agent
-from agentex.types.event import Event
-from agentex.types.task_message_content import TaskMessageContent
-
-
-class RPCMethod(str, Enum):
-    """Available JSON-RPC methods for agent communication."""
-
-    EVENT_SEND = "event/send"
-    MESSAGE_SEND = "message/send"
-    TASK_CANCEL = "task/cancel"
-    TASK_CREATE = "task/create"
-
-
-class CreateTaskParams(BaseModel):
-    """Parameters for task/create method.
-
-    Attributes:
-        agent: The agent that the task was sent to.
-        task: The task to be created.
-        params: The parameters for the task as inputted by the user.
-        request: Additional request context including headers forwarded to this agent.
-    """
-
-    agent: Agent = Field(..., description="The agent that the task was sent to")
-    task: Task = Field(..., description="The task to be created")
-    params: dict[str, Any] | None = Field(
-        None,
-        description="The parameters for the task as inputted by the user",
-    )
-    request: dict[str, Any] | None = Field(
-        default=None,
-        description="Additional request context including headers forwarded to this agent",
-    )
-
-
-class SendMessageParams(BaseModel):
-    """Parameters for message/send method.
-
-    Attributes:
-        agent: The agent that the message was sent to.
-        task: The task that the message was sent to.
-        content: The message that was sent to the agent.
-        stream: Whether to stream the message back to the agentex server from the agent.
-        request: Additional request context including headers forwarded to this agent.
-    """
-
-    agent: Agent = Field(..., description="The agent that the message was sent to")
-    task: Task = Field(..., description="The task that the message was sent to")
-    content: TaskMessageContent = Field(
-        ..., description="The message that was sent to the agent"
-    )
-    stream: bool = Field(
-        False,
-        description="Whether to stream the message back to the agentex server from the agent",
-    )
-    request: dict[str, Any] | None = Field(
-        default=None,
-        description="Additional request context including headers forwarded to this agent",
-    )
-
-
-class SendEventParams(BaseModel):
-    """Parameters for event/send method.
-
-    Attributes:
-        agent: The agent that the event was sent to.
-        task: The task that the message was sent to.
-        event: The event that was sent to the agent.
-        request: Additional request context including headers forwarded to this agent.
-    """
-
-    agent: Agent = Field(..., description="The agent that the event was sent to")
-    task: Task = Field(..., description="The task that the message was sent to")
-    event: Event = Field(..., description="The event that was sent to the agent")
-    request: dict[str, Any] | None = Field(
-        default=None,
-        description="Additional request context including headers forwarded to this agent",
-    )
-
-
-class CancelTaskParams(BaseModel):
-    """Parameters for task/cancel method.
-
-    Attributes:
-        agent: The agent that the task was sent to.
-        task: The task that was cancelled.
-        request: Additional request context including headers forwarded to this agent.
-    """
-
-    agent: Agent = Field(..., description="The agent that the task was sent to")
-    task: Task = Field(..., description="The task that was cancelled")
-    request: dict[str, Any] | None = Field(
-        default=None,
-        description="Additional request context including headers forwarded to this agent",
-    )
-
-
-RPC_SYNC_METHODS = [
-    RPCMethod.MESSAGE_SEND,
-]
-
-PARAMS_MODEL_BY_METHOD: dict[RPCMethod, type[BaseModel]] = {
-    RPCMethod.EVENT_SEND: SendEventParams,
-    RPCMethod.TASK_CANCEL: CancelTaskParams,
-    RPCMethod.MESSAGE_SEND: SendMessageParams,
-    RPCMethod.TASK_CREATE: CreateTaskParams,
-}
+from agentex.protocol.acp import (  # noqa: F401
+    RPCMethod,
+    SendEventParams,
+    CancelTaskParams,
+    CreateTaskParams,
+    SendMessageParams,
+)

--- a/src/agentex/lib/types/acp.py
+++ b/src/agentex/lib/types/acp.py
@@ -5,6 +5,8 @@ continue to work. New code should import from the canonical path.
 """
 
 from agentex.protocol.acp import (  # noqa: F401
+    RPC_SYNC_METHODS,
+    PARAMS_MODEL_BY_METHOD,
     RPCMethod,
     SendEventParams,
     CancelTaskParams,

--- a/src/agentex/lib/types/json_rpc.py
+++ b/src/agentex/lib/types/json_rpc.py
@@ -1,51 +1,11 @@
-from __future__ import annotations
+"""Back-compat shim. The canonical location is :mod:`agentex.protocol.json_rpc`.
 
-from typing import Any, Literal
+Kept here so existing ``from agentex.lib.types.json_rpc import ...`` imports
+continue to work. New code should import from the canonical path.
+"""
 
-from agentex.lib.utils.model_utils import BaseModel
-
-
-class JSONRPCError(BaseModel):
-    """JSON-RPC 2.0 Error
-
-    Attributes:
-        code: The error code
-        message: The error message
-        data: The error data
-    """
-
-    code: int
-    message: str
-    data: Any | None = None
-
-
-class JSONRPCRequest(BaseModel):
-    """JSON-RPC 2.0 Request
-
-    Attributes:
-        jsonrpc: The JSON-RPC version
-        method: The method to call
-        params: The parameters for the request
-        id: The ID of the request
-    """
-
-    jsonrpc: Literal["2.0"] = "2.0"
-    method: str
-    params: dict[str, Any]
-    id: int | str | None = None
-
-
-class JSONRPCResponse(BaseModel):
-    """JSON-RPC 2.0 Response
-
-    Attributes:
-        jsonrpc: The JSON-RPC version
-        result: The result of the request
-        error: The error of the request
-        id: The ID of the request
-    """
-
-    jsonrpc: Literal["2.0"] = "2.0"
-    result: dict[str, Any] | None = None
-    error: JSONRPCError | None = None
-    id: int | str | None = None
+from agentex.protocol.json_rpc import (  # noqa: F401
+    JSONRPCError,
+    JSONRPCRequest,
+    JSONRPCResponse,
+)

--- a/src/agentex/protocol/__init__.py
+++ b/src/agentex/protocol/__init__.py
@@ -1,0 +1,16 @@
+"""Wire-protocol shapes for Agentex.
+
+The modules under `agentex.protocol.*` are the typed shapes for talking to
+an Agentex agent over JSON-RPC (the ACP / Agent Communication Protocol)
+without pulling in the heavy ADK runtime. They depend only on pydantic and
+the Stainless-generated `agentex.types.*` surface, so they are safe to
+import from a slim REST-only install.
+
+Hand-rolled JSON-RPC clients (e.g. the one in `egp-api-backend`) can switch
+from constructing `{"jsonrpc": "2.0", "method": "...", "params": {...}}`
+dicts by hand to constructing `JSONRPCRequest(method=RPCMethod.TASK_CREATE,
+params=CreateTaskParams(...).model_dump())`.
+
+For back-compat, the same classes are re-exported from
+`agentex.lib.types.{acp,json_rpc}` (the historical locations).
+"""

--- a/src/agentex/protocol/acp.py
+++ b/src/agentex/protocol/acp.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import Field, BaseModel
+
+from agentex.types.task import Task
+from agentex.types.agent import Agent
+from agentex.types.event import Event
+from agentex.types.task_message_content import TaskMessageContent
+
+
+class RPCMethod(str, Enum):
+    """Available JSON-RPC methods for agent communication."""
+
+    EVENT_SEND = "event/send"
+    MESSAGE_SEND = "message/send"
+    TASK_CANCEL = "task/cancel"
+    TASK_CREATE = "task/create"
+
+
+class CreateTaskParams(BaseModel):
+    """Parameters for task/create method.
+
+    Attributes:
+        agent: The agent that the task was sent to.
+        task: The task to be created.
+        params: The parameters for the task as inputted by the user.
+        request: Additional request context including headers forwarded to this agent.
+    """
+
+    agent: Agent = Field(..., description="The agent that the task was sent to")
+    task: Task = Field(..., description="The task to be created")
+    params: dict[str, Any] | None = Field(
+        None,
+        description="The parameters for the task as inputted by the user",
+    )
+    request: dict[str, Any] | None = Field(
+        default=None,
+        description="Additional request context including headers forwarded to this agent",
+    )
+
+
+class SendMessageParams(BaseModel):
+    """Parameters for message/send method.
+
+    Attributes:
+        agent: The agent that the message was sent to.
+        task: The task that the message was sent to.
+        content: The message that was sent to the agent.
+        stream: Whether to stream the message back to the agentex server from the agent.
+        request: Additional request context including headers forwarded to this agent.
+    """
+
+    agent: Agent = Field(..., description="The agent that the message was sent to")
+    task: Task = Field(..., description="The task that the message was sent to")
+    content: TaskMessageContent = Field(
+        ..., description="The message that was sent to the agent"
+    )
+    stream: bool = Field(
+        False,
+        description="Whether to stream the message back to the agentex server from the agent",
+    )
+    request: dict[str, Any] | None = Field(
+        default=None,
+        description="Additional request context including headers forwarded to this agent",
+    )
+
+
+class SendEventParams(BaseModel):
+    """Parameters for event/send method.
+
+    Attributes:
+        agent: The agent that the event was sent to.
+        task: The task that the message was sent to.
+        event: The event that was sent to the agent.
+        request: Additional request context including headers forwarded to this agent.
+    """
+
+    agent: Agent = Field(..., description="The agent that the event was sent to")
+    task: Task = Field(..., description="The task that the message was sent to")
+    event: Event = Field(..., description="The event that was sent to the agent")
+    request: dict[str, Any] | None = Field(
+        default=None,
+        description="Additional request context including headers forwarded to this agent",
+    )
+
+
+class CancelTaskParams(BaseModel):
+    """Parameters for task/cancel method.
+
+    Attributes:
+        agent: The agent that the task was sent to.
+        task: The task that was cancelled.
+        request: Additional request context including headers forwarded to this agent.
+    """
+
+    agent: Agent = Field(..., description="The agent that the task was sent to")
+    task: Task = Field(..., description="The task that was cancelled")
+    request: dict[str, Any] | None = Field(
+        default=None,
+        description="Additional request context including headers forwarded to this agent",
+    )
+
+
+RPC_SYNC_METHODS = [
+    RPCMethod.MESSAGE_SEND,
+]
+
+PARAMS_MODEL_BY_METHOD: dict[RPCMethod, type[BaseModel]] = {
+    RPCMethod.EVENT_SEND: SendEventParams,
+    RPCMethod.TASK_CANCEL: CancelTaskParams,
+    RPCMethod.MESSAGE_SEND: SendMessageParams,
+    RPCMethod.TASK_CREATE: CreateTaskParams,
+}

--- a/src/agentex/protocol/json_rpc.py
+++ b/src/agentex/protocol/json_rpc.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+
+# Preserve the config the previous `agentex.lib.utils.model_utils.BaseModel`
+# applied — `from_attributes=True` lets callers `model_validate` from
+# attribute-bearing objects (not just dicts); `populate_by_name=True` is a
+# harmless default future-proofing for any field aliases.
+_PROTOCOL_MODEL_CONFIG = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class JSONRPCError(BaseModel):
@@ -13,6 +19,8 @@ class JSONRPCError(BaseModel):
         message: The error message
         data: The error data
     """
+
+    model_config = _PROTOCOL_MODEL_CONFIG
 
     code: int
     message: str
@@ -29,6 +37,8 @@ class JSONRPCRequest(BaseModel):
         id: The ID of the request
     """
 
+    model_config = _PROTOCOL_MODEL_CONFIG
+
     jsonrpc: Literal["2.0"] = "2.0"
     method: str
     params: dict[str, Any]
@@ -44,6 +54,8 @@ class JSONRPCResponse(BaseModel):
         error: The error of the request
         id: The ID of the request
     """
+
+    model_config = _PROTOCOL_MODEL_CONFIG
 
     jsonrpc: Literal["2.0"] = "2.0"
     result: dict[str, Any] | None = None

--- a/src/agentex/protocol/json_rpc.py
+++ b/src/agentex/protocol/json_rpc.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class JSONRPCError(BaseModel):
+    """JSON-RPC 2.0 Error
+
+    Attributes:
+        code: The error code
+        message: The error message
+        data: The error data
+    """
+
+    code: int
+    message: str
+    data: Any | None = None
+
+
+class JSONRPCRequest(BaseModel):
+    """JSON-RPC 2.0 Request
+
+    Attributes:
+        jsonrpc: The JSON-RPC version
+        method: The method to call
+        params: The parameters for the request
+        id: The ID of the request
+    """
+
+    jsonrpc: Literal["2.0"] = "2.0"
+    method: str
+    params: dict[str, Any]
+    id: int | str | None = None
+
+
+class JSONRPCResponse(BaseModel):
+    """JSON-RPC 2.0 Response
+
+    Attributes:
+        jsonrpc: The JSON-RPC version
+        result: The result of the request
+        error: The error of the request
+        id: The ID of the request
+    """
+
+    jsonrpc: Literal["2.0"] = "2.0"
+    result: dict[str, Any] | None = None
+    error: JSONRPCError | None = None
+    id: int | str | None = None

--- a/tests/test_header_forwarding.py
+++ b/tests/test_header_forwarding.py
@@ -46,7 +46,7 @@ sys.modules["agentex.lib.core.tracing"] = tracing_pkg_stub
 
 from agentex.lib.core.services.adk.acp.acp import ACPService
 from agentex.lib.sdk.fastacp.base.base_acp_server import BaseACPServer
-from agentex.lib.types.acp import RPCMethod, SendMessageParams, SendEventParams
+from agentex.protocol.acp import RPCMethod, SendMessageParams, SendEventParams
 from agentex.types.task_message_content import TextContent
 from agentex.lib.sdk.fastacp.impl.temporal_acp import TemporalACP
 from agentex.lib.core.temporal.services.temporal_task_service import TemporalTaskService

--- a/tests/test_protocol_shims.py
+++ b/tests/test_protocol_shims.py
@@ -31,12 +31,12 @@ def test_acp_shim_re_exports_all_original_symbols() -> None:
     still be importable from that path via the back-compat shim."""
     # Importing each symbol; ImportError here means the shim regressed.
     from agentex.lib.types.acp import (  # noqa: F401
-        PARAMS_MODEL_BY_METHOD,
         RPC_SYNC_METHODS,
-        CancelTaskParams,
-        CreateTaskParams,
+        PARAMS_MODEL_BY_METHOD,
         RPCMethod,
         SendEventParams,
+        CancelTaskParams,
+        CreateTaskParams,
         SendMessageParams,
     )
 
@@ -55,8 +55,8 @@ def test_acp_shim_classes_are_identical_to_canonical() -> None:
     """Shim re-exports must be the *same* class objects as the canonical
     path. Different objects would break ``isinstance`` for code that
     mixes import styles."""
-    from agentex.lib.types import acp as shim
     from agentex.protocol import acp as canon
+    from agentex.lib.types import acp as shim
 
     assert shim.RPCMethod is canon.RPCMethod
     assert shim.CreateTaskParams is canon.CreateTaskParams
@@ -69,8 +69,8 @@ def test_acp_shim_classes_are_identical_to_canonical() -> None:
 
 def test_json_rpc_shim_classes_are_identical_to_canonical() -> None:
     """Same identity check for the JSON-RPC envelope types."""
-    from agentex.lib.types import json_rpc as shim
     from agentex.protocol import json_rpc as canon
+    from agentex.lib.types import json_rpc as shim
 
     assert shim.JSONRPCError is canon.JSONRPCError
     assert shim.JSONRPCRequest is canon.JSONRPCRequest

--- a/tests/test_protocol_shims.py
+++ b/tests/test_protocol_shims.py
@@ -1,0 +1,98 @@
+"""Tests that pin the back-compat contract for protocol-type shims.
+
+The canonical location for wire-protocol shapes is :mod:`agentex.protocol`
+(see PR scaleapi/scale-agentex-python#371). The historical locations
+:mod:`agentex.lib.types.acp` and :mod:`agentex.lib.types.json_rpc` are
+preserved as re-export shims so external consumers' existing imports
+continue to work.
+
+These tests enforce two invariants:
+
+1. **Symbol parity** — every public name the original modules exported
+   is still importable from the old path. Greptile flagged
+   ``RPC_SYNC_METHODS`` and ``PARAMS_MODEL_BY_METHOD`` as missing in an
+   earlier pass; this test prevents that regression.
+2. **Identity** — the class objects at the shim path are the *same*
+   objects as the canonical path. Without this, type-narrowing via
+   ``isinstance`` or pattern matching would silently misbehave for code
+   that mixes import styles.
+
+Also asserts the :class:`pydantic.ConfigDict` settings on the JSON-RPC
+classes survived the move from :mod:`agentex.lib.utils.model_utils` to
+plain :mod:`pydantic` — Greptile flagged the silent loss of
+``from_attributes=True`` / ``populate_by_name=True``.
+"""
+
+from __future__ import annotations
+
+
+def test_acp_shim_re_exports_all_original_symbols() -> None:
+    """Every name historically exported from agentex.lib.types.acp must
+    still be importable from that path via the back-compat shim."""
+    # Importing each symbol; ImportError here means the shim regressed.
+    from agentex.lib.types.acp import (  # noqa: F401
+        PARAMS_MODEL_BY_METHOD,
+        RPC_SYNC_METHODS,
+        CancelTaskParams,
+        CreateTaskParams,
+        RPCMethod,
+        SendEventParams,
+        SendMessageParams,
+    )
+
+
+def test_json_rpc_shim_re_exports_all_original_symbols() -> None:
+    """Every name historically exported from agentex.lib.types.json_rpc
+    must still be importable from that path via the back-compat shim."""
+    from agentex.lib.types.json_rpc import (  # noqa: F401
+        JSONRPCError,
+        JSONRPCRequest,
+        JSONRPCResponse,
+    )
+
+
+def test_acp_shim_classes_are_identical_to_canonical() -> None:
+    """Shim re-exports must be the *same* class objects as the canonical
+    path. Different objects would break ``isinstance`` for code that
+    mixes import styles."""
+    from agentex.lib.types import acp as shim
+    from agentex.protocol import acp as canon
+
+    assert shim.RPCMethod is canon.RPCMethod
+    assert shim.CreateTaskParams is canon.CreateTaskParams
+    assert shim.SendMessageParams is canon.SendMessageParams
+    assert shim.SendEventParams is canon.SendEventParams
+    assert shim.CancelTaskParams is canon.CancelTaskParams
+    assert shim.RPC_SYNC_METHODS is canon.RPC_SYNC_METHODS
+    assert shim.PARAMS_MODEL_BY_METHOD is canon.PARAMS_MODEL_BY_METHOD
+
+
+def test_json_rpc_shim_classes_are_identical_to_canonical() -> None:
+    """Same identity check for the JSON-RPC envelope types."""
+    from agentex.lib.types import json_rpc as shim
+    from agentex.protocol import json_rpc as canon
+
+    assert shim.JSONRPCError is canon.JSONRPCError
+    assert shim.JSONRPCRequest is canon.JSONRPCRequest
+    assert shim.JSONRPCResponse is canon.JSONRPCResponse
+
+
+def test_json_rpc_classes_preserve_legacy_model_config() -> None:
+    """Pre-refactor, JSON-RPC classes inherited
+    ``from_attributes=True`` / ``populate_by_name=True`` from
+    ``agentex.lib.utils.model_utils.BaseModel``. The refactor swapped
+    to plain ``pydantic.BaseModel`` and set ``model_config`` explicitly
+    to preserve both flags. Catch any future drop."""
+    from agentex.protocol.json_rpc import (
+        JSONRPCError,
+        JSONRPCRequest,
+        JSONRPCResponse,
+    )
+
+    for cls in (JSONRPCError, JSONRPCRequest, JSONRPCResponse):
+        assert cls.model_config.get("from_attributes") is True, (
+            f"{cls.__name__}.model_config dropped from_attributes=True"
+        )
+        assert cls.model_config.get("populate_by_name") is True, (
+            f"{cls.__name__}.model_config dropped populate_by_name=True"
+        )


### PR DESCRIPTION
## Summary

Moves the JSON-RPC envelope types (`JSONRPCRequest`/`Response`/`Error`) and ACP method-param types (`CreateTaskParams`, `SendMessageParams`, `SendEventParams`, `CancelTaskParams`, `RPCMethod`) out of `agentex.lib.types.*` into a new canonical location at `agentex.protocol.*`. Back-compat shims at the old paths re-export the same classes — existing imports continue to work.

**Zero install-time impact for existing consumers.** Same import paths keep working.

Tracking: [AGX1-292](https://linear.app/scale-epd/issue/AGX1-292/reduce-agentex-sdk-runtime-deps-47-6-base-move-adkserver-deps-to). First of two PRs:
- **This PR**: refactor only — set up `agentex.protocol.*` as the canonical location for protocol types
- **Follow-up PR**: introduces the slim `agentex-sdk-client` package (which will ship `agentex.protocol.*` but not `agentex.lib.*`), letting REST-only consumers like [`packages/egp-api-backend`](https://github.com/scaleapi/scaleapi/tree/master/packages/egp-api-backend) drop hand-rolled JSON-RPC dict literals in favor of these typed shapes

## Motivation

`egp-api-backend` today hand-rolls a ~600-line JSON-RPC gateway at `egp_api_backend/server/internal/interfaces/services/evaluation_task/evaluation_task_gateways/agentex_output_evaluation_task_gateway.py`. Sample:

```python
async with session.post(
    rpc_path,
    json={
        "jsonrpc": "2.0",
        "method": "task/create",
        "params": {
            "name": task_name,
            "params": {"description": ..., "is_eval": True},
        },
    },
) as resp:
```

These shapes map directly onto the types defined in `agentex.lib.types.acp` and `agentex.lib.types.json_rpc`. They hand-roll because importing those types currently requires pulling in the full ADK runtime (~31 deps including temporalio, fastapi, claude-agent-sdk, etc.).

Moving the protocol types out of `agentex.lib.*` is the prerequisite for letting them ship in a future slim-package install.

## Changes

| File | Change |
|---|---|
| `src/agentex/protocol/__init__.py` | New — package docstring |
| `src/agentex/protocol/acp.py` | Moved from `src/agentex/lib/types/acp.py`; no other change |
| `src/agentex/protocol/json_rpc.py` | Moved from `src/agentex/lib/types/json_rpc.py`; swapped `from agentex.lib.utils.model_utils import BaseModel` → `from pydantic import BaseModel` (behavior-preserving — these classes don't use any `model_utils` extensions like `from_yaml`/`to_json`/`populate_by_name`) |
| `src/agentex/lib/types/acp.py` | Replaced with back-compat shim re-exporting from canonical path |
| `src/agentex/lib/types/json_rpc.py` | Replaced with back-compat shim re-exporting from canonical path |
| 9 files in `src/agentex/lib/*` | Internal imports updated to canonical path |
| `tests/test_header_forwarding.py` | Internal import updated to canonical path |

## Slim-safety of moved files

Both moved modules depend only on `pydantic` and `agentex.types.{Task, Agent, Event, TaskMessageContent}` — all already-slim-safe (Stainless-generated client surface + pydantic, which is in the bare client's 6 base deps).

Other `agentex.lib.types.*` modules have heavier deps (e.g. `fastacp.py` pulls temporal, `converters.py` pulls openai-agents) and are intentionally left in place. They can be promoted in follow-up PRs if/when other consumers need them slim-safe.

## Verification (local)

```sh
ruff check .
# All checks passed!

python -m build --wheel
unzip -l dist/agentex_sdk-0.11.4-py3-none-any.whl | grep -E "(protocol/|lib/types/(acp|json_rpc))"
# Both paths shipped: agentex/protocol/acp.py + agentex/protocol/json_rpc.py
#                     agentex/lib/types/acp.py (shim) + agentex/lib/types/json_rpc.py (shim)

# Identity check from a fresh install:
python -c "
from agentex.protocol.acp import RPCMethod as A
from agentex.lib.types.acp import RPCMethod as B
assert A is B  # same class object — shim re-exports, not duplicates
print('identity OK')
"
# identity OK
```

## Test plan

- [ ] CI passes (ruff, pyright, mypy, pytest).
- [ ] Any consumer doing `from agentex.lib.types.acp import CreateTaskParams` continues to work without change.
- [ ] `from agentex.protocol.acp import CreateTaskParams` works as the new canonical path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes the JSON-RPC envelope types (`JSONRPCRequest`/`Response`/`Error`) and ACP method-param types (`CreateTaskParams`, `SendMessageParams`, etc.) from `agentex.lib.types.*` to a new canonical package at `agentex.protocol.*`. The old paths are converted to thin re-export shims so existing consumer imports continue to work without any code changes.

- **New `agentex.protocol` package** (`acp.py`, `json_rpc.py`, `__init__.py`) holds the canonical definitions; `json_rpc.py` explicitly restores the `from_attributes=True` / `populate_by_name=True` `ConfigDict` that was previously inherited from the shared `model_utils.BaseModel`.
- **Back-compat shims** at `agentex.lib.types.{acp,json_rpc}` re-export all original public symbols — including `RPC_SYNC_METHODS` and `PARAMS_MODEL_BY_METHOD` — so `isinstance` checks, type annotations, and existing imports remain identity-safe.
- **New test file** `tests/test_protocol_shims.py` pins both the symbol-parity and class-identity invariants, and separately asserts the `ConfigDict` preservation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a pure namespace reorganisation with no behavioural changes and fully-covered back-compat shims.

Both issues raised in the previous review round have been addressed in full: the shim now re-exports RPC_SYNC_METHODS and PARAMS_MODEL_BY_METHOD, and json_rpc.py explicitly restores from_attributes=True / populate_by_name=True via a shared ConfigDict. A dedicated test file pins both invariants. All internal imports and CLI templates have been mechanically updated to the canonical paths. No logic was changed anywhere.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/protocol/acp.py | New canonical location for ACP types; identical content to the original lib/types/acp.py using plain pydantic.BaseModel (which the original already used). All seven public symbols present. |
| src/agentex/protocol/json_rpc.py | New canonical location for JSON-RPC types; explicitly preserves from_attributes=True / populate_by_name=True via _PROTOCOL_MODEL_CONFIG, restoring the behavior previously inherited from model_utils.BaseModel. |
| src/agentex/lib/types/acp.py | Replaced with back-compat shim; re-exports all seven original public symbols including RPC_SYNC_METHODS and PARAMS_MODEL_BY_METHOD. |
| src/agentex/lib/types/json_rpc.py | Replaced with back-compat shim; re-exports all three JSON-RPC envelope classes from the canonical path. |
| tests/test_protocol_shims.py | New test file pinning symbol-parity, class-identity, and ConfigDict preservation invariants across both shims; directly addresses the concerns raised in previous review threads. |
| src/agentex/lib/sdk/fastacp/base/base_acp_server.py | Import updated to agentex.protocol.{acp,json_rpc}; no logic change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[agentex.protocol.acp\nCANONICAL] -->|re-exported by| B[agentex.lib.types.acp\nback-compat shim]
    C[agentex.protocol.json_rpc\nCANONICAL] -->|re-exported by| D[agentex.lib.types.json_rpc\nback-compat shim]

    A -->|imported directly| E[fastacp/base_acp_server.py]
    A -->|imported directly| F[fastacp/impl/*.py]
    A -->|imported directly| G[temporal workflows & services]
    A -->|imported directly| H[CLI templates *.j2]

    C -->|imported directly| E

    B -->|still works for| I[external consumers]
    D -->|still works for| I

    subgraph "agentex.protocol package"
        A
        C
        J[__init__.py\ndocstring only]
    end
```
</details>

<sub>Reviews (6): Last reviewed commit: ["docs(claude): document agentex.protocol/..."](https://github.com/scaleapi/scale-agentex-python/commit/9f237a0db9e423fbb8ebf435edda5274daf06a6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34091628)</sub>

<!-- /greptile_comment -->