### PR TITLE
feat(lib): expose data_converter kwarg on AgentexWorker and Temporal client APIs

### DIFF
--- a/src/agentex/lib/core/clients/temporal/temporal_client.py
+++ b/src/agentex/lib/core/clients/temporal/temporal_client.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from temporalio.client import Client, WorkflowExecutionStatus
 from temporalio.common import RetryPolicy as TemporalRetryPolicy, WorkflowIDReusePolicy
 from temporalio.service import RPCError, RPCStatusCode
-from temporalio.converter import DataConverter, PayloadCodec
+from temporalio.converter import PayloadCodec, DataConverter
 
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.utils.model_utils import BaseModel

--- a/src/agentex/lib/core/clients/temporal/temporal_client.py
+++ b/src/agentex/lib/core/clients/temporal/temporal_client.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from temporalio.client import Client, WorkflowExecutionStatus
 from temporalio.common import RetryPolicy as TemporalRetryPolicy, WorkflowIDReusePolicy
 from temporalio.service import RPCError, RPCStatusCode
-from temporalio.converter import PayloadCodec
+from temporalio.converter import DataConverter, PayloadCodec
 
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.utils.model_utils import BaseModel
@@ -78,11 +78,16 @@ DUPLICATE_POLICY_TO_ID_REUSE_POLICY = {
 
 class TemporalClient:
     def __init__(
-        self, temporal_client: Client | None = None, plugins: list[Any] = [], payload_codec: PayloadCodec | None = None
+        self,
+        temporal_client: Client | None = None,
+        plugins: list[Any] = [],
+        payload_codec: PayloadCodec | None = None,
+        data_converter: DataConverter | None = None,
     ):
         self._client: Client | None = temporal_client
         self._plugins = plugins
         self._payload_codec = payload_codec
+        self._data_converter = data_converter
 
     @property
     def client(self) -> Client:
@@ -92,7 +97,13 @@ class TemporalClient:
         return self._client
 
     @classmethod
-    async def create(cls, temporal_address: str, plugins: list[Any] = [], payload_codec: PayloadCodec | None = None):
+    async def create(
+        cls,
+        temporal_address: str,
+        plugins: list[Any] = [],
+        payload_codec: PayloadCodec | None = None,
+        data_converter: DataConverter | None = None,
+    ):
         if temporal_address in [
             "false",
             "False",
@@ -105,8 +116,13 @@ class TemporalClient:
         ]:
             _client = None
         else:
-            _client = await get_temporal_client(temporal_address, plugins=plugins, payload_codec=payload_codec)
-        return cls(_client, plugins, payload_codec)
+            _client = await get_temporal_client(
+                temporal_address,
+                plugins=plugins,
+                payload_codec=payload_codec,
+                data_converter=data_converter,
+            )
+        return cls(_client, plugins, payload_codec, data_converter)
 
     async def setup(self, temporal_address: str):
         self._client = await self._get_temporal_client(temporal_address=temporal_address)
@@ -124,7 +140,12 @@ class TemporalClient:
         ]:
             return None
         else:
-            return await get_temporal_client(temporal_address, plugins=self._plugins, payload_codec=self._payload_codec)
+            return await get_temporal_client(
+                temporal_address,
+                plugins=self._plugins,
+                payload_codec=self._payload_codec,
+                data_converter=self._data_converter,
+            )
 
     async def start_workflow(
         self,

--- a/src/agentex/lib/core/clients/temporal/utils.py
+++ b/src/agentex/lib/core/clients/temporal/utils.py
@@ -6,7 +6,7 @@ from typing import Any
 from temporalio.client import Client, Plugin as ClientPlugin
 from temporalio.worker import Interceptor
 from temporalio.runtime import Runtime, TelemetryConfig, OpenTelemetryConfig
-from temporalio.converter import DataConverter, PayloadCodec
+from temporalio.converter import PayloadCodec, DataConverter
 from temporalio.contrib.pydantic import pydantic_data_converter
 
 # class DateTimeJSONEncoder(AdvancedJSONEncoder):
@@ -118,17 +118,11 @@ async def get_temporal_client(
             "kwarg. Specifying both is ambiguous."
         )
 
-    # Check if OpenAI plugin is present - it needs to configure its own data converter
     # Lazy import to avoid pulling in opentelemetry.sdk for non-Temporal agents
     from temporalio.contrib.openai_agents import OpenAIAgentsPlugin
 
     has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
-    # When the OpenAI plugin is present, its `_data_converter` transformer
-    # builds a fresh DataConverter (without any codec) if none is supplied,
-    # so a standalone `payload_codec` kwarg would be silently dropped and
-    # payloads would land in Temporal in plain text. Guide the caller to
-    # the working composition path instead.
     if has_openai_plugin and payload_codec is not None and data_converter is None:
         raise ValueError(
             "payload_codec passed as a kwarg alongside OpenAIAgentsPlugin would "
@@ -145,10 +139,6 @@ async def get_temporal_client(
     }
 
     if data_converter is not None:
-        # Caller supplied a pre-built converter. With the OpenAI plugin present
-        # and `payload_converter_class=OpenAIPayloadConverter` (or subclass),
-        # the plugin's `_data_converter` transformer passes it through intact,
-        # preserving any payload_codec.
         connect_kwargs["data_converter"] = data_converter
     elif not has_openai_plugin:
         dc = pydantic_data_converter

--- a/src/agentex/lib/core/clients/temporal/utils.py
+++ b/src/agentex/lib/core/clients/temporal/utils.py
@@ -6,7 +6,7 @@ from typing import Any
 from temporalio.client import Client, Plugin as ClientPlugin
 from temporalio.worker import Interceptor
 from temporalio.runtime import Runtime, TelemetryConfig, OpenTelemetryConfig
-from temporalio.converter import PayloadCodec
+from temporalio.converter import DataConverter, PayloadCodec
 from temporalio.contrib.pydantic import pydantic_data_converter
 
 # class DateTimeJSONEncoder(AdvancedJSONEncoder):
@@ -86,6 +86,7 @@ async def get_temporal_client(
     metrics_url: str | None = None,
     plugins: list[Any] = [],
     payload_codec: PayloadCodec | None = None,
+    data_converter: DataConverter | None = None,
 ) -> Client:
     """
     Create a Temporal client with plugin integration.
@@ -94,7 +95,14 @@ async def get_temporal_client(
         temporal_address: Temporal server address
         metrics_url: Optional metrics endpoint URL
         plugins: List of Temporal plugins to include
-        payload_codec: Optional payload codec for encoding/decoding payloads (e.g. encryption, compression)
+        payload_codec: Optional payload codec for encoding/decoding payloads
+            (e.g. encryption, compression). Cannot be combined with the
+            OpenAIAgentsPlugin via this kwarg — see ``data_converter``.
+        data_converter: Optional pre-built ``DataConverter``. Use this when
+            composing the OpenAIAgentsPlugin with a payload codec: build a
+            ``DataConverter(payload_converter_class=OpenAIPayloadConverter,
+            payload_codec=...)`` and pass it here. Mutually exclusive with
+            ``payload_codec``.
 
     Returns:
         Configured Temporal client
@@ -103,29 +111,50 @@ async def get_temporal_client(
     if plugins:
         validate_client_plugins(plugins)
 
+    if payload_codec is not None and data_converter is not None:
+        raise ValueError(
+            "Pass payload_codec inside `data_converter` "
+            "(DataConverter(..., payload_codec=...)) instead of as a separate "
+            "kwarg. Specifying both is ambiguous."
+        )
+
     # Check if OpenAI plugin is present - it needs to configure its own data converter
     # Lazy import to avoid pulling in opentelemetry.sdk for non-Temporal agents
     from temporalio.contrib.openai_agents import OpenAIAgentsPlugin
 
     has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
-    if has_openai_plugin and payload_codec is not None:
+    # When the OpenAI plugin is present, its `_data_converter` transformer
+    # builds a fresh DataConverter (without any codec) if none is supplied,
+    # so a standalone `payload_codec` kwarg would be silently dropped and
+    # payloads would land in Temporal in plain text. Guide the caller to
+    # the working composition path instead.
+    if has_openai_plugin and payload_codec is not None and data_converter is None:
         raise ValueError(
-            "payload_codec is not supported alongside OpenAIAgentsPlugin: the plugin "
-            "installs its own data converter and the codec would be silently ignored, "
-            "leaving payloads unencoded. Remove one or the other."
+            "payload_codec passed as a kwarg alongside OpenAIAgentsPlugin would "
+            "be silently dropped by the plugin's data-converter transformer. "
+            "Build a DataConverter explicitly with "
+            "`payload_converter_class=OpenAIPayloadConverter` (or a subclass) "
+            "and `payload_codec=...`, then pass it via the `data_converter` "
+            "kwarg instead."
         )
 
-    connect_kwargs = {
+    connect_kwargs: dict[str, Any] = {
         "target_host": temporal_address,
         "plugins": plugins,
     }
 
-    if not has_openai_plugin:
-        data_converter = pydantic_data_converter
-        if payload_codec:
-            data_converter = dataclasses.replace(data_converter, payload_codec=payload_codec)
+    if data_converter is not None:
+        # Caller supplied a pre-built converter. With the OpenAI plugin present
+        # and `payload_converter_class=OpenAIPayloadConverter` (or subclass),
+        # the plugin's `_data_converter` transformer passes it through intact,
+        # preserving any payload_codec.
         connect_kwargs["data_converter"] = data_converter
+    elif not has_openai_plugin:
+        dc = pydantic_data_converter
+        if payload_codec:
+            dc = dataclasses.replace(dc, payload_codec=payload_codec)
+        connect_kwargs["data_converter"] = dc
 
     if not metrics_url:
         client = await Client.connect(**connect_kwargs)

--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -95,9 +95,17 @@ async def get_temporal_client(
     metrics_url: str | None = None,
     plugins: list = [],
     payload_codec: PayloadCodec | None = None,
+    data_converter: DataConverter | None = None,
 ) -> Client:
     if plugins != []:  # We don't need to validate the plugins if they are empty
         _validate_plugins(plugins)
+
+    if payload_codec is not None and data_converter is not None:
+        raise ValueError(
+            "Pass payload_codec inside `data_converter` "
+            "(DataConverter(..., payload_codec=...)) instead of as a separate "
+            "kwarg. Specifying both is ambiguous."
+        )
 
     # Check if OpenAI plugin is present - it needs to configure its own data converter
     # Lazy import to avoid pulling in opentelemetry.sdk for non-Temporal agents
@@ -105,25 +113,37 @@ async def get_temporal_client(
 
     has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
-    if has_openai_plugin and payload_codec is not None:
+    # When the OpenAI plugin is present, its `_data_converter` transformer
+    # builds a fresh DataConverter (without any codec) if none is supplied,
+    # so a standalone `payload_codec` kwarg would be silently dropped and
+    # payloads would land in Temporal in plain text. Guide the caller to
+    # the working composition path instead.
+    if has_openai_plugin and payload_codec is not None and data_converter is None:
         raise ValueError(
-            "payload_codec is not supported alongside OpenAIAgentsPlugin: the plugin "
-            "installs its own data converter and the codec would be silently ignored, "
-            "leaving payloads unencoded. Remove one or the other."
+            "payload_codec passed as a kwarg alongside OpenAIAgentsPlugin would "
+            "be silently dropped by the plugin's data-converter transformer. "
+            "Build a DataConverter explicitly with "
+            "`payload_converter_class=OpenAIPayloadConverter` (or a subclass) "
+            "and `payload_codec=...`, then pass it via the `data_converter` "
+            "kwarg instead."
         )
 
-    # Build connection kwargs
-    connect_kwargs = {
+    connect_kwargs: dict[str, Any] = {
         "target_host": temporal_address,
         "plugins": plugins,
     }
 
-    # Only set data_converter if OpenAI plugin is not present
-    if not has_openai_plugin:
-        data_converter = custom_data_converter
-        if payload_codec:
-            data_converter = dataclasses.replace(data_converter, payload_codec=payload_codec)
+    if data_converter is not None:
+        # Caller supplied a pre-built converter. With the OpenAI plugin present
+        # and `payload_converter_class=OpenAIPayloadConverter` (or subclass),
+        # the plugin's `_data_converter` transformer passes it through intact,
+        # preserving any payload_codec.
         connect_kwargs["data_converter"] = data_converter
+    elif not has_openai_plugin:
+        dc = custom_data_converter
+        if payload_codec:
+            dc = dataclasses.replace(dc, payload_codec=payload_codec)
+        connect_kwargs["data_converter"] = dc
 
     if not metrics_url:
         client = await Client.connect(**connect_kwargs)
@@ -145,6 +165,7 @@ class AgentexWorker:
         interceptors: list = [],
         metrics_url: str | None = None,
         payload_codec: PayloadCodec | None = None,
+        data_converter: DataConverter | None = None,
     ):
         self.task_queue = task_queue
         self.activity_handles = []
@@ -159,6 +180,7 @@ class AgentexWorker:
         self.interceptors = interceptors
         self.metrics_url = metrics_url
         self.payload_codec = payload_codec
+        self.data_converter = data_converter
 
     @overload
     async def run(
@@ -195,6 +217,7 @@ class AgentexWorker:
             plugins=self.plugins,
             metrics_url=self.metrics_url,
             payload_codec=self.payload_codec,
+            data_converter=self.data_converter,
         )
 
         # Enable debug mode if AgentEx debug is enabled (disables deadlock detection)

--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -107,17 +107,11 @@ async def get_temporal_client(
             "kwarg. Specifying both is ambiguous."
         )
 
-    # Check if OpenAI plugin is present - it needs to configure its own data converter
     # Lazy import to avoid pulling in opentelemetry.sdk for non-Temporal agents
     from temporalio.contrib.openai_agents import OpenAIAgentsPlugin
 
     has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
-    # When the OpenAI plugin is present, its `_data_converter` transformer
-    # builds a fresh DataConverter (without any codec) if none is supplied,
-    # so a standalone `payload_codec` kwarg would be silently dropped and
-    # payloads would land in Temporal in plain text. Guide the caller to
-    # the working composition path instead.
     if has_openai_plugin and payload_codec is not None and data_converter is None:
         raise ValueError(
             "payload_codec passed as a kwarg alongside OpenAIAgentsPlugin would "
@@ -134,10 +128,6 @@ async def get_temporal_client(
     }
 
     if data_converter is not None:
-        # Caller supplied a pre-built converter. With the OpenAI plugin present
-        # and `payload_converter_class=OpenAIPayloadConverter` (or subclass),
-        # the plugin's `_data_converter` transformer passes it through intact,
-        # preserving any payload_codec.
         connect_kwargs["data_converter"] = data_converter
     elif not has_openai_plugin:
         dc = custom_data_converter

--- a/src/agentex/lib/sdk/fastacp/fastacp.py
+++ b/src/agentex/lib/sdk/fastacp/fastacp.py
@@ -65,6 +65,8 @@ class FastACP:
                 temporal_config["interceptors"] = config.interceptors  # type: ignore[attr-defined]
             if hasattr(config, "payload_codec"):
                 temporal_config["payload_codec"] = config.payload_codec  # type: ignore[attr-defined]
+            if hasattr(config, "data_converter"):
+                temporal_config["data_converter"] = config.data_converter  # type: ignore[attr-defined]
             return implementation_class.create(**temporal_config)
         else:
             return implementation_class.create(**kwargs)

--- a/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
+++ b/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, AsyncGenerator, override
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from temporalio.converter import PayloadCodec
+from temporalio.converter import DataConverter, PayloadCodec
 
 from agentex.protocol.acp import (
     SendEventParams,
@@ -33,6 +33,7 @@ class TemporalACP(BaseACPServer):
         plugins: list[Any] | None = None,
         interceptors: list[Any] | None = None,
         payload_codec: PayloadCodec | None = None,
+        data_converter: DataConverter | None = None,
     ):
         super().__init__()
         self._temporal_task_service = temporal_task_service
@@ -40,6 +41,7 @@ class TemporalACP(BaseACPServer):
         self._plugins = plugins or []
         self._interceptors = interceptors or []
         self._payload_codec = payload_codec
+        self._data_converter = data_converter
 
     @classmethod
     @override
@@ -49,12 +51,17 @@ class TemporalACP(BaseACPServer):
         plugins: list[Any] | None = None,
         interceptors: list[Any] | None = None,
         payload_codec: PayloadCodec | None = None,
+        data_converter: DataConverter | None = None,
     ) -> "TemporalACP":
         logger.info("Initializing TemporalACP instance")
 
         # Create instance without temporal client initially
         temporal_acp = cls(
-            temporal_address=temporal_address, plugins=plugins, interceptors=interceptors, payload_codec=payload_codec
+            temporal_address=temporal_address,
+            plugins=plugins,
+            interceptors=interceptors,
+            payload_codec=payload_codec,
+            data_converter=data_converter,
         )
         temporal_acp._setup_handlers()
         logger.info("TemporalACP instance initialized now")
@@ -71,7 +78,10 @@ class TemporalACP(BaseACPServer):
             if self._temporal_task_service is None:
                 env_vars = EnvironmentVariables.refresh()
                 temporal_client = await TemporalClient.create(
-                    temporal_address=self._temporal_address, plugins=self._plugins, payload_codec=self._payload_codec
+                    temporal_address=self._temporal_address,
+                    plugins=self._plugins,
+                    payload_codec=self._payload_codec,
+                    data_converter=self._data_converter,
                 )
                 self._temporal_task_service = TemporalTaskService(
                     temporal_client=temporal_client,

--- a/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
+++ b/src/agentex/lib/sdk/fastacp/impl/temporal_acp.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, AsyncGenerator, override
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from temporalio.converter import DataConverter, PayloadCodec
+from temporalio.converter import PayloadCodec, DataConverter
 
 from agentex.protocol.acp import (
     SendEventParams,

--- a/src/agentex/lib/types/fastacp.py
+++ b/src/agentex/lib/types/fastacp.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import Field, BaseModel, field_validator
+from pydantic import Field, BaseModel, field_validator, model_validator
 
 from agentex.lib.core.clients.temporal.utils import validate_client_plugins, validate_worker_interceptors
 
@@ -88,6 +88,16 @@ class TemporalACPConfig(AsyncACPConfig):
         """Validate that all interceptors are valid Temporal worker interceptors."""
         validate_worker_interceptors(v)
         return v
+
+    @model_validator(mode="after")
+    def _validate_codec_and_data_converter_mutually_exclusive(self) -> "TemporalACPConfig":
+        if self.payload_codec is not None and self.data_converter is not None:
+            raise ValueError(
+                "Pass payload_codec inside `data_converter` "
+                "(DataConverter(..., payload_codec=...)) instead of as a separate "
+                "field. Specifying both is ambiguous."
+            )
+        return self
 
 
 class AsyncBaseACPConfig(AsyncACPConfig):

--- a/src/agentex/lib/types/fastacp.py
+++ b/src/agentex/lib/types/fastacp.py
@@ -56,7 +56,16 @@ class TemporalACPConfig(AsyncACPConfig):
             encoding/decoding payloads (e.g. encryption, compression). NOTE:
             this only configures the ACP (client) side. The worker side must
             be configured separately via ``AgentexWorker(payload_codec=...)``
-            with the SAME codec, or decode will fail at runtime.
+            with the SAME codec, or decode will fail at runtime. Cannot be
+            combined with ``OpenAIAgentsPlugin``; use ``data_converter``
+            instead in that case.
+        data_converter: Optional pre-built ``temporalio.converter.DataConverter``.
+            Use this when composing the ``OpenAIAgentsPlugin`` with a payload
+            codec: build a ``DataConverter(payload_converter_class=
+            OpenAIPayloadConverter, payload_codec=...)`` and pass it here.
+            Mutually exclusive with ``payload_codec``. The worker side must
+            be configured separately via ``AgentexWorker(data_converter=...)``
+            with the SAME converter, or decode will fail at runtime.
     """
 
     type: Literal["temporal"] = Field(default="temporal", frozen=True)
@@ -64,6 +73,7 @@ class TemporalACPConfig(AsyncACPConfig):
     plugins: list[Any] = Field(default=[], frozen=True)
     interceptors: list[Any] = Field(default=[], frozen=True)
     payload_codec: Any = Field(default=None, frozen=True)
+    data_converter: Any = Field(default=None, frozen=True)
 
     @field_validator("plugins")
     @classmethod

--- a/tests/lib/test_payload_codec.py
+++ b/tests/lib/test_payload_codec.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from temporalio.client import Client, Plugin as ClientPlugin
-from temporalio.converter import PayloadCodec
+from temporalio.converter import (
+    DataConverter,
+    PayloadCodec,
+    DefaultPayloadConverter,
+)
 from temporalio.contrib.pydantic import pydantic_data_converter
 
 
@@ -68,6 +72,28 @@ class TestTemporalClient:
         mock_get.assert_awaited_once()
         assert mock_get.await_args.kwargs["payload_codec"] is codec
 
+    def test_init_stores_data_converter(self):
+        from agentex.lib.core.clients.temporal.temporal_client import TemporalClient
+
+        dc = DataConverter(payload_codec=_NoopCodec())
+        client = TemporalClient(data_converter=dc)
+        assert client._data_converter is dc
+
+    def test_init_default_data_converter_is_none(self):
+        from agentex.lib.core.clients.temporal.temporal_client import TemporalClient
+
+        assert TemporalClient()._data_converter is None
+
+    async def test_create_propagates_data_converter_to_get_temporal_client(self):
+        import agentex.lib.core.clients.temporal.temporal_client as module
+
+        dc = DataConverter(payload_codec=_NoopCodec())
+        with patch.object(module, "get_temporal_client", new=AsyncMock(return_value=object())) as mock_get:
+            await module.TemporalClient.create(temporal_address="localhost:7233", plugins=[], data_converter=dc)
+
+        mock_get.assert_awaited_once()
+        assert mock_get.await_args.kwargs["data_converter"] is dc
+
 
 class TestGetTemporalClientUtils:
     async def test_no_codec_uses_pydantic_data_converter_unchanged(self):
@@ -96,7 +122,7 @@ class TestGetTemporalClientUtils:
 
         codec = _NoopCodec()
         with _patch_openai_plugin(), _mock_connect() as mock_connect:
-            with pytest.raises(ValueError, match="payload_codec is not supported alongside OpenAIAgentsPlugin"):
+            with pytest.raises(ValueError, match="silently dropped by the plugin's data-converter transformer"):
                 await get_temporal_client(
                     temporal_address="localhost:7233",
                     plugins=[_FakeOpenAIPlugin()],
@@ -111,6 +137,42 @@ class TestGetTemporalClientUtils:
             await get_temporal_client(temporal_address="localhost:7233", plugins=[_FakeOpenAIPlugin()])
 
         assert "data_converter" not in mock_connect.await_args.kwargs
+
+    async def test_data_converter_passthrough_with_openai_plugin(self):
+        from agentex.lib.core.clients.temporal.utils import get_temporal_client
+
+        dc = DataConverter(payload_codec=_NoopCodec())
+        with _patch_openai_plugin(), _mock_connect() as mock_connect:
+            await get_temporal_client(
+                temporal_address="localhost:7233",
+                plugins=[_FakeOpenAIPlugin()],
+                data_converter=dc,
+            )
+
+        assert mock_connect.await_args.kwargs["data_converter"] is dc
+
+    async def test_data_converter_passthrough_without_openai_plugin(self):
+        from agentex.lib.core.clients.temporal.utils import get_temporal_client
+
+        dc = DataConverter(payload_converter_class=DefaultPayloadConverter)
+        with _mock_connect() as mock_connect:
+            await get_temporal_client(temporal_address="localhost:7233", data_converter=dc)
+
+        assert mock_connect.await_args.kwargs["data_converter"] is dc
+
+    async def test_codec_and_data_converter_together_raises(self):
+        from agentex.lib.core.clients.temporal.utils import get_temporal_client
+
+        codec = _NoopCodec()
+        dc = DataConverter(payload_codec=codec)
+        with _mock_connect() as mock_connect:
+            with pytest.raises(ValueError, match="Pass payload_codec inside `data_converter`"):
+                await get_temporal_client(
+                    temporal_address="localhost:7233",
+                    payload_codec=codec,
+                    data_converter=dc,
+                )
+            mock_connect.assert_not_awaited()
 
 
 class TestGetTemporalClientWorker:
@@ -140,7 +202,7 @@ class TestGetTemporalClientWorker:
 
         codec = _NoopCodec()
         with _patch_openai_plugin(), _mock_connect() as mock_connect:
-            with pytest.raises(ValueError, match="payload_codec is not supported alongside OpenAIAgentsPlugin"):
+            with pytest.raises(ValueError, match="silently dropped by the plugin's data-converter transformer"):
                 await get_temporal_client(
                     temporal_address="localhost:7233",
                     plugins=[_FakeOpenAIPlugin()],
@@ -155,6 +217,42 @@ class TestGetTemporalClientWorker:
             await get_temporal_client(temporal_address="localhost:7233", plugins=[_FakeOpenAIPlugin()])
 
         assert "data_converter" not in mock_connect.await_args.kwargs
+
+    async def test_data_converter_passthrough_with_openai_plugin(self):
+        from agentex.lib.core.temporal.workers.worker import get_temporal_client
+
+        dc = DataConverter(payload_codec=_NoopCodec())
+        with _patch_openai_plugin(), _mock_connect() as mock_connect:
+            await get_temporal_client(
+                temporal_address="localhost:7233",
+                plugins=[_FakeOpenAIPlugin()],
+                data_converter=dc,
+            )
+
+        assert mock_connect.await_args.kwargs["data_converter"] is dc
+
+    async def test_data_converter_passthrough_without_openai_plugin(self):
+        from agentex.lib.core.temporal.workers.worker import get_temporal_client
+
+        dc = DataConverter(payload_converter_class=DefaultPayloadConverter)
+        with _mock_connect() as mock_connect:
+            await get_temporal_client(temporal_address="localhost:7233", data_converter=dc)
+
+        assert mock_connect.await_args.kwargs["data_converter"] is dc
+
+    async def test_codec_and_data_converter_together_raises(self):
+        from agentex.lib.core.temporal.workers.worker import get_temporal_client
+
+        codec = _NoopCodec()
+        dc = DataConverter(payload_codec=codec)
+        with _mock_connect() as mock_connect:
+            with pytest.raises(ValueError, match="Pass payload_codec inside `data_converter`"):
+                await get_temporal_client(
+                    temporal_address="localhost:7233",
+                    payload_codec=codec,
+                    data_converter=dc,
+                )
+            mock_connect.assert_not_awaited()
 
 
 class TestAgentexWorkerCodec:
@@ -171,6 +269,19 @@ class TestAgentexWorkerCodec:
         worker = AgentexWorker(task_queue="test-queue", health_check_port=80)
         assert worker.payload_codec is None
 
+    def test_worker_stores_data_converter(self):
+        from agentex.lib.core.temporal.workers.worker import AgentexWorker
+
+        dc = DataConverter(payload_codec=_NoopCodec())
+        worker = AgentexWorker(task_queue="test-queue", health_check_port=80, data_converter=dc)
+        assert worker.data_converter is dc
+
+    def test_worker_default_data_converter_is_none(self):
+        from agentex.lib.core.temporal.workers.worker import AgentexWorker
+
+        worker = AgentexWorker(task_queue="test-queue", health_check_port=80)
+        assert worker.data_converter is None
+
 
 class TestTemporalACPCodec:
     def test_create_stores_payload_codec(self):
@@ -185,6 +296,19 @@ class TestTemporalACPCodec:
 
         acp = TemporalACP.create(temporal_address="localhost:7233")
         assert acp._payload_codec is None
+
+    def test_create_stores_data_converter(self):
+        from agentex.lib.sdk.fastacp.impl.temporal_acp import TemporalACP
+
+        dc = DataConverter(payload_codec=_NoopCodec())
+        acp = TemporalACP.create(temporal_address="localhost:7233", data_converter=dc)
+        assert acp._data_converter is dc
+
+    def test_create_default_data_converter_is_none(self):
+        from agentex.lib.sdk.fastacp.impl.temporal_acp import TemporalACP
+
+        acp = TemporalACP.create(temporal_address="localhost:7233")
+        assert acp._data_converter is None
 
 
 class TestFastACPConfigCodec:
@@ -218,3 +342,34 @@ class TestFastACPConfigCodec:
             FastACP.create("async", config=config)
 
         assert captured.get("payload_codec") is codec
+
+    def test_config_default_data_converter_is_none(self):
+        from agentex.lib.types.fastacp import TemporalACPConfig
+
+        assert TemporalACPConfig().data_converter is None
+
+    def test_config_accepts_data_converter(self):
+        from agentex.lib.types.fastacp import TemporalACPConfig
+
+        dc = DataConverter(payload_codec=_NoopCodec())
+        assert TemporalACPConfig(data_converter=dc).data_converter is dc
+
+    def test_fastacp_forwards_data_converter_from_config(self):
+        from agentex.lib.types.fastacp import TemporalACPConfig
+        from agentex.lib.sdk.fastacp.fastacp import FastACP
+
+        dc = DataConverter(payload_codec=_NoopCodec())
+        config = TemporalACPConfig(data_converter=dc)
+        captured: dict[str, Any] = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+        with patch(
+            "agentex.lib.sdk.fastacp.impl.temporal_acp.TemporalACP.create",
+            side_effect=fake_create,
+        ):
+            FastACP.create("async", config=config)
+
+        assert captured.get("data_converter") is dc

--- a/tests/lib/test_payload_codec.py
+++ b/tests/lib/test_payload_codec.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from temporalio.client import Client, Plugin as ClientPlugin
 from temporalio.converter import (
-    DataConverter,
     PayloadCodec,
+    DataConverter,
     DefaultPayloadConverter,
 )
 from temporalio.contrib.pydantic import pydantic_data_converter
@@ -353,6 +353,16 @@ class TestFastACPConfigCodec:
 
         dc = DataConverter(payload_codec=_NoopCodec())
         assert TemporalACPConfig(data_converter=dc).data_converter is dc
+
+    def test_config_rejects_codec_and_data_converter_together(self):
+        from pydantic import ValidationError
+
+        from agentex.lib.types.fastacp import TemporalACPConfig
+
+        codec = _NoopCodec()
+        dc = DataConverter(payload_codec=codec)
+        with pytest.raises(ValidationError, match="Pass payload_codec inside `data_converter`"):
+            TemporalACPConfig(payload_codec=codec, data_converter=dc)
 
     def test_fastacp_forwards_data_converter_from_config(self):
         from agentex.lib.types.fastacp import TemporalACPConfig


### PR DESCRIPTION
## Summary

Adds a `data_converter` kwarg to the AgentexWorker / TemporalClient / TemporalACP API surface so callers can compose `OpenAIAgentsPlugin` with a payload codec (e.g. AES-GCM at-rest encryption).

## Why

Today, passing `payload_codec=...` to `AgentexWorker(...)` together with `OpenAIAgentsPlugin` raises with a hard guard. That guard is correct for the API surface currently exposed: without it, the plugin's `_data_converter(None)` transformer builds a fresh `DataConverter` and the user's codec is silently dropped — payloads land in Temporal in plain text.

But the composition **does work** if you pre-build a `DataConverter` with both `payload_converter_class=OpenAIPayloadConverter` AND `payload_codec=...` and pass it via `Client.connect(data_converter=...)`. The plugin's transformer has a fourth branch that passes through any `DataConverter` whose payload converter is an `OpenAIPayloadConverter` instance (or subclass) unchanged. This PR exposes that working path through the agentex API.

The first downstream user is the Emu Deep Research agent, which needs both `OpenAIAgentsPlugin` (to dispatch model calls as `invoke_model_activity` under Temporal) and the shared `emu_shared.encryption.codec.get_payload_codec()` already used by OneEdge / FDD / VDR.

## What changed

**New `data_converter` kwarg** on:
- `agentex.lib.core.temporal.workers.worker.get_temporal_client` and `AgentexWorker.__init__` (worker side)
- `agentex.lib.core.clients.temporal.utils.get_temporal_client` (client side)
- `TemporalClient.__init__` / `TemporalClient.create`
- `TemporalACP.__init__` / `TemporalACP.create`
- `TemporalACPConfig` (forwarded by `FastACP.create_async_acp`)

**Guards** in both `get_temporal_client` implementations:
1. **Ambiguity** — `payload_codec` AND `data_converter` together raise `ValueError` (the codec belongs *inside* the data converter).
2. **Silent-drop guard refined** — fires only when `OpenAIAgentsPlugin` is present AND `payload_codec` is the standalone kwarg AND no `data_converter` was supplied. The error message now points callers at the working composition path (`DataConverter(payload_converter_class=OpenAIPayloadConverter, payload_codec=...)`).

**No behavior change for existing callers** — none currently pass `data_converter`.

## Usage

```python
from temporalio.converter import DataConverter
from temporalio.contrib.openai_agents import OpenAIAgentsPlugin, OpenAIPayloadConverter

worker = AgentexWorker(
    task_queue=...,
    plugins=[OpenAIAgentsPlugin(...)],
    data_converter=DataConverter(
        payload_converter_class=OpenAIPayloadConverter,
        payload_codec=my_aes_gcm_codec,
    ),
)
```

## Test plan

- [x] All 355 existing tests in `tests/lib/` pass
- [x] New tests added in `tests/lib/test_payload_codec.py` for both `get_temporal_client` paths:
  - `data_converter` pass-through with `OpenAIAgentsPlugin`
  - `data_converter` pass-through without plugin
  - `payload_codec` + `data_converter` together raises ambiguity error
  - Silent-drop guard error message references `data_converter`
- [x] New tests for `AgentexWorker`, `TemporalClient`, `TemporalACP`, `TemporalACPConfig`, `FastACP` storing/forwarding `data_converter`
- [x] Signature smoke check confirms `data_converter` appears on all five public surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes a `data_converter` kwarg across the full Agentex worker/client API surface (`AgentexWorker`, `TemporalClient`, `TemporalACP`, `TemporalACPConfig`, `FastACP`) so callers can compose `OpenAIAgentsPlugin` with an encryption codec by pre-building a `DataConverter(payload_converter_class=OpenAIPayloadConverter, payload_codec=...)` and passing it directly, bypassing the silent-drop guard that blocked this pattern before.

- **New `data_converter` parameter** added to all five public surfaces, forwarded through to `Client.connect`; the existing `payload_codec` standalone path is preserved unchanged.
- **Two mutual-exclusivity guards** added in both `get_temporal_client` implementations: one raising immediately if both `payload_codec` and `data_converter` are provided, and one refining the existing guard to fire only when `payload_codec` is the standalone kwarg with `OpenAIAgentsPlugin` present (not when `data_converter` is supplied).
- **`TemporalACPConfig` gains a `model_validator`** mirroring the runtime guard so misconfiguration is caught at Pydantic construction time; new tests cover all five surfaces.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive, all existing callers are unaffected, and the two new guards prevent the same silent-drop failure mode the original guard was added for.

All five public surfaces are updated consistently, the mutual-exclusivity guards fire before any connection attempt, and the TemporalACPConfig model validator catches misconfiguration at object construction time. The lazy-validation pattern in AgentexWorker and TemporalACP is deliberate and consistent with how interceptors are validated in the same classes. No existing behavior is changed for callers who don't pass data_converter.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/clients/temporal/utils.py | Adds data_converter param to get_temporal_client; two guards (ambiguity + OpenAI silent-drop) correctly gate the new path; pass-through branch and default pydantic path are mutually exclusive and correct. |
| src/agentex/lib/core/temporal/workers/worker.py | Mirrors the utils changes: data_converter stored on AgentexWorker and forwarded to the worker-side get_temporal_client; identical guard logic applied; Worker uses the client's data converter so no separate forwarding is needed. |
| src/agentex/lib/types/fastacp.py | Adds data_converter: Any field to TemporalACPConfig and a model_validator enforcing mutual exclusivity with payload_codec at Pydantic construction time — the only layer with eager validation in this PR. |
| src/agentex/lib/sdk/fastacp/impl/temporal_acp.py | Threads data_converter through TemporalACP.__init__, create, and into TemporalClient.create during lifespan; straightforward and consistent with the payload_codec pattern already present. |
| src/agentex/lib/core/clients/temporal/temporal_client.py | Stores data_converter in TemporalClient.__init__ and forwards it via both create() and _get_temporal_client(); the setup() path already delegates to _get_temporal_client so it inherits the forwarding correctly. |
| src/agentex/lib/sdk/fastacp/fastacp.py | Adds one hasattr forwarding block for data_converter in create_async_acp, consistent with the existing pattern for payload_codec and other temporal-specific fields. |
| tests/lib/test_payload_codec.py | Well-structured new tests covering pass-through with and without OpenAI plugin, ambiguity error, and forwarding through all five public surfaces; tests mock Client.connect appropriately for the unit-test scope. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant AgentexWorker / TemporalACP / TemporalClient
    participant get_temporal_client
    participant Client.connect

    Caller->>AgentexWorker / TemporalACP / TemporalClient: __init__(data_converter=dc)
    Note over AgentexWorker / TemporalACP / TemporalClient: stores data_converter, no early validation

    Caller->>AgentexWorker / TemporalACP / TemporalClient: run() / lifespan / create()
    AgentexWorker / TemporalACP / TemporalClient->>get_temporal_client: (plugins, payload_codec, data_converter)

    alt "payload_codec != None AND data_converter != None"
        get_temporal_client-->>Caller: ValueError (ambiguous)
    else "OpenAIAgentsPlugin + payload_codec != None AND data_converter == None"
        get_temporal_client-->>Caller: ValueError (silent-drop guard)
    else "data_converter != None"
        get_temporal_client->>Client.connect: "data_converter=dc (pass-through)"
    else not has_openai_plugin
        get_temporal_client->>Client.connect: "data_converter=pydantic/custom (optionally +payload_codec)"
    else OpenAIAgentsPlugin, no codec
        get_temporal_client->>Client.connect: (no data_converter — plugin sets its own)
    end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(lib): tighten TemporalACPConfig + co..."](https://github.com/scaleapi/scale-agentex-python/commit/0f4733ee2a39ba670f4d5bd3dd2cc38a1c1c048f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34191171)</sub>

<!-- /greptile_comment -->