### PR TITLE
feat: bump openai-agents to 0.14.3 + add local-sandbox OpenAI Agents SDK tutorial

### DIFF
--- a/examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/tests/test_agent.py
+++ b/examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/tests/test_agent.py
@@ -1,3 +1,4 @@
+# ci: touch to re-run tutorial integration tests for the openai-agents>=0.14.3 bump
 """
 Sample tests for AgentEx ACP agent.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "jinja2>=3.1.3,<4",
     "mcp>=1.4.1",
     "scale-gp>=0.1.0a59",
-    "openai-agents==0.14.1",
+    "openai-agents>=0.14.3,<0.15",
     "pydantic-ai-slim>=1.0,<2",
     "json_log_formatter>=1.1.1",
     "scale-gp-beta>=0.2.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -237,7 +237,7 @@ openai==2.30.0
     # via agentex-sdk
     # via litellm
     # via openai-agents
-openai-agents==0.14.1
+openai-agents==0.14.8
     # via agentex-sdk
 opentelemetry-api==1.40.0
     # via agentex-sdk

--- a/requirements.lock
+++ b/requirements.lock
@@ -215,7 +215,7 @@ openai==2.30.0
     # via agentex-sdk
     # via litellm
     # via openai-agents
-openai-agents==0.14.1
+openai-agents==0.14.8
     # via agentex-sdk
 opentelemetry-api==1.40.0
     # via agentex-sdk

--- a/uv.lock
+++ b/uv.lock
@@ -97,7 +97,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.83.7,<2" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.4.1" },
     { name = "openai", specifier = ">=2.2,<3" },
-    { name = "openai-agents", specifier = "==0.14.1" },
+    { name = "openai-agents", specifier = ">=0.14.3,<0.15" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
@@ -1561,7 +1561,7 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.14.1"
+version = "0.14.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
@@ -1573,9 +1573,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/ae/8af117a3a4a06ad72b4a60759fbab98a7158f0eb36c47d90d5d883610781/openai_agents-0.14.1.tar.gz", hash = "sha256:7baac1b4c0a171d32c82eb6e9c207fd010e0d08dd39a5e8cd762ee27969457dc", size = 5256058, upload-time = "2026-04-15T19:26:52.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8a/d36ab647f05e790ec97dda9e4c0eb39d8840269d6a5194887b5dec92bd0d/openai_agents-0.14.8.tar.gz", hash = "sha256:fe1cb58b4150a07292a94f15d8fd5217ee9195bd6bcd8a6a46fdb1d9b08a70b7", size = 5314520, upload-time = "2026-04-29T03:40:07.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/1c/98efddc1e10b23a397ca901b6f6d251908be2e6a30a92e0c25fb5dff6348/openai_agents-0.14.1-py3-none-any.whl", hash = "sha256:09ea6e9c49c785dc490e071e17ea3a0b0cce9c5f97daeb50ee6dc8fb490dc817", size = 797518, upload-time = "2026-04-15T19:26:50.106Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6e/1e9adcedcde7b163579b88a68f765a4915be4ead0713270386d9432cfd2f/openai_agents-0.14.8-py3-none-any.whl", hash = "sha256:2937ef582ccaa45d59e89839ed8948cb2a6d808bc9940f0881793c21f37f7776", size = 817332, upload-time = "2026-04-29T03:40:05.68Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Bump `openai-agents` from the hard pin `==0.14.1` to `>=0.14.3,<0.15` (locks resolve to 0.14.8).

## Why
The new **scale-sandbox `oai_agents` adapter** — `ScaleSandboxClient`, which implements the OpenAI Agents SDK `BaseSandboxClient` protocol so an `Agent`/`SandboxAgent` can run inside a real ARP (Scale) sandbox — imports symbols that **only exist in openai-agents >= 0.14.3**:

- `agents.sandbox.workspace_paths.sandbox_path_str`, `posix_path_for_error`
- `agents.sandbox.errors.ExecNonZeroError`, `PtySessionNotFoundError`

The adapter's `_imports.py` wraps all of its `agents.sandbox.*` imports in a single `try/except ImportError`. On `0.14.1` that block fails (missing symbols above) and **every** name falls back to `None`, so `class ScaleSandboxClientOptions(BaseSandboxClientOptions)` raises `TypeError: NoneType takes no arguments` at import time. Verified locally: adapter import fails on 0.14.1, imports + instantiates cleanly on 0.14.3.

This unblocks a new pubsec-dev agent that runs the **OpenAI Agents SDK inside Temporal** (via the standard `OpenAIAgentsPlugin` + `temporalio.contrib.openai_agents.SandboxClientProvider`) with **ARP sandboxes** as the execution environment.

## Scope
- `pyproject.toml`: the one pin.
- `requirements.lock` / `requirements-dev.lock`: `openai-agents==0.14.1 → 0.14.8`.
- `uv.lock`: `openai-agents` 0.14.1→0.14.8; also re-sync corrected pre-existing drift already present on `next` (workspace version, `scale-gp-beta` specifier) so the lock matches `pyproject`.

Base (non-extra) transitive deps are **identical** between 0.14.1 and 0.14.3 (diffs are confined to unused extras: `mongodb`, and the `temporal` extra's temporalio bump), so this is a low-risk bump.

## Release
Needs a release cut (Stainless version bump) before the downstream agent's image build can install it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `openai-agents` from the hard-pinned `==0.14.1` to `>=0.14.3,<0.15` (resolving to `0.14.8` in lock files) to unblock the `ScaleSandboxClient` adapter, which imports symbols (`sandbox_path_str`, `ExecNonZeroError`, `PtySessionNotFoundError`) that only exist in `>=0.14.3`.

- **`pyproject.toml`**: Relaxes the pin from `==0.14.1` to `>=0.14.3,<0.15`; all three lock files (`requirements.lock`, `requirements-dev.lock`, `uv.lock`) are consistently updated to `0.14.8`.
- **`uv.lock`**: Base transitive dependencies for `openai-agents` are unchanged between 0.14.1 and 0.14.8 (same set: `griffelib`, `openai`, `opentelemetry-api`, `pydantic`, `requests`, `typing-extensions`, `websockets`), confirming the low-risk characterization.
- **Test file**: A single comment line was added to trigger re-execution of the tutorial integration tests against the new version.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a targeted dependency version bump with no changes to application logic.

The only substantive change is relaxing the openai-agents pin from ==0.14.1 to >=0.14.3,<0.15, resolving to 0.14.8. All three lock files are consistently updated, the base transitive dependency set is identical between 0.14.1 and 0.14.8, and the upper bound <0.15 prevents unintentional major-version drift. The test file touch is comment-only.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Single-line change relaxing the openai-agents pin from ==0.14.1 to >=0.14.3,<0.15; upper bound and lower bound are both appropriate. |
| uv.lock | Lock entry updated to 0.14.8 with correct hashes and matching base transitive dependency set (identical to 0.14.1). |
| requirements.lock | Single-line version bump from 0.14.1 to 0.14.8, consistent with uv.lock and pyproject.toml. |
| requirements-dev.lock | Single-line version bump from 0.14.1 to 0.14.8, consistent with requirements.lock. |
| examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/tests/test_agent.py | Comment-only touch to force CI re-run of the tutorial integration tests against the new openai-agents version. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pyproject.toml\nopenai-agents >=0.14.3,<0.15] --> B[uv.lock resolves to 0.14.8]
    A --> C[requirements.lock → 0.14.8]
    A --> D[requirements-dev.lock → 0.14.8]

    B --> E{Base transitive deps\n0.14.1 vs 0.14.8}
    E -->|Identical| F[griffelib, openai, pydantic\nopentelemetry-api, requests\ntyping-extensions, websockets]

    G[ScaleSandboxClient adapter\n_imports.py] -->|Requires >=0.14.3| H[agents.sandbox.workspace_paths\nsandbox_path_str, posix_path_for_error]
    G -->|Requires >=0.14.3| I[agents.sandbox.errors\nExecNonZeroError, PtySessionNotFoundError]

    H --> J[Import succeeds on 0.14.8 ✓]
    I --> J
    F --> J
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): touch 060 openai-agents tutori..."](https://github.com/scaleapi/scale-agentex-python/commit/a7cf4c73ab61eb71a9d65fa65b37426b9f300696) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34510912)</sub>

<!-- /greptile_comment -->