### PR TITLE
feat(openai-agents): stream tool-call argument deltas to the UI

### DIFF
--- a/src/agentex/lib/core/temporal/plugins/openai_agents/hooks/hooks.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/hooks/hooks.py
@@ -13,7 +13,7 @@ from temporalio import workflow
 from agents.tool_context import ToolContext
 
 from agentex.types.text_content import TextContent
-from agentex.types.task_message_content import ToolRequestContent, ToolResponseContent
+from agentex.types.task_message_content import ToolResponseContent
 from agentex.lib.core.observability.llm_metrics_hooks import LLMMetricsHooks
 from agentex.lib.core.temporal.plugins.openai_agents.hooks.activities import stream_lifecycle_content
 
@@ -106,44 +106,25 @@ class TemporalStreamingHooks(LLMMetricsHooks):
 
     @override
     async def on_tool_start(self, context: RunContextWrapper, agent: Agent, tool: Tool) -> None:  # noqa: ARG002
-        """Stream tool request when a tool starts execution.
+        """Called when a tool starts execution.
 
-        Extracts the tool_call_id and tool_arguments from the context and streams a
-        ToolRequestContent message to the UI showing that the tool is about to execute.
+        The tool request (ToolRequestContent) is now streamed live by the model
+        layer (TemporalStreamingModel) as the function-call arguments arrive over
+        the Responses API stream. Emitting it again here would double-render the
+        tool request in the UI, so this hook no longer streams a ToolRequestContent.
+        The tool *result* is still streamed by on_tool_end (ToolResponseContent),
+        which the model stream does not produce.
 
         Args:
             context: The run context wrapper (will be a ToolContext with tool_call_id and tool_arguments)
             agent: The agent executing the tool
             tool: The tool being executed
         """
-        import json
-
         tool_context = context if isinstance(context, ToolContext) else None
         tool_call_id = tool_context.tool_call_id if tool_context else f"call_{id(tool)}"
-
-        # Extract tool arguments from context
-        tool_arguments = {}
-        if tool_context and hasattr(tool_context, 'tool_arguments'):
-            try:
-                # tool_arguments is a JSON string, parse it
-                tool_arguments = json.loads(tool_context.tool_arguments)
-            except (json.JSONDecodeError, TypeError):
-                # If parsing fails, log and use empty dict
-                logger.warning(f"Failed to parse tool arguments: {tool_context.tool_arguments}")
-                tool_arguments = {}
-
-        await workflow.execute_activity(
-            stream_lifecycle_content,
-            args=[
-                self.task_id,
-                ToolRequestContent(
-                    author="agent",
-                    tool_call_id=tool_call_id,
-                    name=tool.name,
-                    arguments=tool_arguments,
-                ).model_dump(),
-            ],
-            start_to_close_timeout=self.timeout,
+        logger.debug(
+            f"[TemporalStreamingHooks] Tool '{tool.name}' started (tool_call_id={tool_call_id}); "
+            "tool request is streamed live by the model layer, not re-emitted here."
         )
 
     @override

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
@@ -64,8 +64,10 @@ from agentex.lib import adk
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.core.tracing.tracer import AsyncTracer
 from agentex.types.task_message_delta import TextDelta, ReasoningContentDelta, ReasoningSummaryDelta
+from agentex.types.tool_request_delta import ToolRequestDelta
 from agentex.types.task_message_update import StreamTaskMessageFull, StreamTaskMessageDelta
 from agentex.types.task_message_content import TextContent, ReasoningContent
+from agentex.types.tool_request_content import ToolRequestContent
 from agentex.lib.adk.utils._modules.client import create_async_agentex_client
 from agentex.lib.core.temporal.plugins.openai_agents.interceptors.context_interceptor import (
     streaming_task_id,
@@ -671,6 +673,7 @@ class TemporalStreamingModel(Model):
 
                 # Process events from the Responses API stream
                 function_calls_in_progress = {}  # Track function calls being streamed
+                tool_call_contexts: dict[int, Any] = {}  # Open streaming contexts per function call
 
                 async for event in stream:
                     event_count += 1
@@ -723,13 +726,28 @@ class TemporalStreamingModel(Model):
                                 ).__aenter__()
                         elif item and getattr(item, 'type', None) == 'function_call':
                             # Track the function call being streamed
+                            call_id = getattr(item, 'call_id', '')
+                            name = getattr(item, 'name', '')
                             function_calls_in_progress[output_index] = {
                                 'id': getattr(item, 'id', ''),
-                                'call_id': getattr(item, 'call_id', ''),
-                                'name': getattr(item, 'name', ''),
+                                'call_id': call_id,
+                                'name': name,
                                 'arguments': getattr(item, 'arguments', ''),
                             }
                             logger.debug(f"[TemporalStreamingModel] Starting function call: {item.name}")
+
+                            # Open a streaming context so tool-call args stream live to the UI
+                            tool_ctx = await adk.streaming.streaming_task_message_context(
+                                task_id=task_id,
+                                initial_content=ToolRequestContent(
+                                    author="agent",
+                                    tool_call_id=call_id,
+                                    name=name,
+                                    arguments={},
+                                ),
+                                streaming_mode=self.streaming_mode,
+                            ).__aenter__()
+                            tool_call_contexts[output_index] = tool_ctx
 
                         elif item and getattr(item, 'type', None) == 'message':
                             # Track the message being streamed
@@ -751,6 +769,25 @@ class TemporalStreamingModel(Model):
                         if output_index in function_calls_in_progress:
                             function_calls_in_progress[output_index]['arguments'] += delta
                             logger.debug(f"[TemporalStreamingModel] Function call args delta: {delta[:50]}...")
+
+                            # Stream the args delta live to the UI. The delta event carries
+                            # no call_id/name, so pull them from function_calls_in_progress
+                            # (populated at announce time, keyed by output_index).
+                            ctx = tool_call_contexts.get(output_index)
+                            if ctx is not None and delta:
+                                try:
+                                    await ctx.stream_update(StreamTaskMessageDelta(
+                                        parent_task_message=ctx.task_message,
+                                        delta=ToolRequestDelta(
+                                            type="tool_request",
+                                            tool_call_id=function_calls_in_progress[output_index]['call_id'],
+                                            name=function_calls_in_progress[output_index]['name'],
+                                            arguments_delta=delta,
+                                        ),
+                                        type="delta",
+                                    ))
+                                except Exception as e:
+                                    logger.warning(f"Failed to stream tool-call args delta: {e}")
 
                     elif isinstance(event, ResponseFunctionCallArgumentsDoneEvent):
                         # Function call arguments complete
@@ -874,6 +911,14 @@ class TemporalStreamingModel(Model):
                                 )
                                 output_items.append(tool_call)
 
+                            # Close + pop the live-streaming context for this tool call
+                            ctx = tool_call_contexts.pop(output_index, None)
+                            if ctx is not None:
+                                try:
+                                    await ctx.close()
+                                except Exception as e:
+                                    logger.warning(f"Failed to close tool-call stream context: {e}")
+
                     elif isinstance(event, ResponseReasoningSummaryPartAddedEvent):
                         # New reasoning part/summary started - reset accumulator
                         part = getattr(event, 'part', None)
@@ -906,6 +951,16 @@ class TemporalStreamingModel(Model):
                 if streaming_context:
                     await streaming_context.close()
                     streaming_context = None
+
+                # Close any tool-call contexts still open (e.g. stream ended without
+                # a per-item done event). A partial / invalid-JSON args close can
+                # raise, so guard each one so it never crashes the activity.
+                for ctx in tool_call_contexts.values():
+                    try:
+                        await ctx.close()
+                    except Exception as e:
+                        logger.warning(f"Failed to close tool-call stream context: {e}")
+                tool_call_contexts.clear()
 
                 # Build the response from output items collected during streaming
                 # Create output from the items we collected
@@ -1061,6 +1116,17 @@ class TemporalStreamingModel(Model):
 
             except Exception as e:
                 logger.error(f"Error using Responses API: {e}")
+                # Close any tool-call streaming contexts still open so the error
+                # path doesn't leak open contexts. A partial / invalid-JSON args
+                # close can raise, so guard each one. tool_call_contexts may be
+                # unbound if the error fired before the stream loop started.
+                for ctx in locals().get("tool_call_contexts", {}).values():
+                    try:
+                        await ctx.close()
+                    except Exception as close_err:
+                        logger.warning(f"Failed to close tool-call stream context: {close_err}")
+                if "tool_call_contexts" in locals():
+                    tool_call_contexts.clear()
                 # LLMMetricsHooks.on_llm_end doesn't fire on error, so emit the
                 # failure counter here. Best-effort so the typed LLM exception
                 # always propagates intact for retry / circuit-breaker logic.


### PR DESCRIPTION
## What
Stream OpenAI Agents SDK **tool-call arguments live** as the model generates them, so the UI shows the tool name + arguments building incrementally instead of appearing all-at-once.

## Why / finding
`TemporalStreamingModel.get_response` already *parsed* the Responses API `response.function_call_arguments.delta` events but only accumulated them — tool calls only surfaced later (all-at-once) via the hooks layer. This wires the deltas into the same agentex streaming path the text deltas already use.

## Change
`models/temporal_streaming_model.py`:
- On a `function_call` item announce (`ResponseOutputItemAddedEvent`): open a `streaming_task_message_context` with an initial `ToolRequestContent` (name + call_id, empty args), stashed per `output_index`.
- On each `ResponseFunctionCallArgumentsDeltaEvent`: push a `StreamTaskMessageDelta(ToolRequestDelta(arguments_delta=...))` (name/call_id pulled from the per-call record — the delta event carries neither).
- On item-done / end-of-loop / error: close the per-call contexts (guarded so a partial-JSON close can't crash the activity).

`hooks/hooks.py`:
- `on_tool_start` no longer emits a duplicate `ToolRequestContent` (the model layer now streams it live — emitting again would double-render). `on_tool_end`'s `ToolResponseContent` (the result) is unchanged.

## Invariant
The returned `ModelResponse` / `output_items` / usage / response_id assembly is untouched — streaming is a side-effect only.

## Validation
Existing plugin tests pass (`test_streaming_model.py` + `test_convert_tools.py`: 43 passed); ruff clean; modules import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires tool-call argument deltas from the OpenAI Responses API stream directly to the UI, so the tool name and arguments build incrementally instead of appearing all at once. It also removes the now-redundant `ToolRequestContent` emission from the `on_tool_start` hook to avoid double-rendering.

- **`temporal_streaming_model.py`**: On a `function_call` `ResponseOutputItemAddedEvent`, a `streaming_task_message_context` is opened with an initial `ToolRequestContent(arguments={})` and stored in a new `tool_call_contexts` dict keyed by `output_index`. Each `ResponseFunctionCallArgumentsDeltaEvent` pushes a `ToolRequestDelta` through that context, and `ResponseOutputItemDoneEvent` (or post-loop/exception-path cleanup) closes it.
- **`hooks/hooks.py`**: `on_tool_start` no longer calls `stream_lifecycle_content` with a `ToolRequestContent`; it now only emits a debug log. `on_tool_end` is unchanged.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The streaming side-effect is well-guarded and does not touch the ModelResponse assembly path, making the core output unchanged and the risk of regression low.

The new tool-call streaming follows the established text/reasoning context pattern closely, cleanup is handled in three places (item-done, post-loop, error path), and the on_tool_start hook removal is correct. The only rough edge is the locals() dance in the exception handler, which is functional but harder to maintain than initializing the dict before the try block.

temporal_streaming_model.py exception handler (lines 1123–1129) — the locals() pattern should be reviewed, but it does not affect correctness.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py | Adds live streaming of tool-call argument deltas by opening a streaming_task_message_context per function call and pushing ToolRequestDelta updates; contexts are closed in ResponseOutputItemDoneEvent, post-loop cleanup, and an exception handler that uses locals() to guard against early-throw scenarios. |
| src/agentex/lib/core/temporal/plugins/openai_agents/hooks/hooks.py | Removes the ToolRequestContent emission from on_tool_start (now handled by the model layer) and replaces the activity call with a debug log; on_tool_end's ToolResponseContent emission is untouched. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant OAI as OpenAI Responses API
    participant TSM as TemporalStreamingModel
    participant Ctx as streaming_task_message_context
    participant UI as Agentex UI
    participant Hook as TemporalStreamingHooks

    OAI->>TSM: ResponseOutputItemAddedEvent (function_call)
    TSM->>Ctx: "__aenter__() with ToolRequestContent(arguments={})"
    Ctx->>UI: "initial ToolRequestContent streamed"

    loop For each argument delta
        OAI->>TSM: ResponseFunctionCallArgumentsDeltaEvent(delta)
        TSM->>Ctx: "stream_update(StreamTaskMessageDelta(ToolRequestDelta))"
        Ctx->>UI: incremental argument delta
    end

    OAI->>TSM: ResponseFunctionCallArgumentsDoneEvent
    OAI->>TSM: ResponseOutputItemDoneEvent (function_call)
    TSM->>Ctx: close()

    Note over Hook: on_tool_start() only logs now
    Note over Hook: no longer emits ToolRequestContent

    Hook->>UI: "on_tool_end: stream_lifecycle_content(ToolResponseContent)"
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Fmodels%2Ftemporal_streaming_model.py%3A1123-1129%0A**%60locals%28%29%60%20cleanup%20is%20fragile%20and%20redundant%20with%20the%20inline%20init**%0A%0A%60tool_call_contexts%60%20is%20initialized%20unconditionally%20at%20line%20676%20inside%20the%20same%20%60try%60%20block%2C%20so%20by%20the%20time%20any%20exception%20is%20raised%20*during%20streaming*%20it%20is%20always%20in%20scope.%20The%20only%20scenario%20where%20it%20is%20absent%20is%20an%20exception%20thrown%20before%20line%20676%20%28e.g.%2C%20during%20%60responses.create%28%29%60%29%2C%20in%20which%20case%20the%20dict%20is%20empty%20anyway%20and%20no%20cleanup%20is%20needed.%20Moving%20%60tool_call_contexts%3A%20dict%5Bint%2C%20Any%5D%20%3D%20%7B%7D%60%20to%20just%20before%20the%20%60try%60%20at%20line%20541%20%E2%80%94%20alongside%20%60streaming_context%20%3D%20None%60%20%2F%20%60reasoning_context%20%3D%20None%60%20%E2%80%94%20would%20let%20the%20error%20handler%20use%20the%20variable%20directly%20%28%60for%20ctx%20in%20tool_call_contexts.values%28%29%3A%60%20and%20%60tool_call_contexts.clear%28%29%60%29%20and%20removes%20the%20two%20%60locals%28%29%60%20calls%20entirely.%0A%0A&pr=378&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Fmodels%2Ftemporal_streaming_model.py%3A1123-1129%0A**%60locals%28%29%60%20cleanup%20is%20fragile%20and%20redundant%20with%20the%20inline%20init**%0A%0A%60tool_call_contexts%60%20is%20initialized%20unconditionally%20at%20line%20676%20inside%20the%20same%20%60try%60%20block%2C%20so%20by%20the%20time%20any%20exception%20is%20raised%20*during%20streaming*%20it%20is%20always%20in%20scope.%20The%20only%20scenario%20where%20it%20is%20absent%20is%20an%20exception%20thrown%20before%20line%20676%20%28e.g.%2C%20during%20%60responses.create%28%29%60%29%2C%20in%20which%20case%20the%20dict%20is%20empty%20anyway%20and%20no%20cleanup%20is%20needed.%20Moving%20%60tool_call_contexts%3A%20dict%5Bint%2C%20Any%5D%20%3D%20%7B%7D%60%20to%20just%20before%20the%20%60try%60%20at%20line%20541%20%E2%80%94%20alongside%20%60streaming_context%20%3D%20None%60%20%2F%20%60reasoning_context%20%3D%20None%60%20%E2%80%94%20would%20let%20the%20error%20handler%20use%20the%20variable%20directly%20%28%60for%20ctx%20in%20tool_call_contexts.values%28%29%3A%60%20and%20%60tool_call_contexts.clear%28%29%60%29%20and%20removes%20the%20two%20%60locals%28%29%60%20calls%20entirely.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=378&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22dm%2Foai-tool-arg-delta-streaming%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dm%2Foai-tool-arg-delta-streaming%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Fmodels%2Ftemporal_streaming_model.py%3A1123-1129%0A**%60locals%28%29%60%20cleanup%20is%20fragile%20and%20redundant%20with%20the%20inline%20init**%0A%0A%60tool_call_contexts%60%20is%20initialized%20unconditionally%20at%20line%20676%20inside%20the%20same%20%60try%60%20block%2C%20so%20by%20the%20time%20any%20exception%20is%20raised%20*during%20streaming*%20it%20is%20always%20in%20scope.%20The%20only%20scenario%20where%20it%20is%20absent%20is%20an%20exception%20thrown%20before%20line%20676%20%28e.g.%2C%20during%20%60responses.create%28%29%60%29%2C%20in%20which%20case%20the%20dict%20is%20empty%20anyway%20and%20no%20cleanup%20is%20needed.%20Moving%20%60tool_call_contexts%3A%20dict%5Bint%2C%20Any%5D%20%3D%20%7B%7D%60%20to%20just%20before%20the%20%60try%60%20at%20line%20541%20%E2%80%94%20alongside%20%60streaming_context%20%3D%20None%60%20%2F%20%60reasoning_context%20%3D%20None%60%20%E2%80%94%20would%20let%20the%20error%20handler%20use%20the%20variable%20directly%20%28%60for%20ctx%20in%20tool_call_contexts.values%28%29%3A%60%20and%20%60tool_call_contexts.clear%28%29%60%29%20and%20removes%20the%20two%20%60locals%28%29%60%20calls%20entirely.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py:1123-1129
**`locals()` cleanup is fragile and redundant with the inline init**

`tool_call_contexts` is initialized unconditionally at line 676 inside the same `try` block, so by the time any exception is raised *during streaming* it is always in scope. The only scenario where it is absent is an exception thrown before line 676 (e.g., during `responses.create()`), in which case the dict is empty anyway and no cleanup is needed. Moving `tool_call_contexts: dict[int, Any] = {}` to just before the `try` at line 541 — alongside `streaming_context = None` / `reasoning_context = None` — would let the error handler use the variable directly (`for ctx in tool_call_contexts.values():` and `tool_call_contexts.clear()`) and removes the two `locals()` calls entirely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(openai-agents): stream tool-call ar..."](https://github.com/scaleapi/scale-agentex-python/commit/265515e63ed2656ffa514d3c328564679600eab6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34580540)</sub>

<!-- /greptile_comment -->