### PR TITLE
fix(tutorials): restore tutorial CI deps after agentex-sdk 0.11.5 (pytest + debugpy)

### DIFF
--- a/examples/tutorials/run_agent_test.sh
+++ b/examples/tutorials/run_agent_test.sh
@@ -259,8 +259,15 @@ run_test() {
     cd "$tutorial_path" || return 1
 
 
-    # Run the tests with retry mechanism
-    local -a pytest_cmd=("uv" "run" "pytest")
+    # Run the tests with retry mechanism.
+    #
+    # pytest is brought in explicitly via --with: the tutorials only list it
+    # under an optional `dev` extra (which `uv run` does not install), and it
+    # used to be pulled in transitively by agentex-sdk's runtime deps. Once
+    # agentex-sdk 0.11.5 dropped pytest as a runtime dep, `uv run pytest` could
+    # no longer find it ("Failed to spawn: pytest"). Requesting it directly is
+    # robust across all tutorials regardless of how each declares test deps.
+    local -a pytest_cmd=("uv" "run" "--with" "pytest" "--with" "pytest-asyncio" "pytest")
     if [ "$BUILD_CLI" = true ]; then
         local wheel_file
         wheel_file=$(ls /home/runner/work/*/*/dist/agentex_sdk-*.whl 2>/dev/null | head -n1)
@@ -268,7 +275,7 @@ run_test() {
             wheel_file=$(ls "${SCRIPT_DIR}/../../dist/agentex_sdk-*.whl" 2>/dev/null | head -n1)
         fi
         if [[ -n "$wheel_file" ]]; then
-            pytest_cmd=("uv" "run" "--with" "$wheel_file" "pytest")
+            pytest_cmd=("uv" "run" "--with" "$wheel_file" "--with" "pytest" "--with" "pytest-asyncio" "pytest")
         fi
     fi
 

--- a/src/agentex/lib/utils/debug.py
+++ b/src/agentex/lib/utils/debug.py
@@ -6,8 +6,6 @@ Provides debugging setup functionality that can be used across different compone
 
 import os
 
-import debugpy  # type: ignore
-
 from agentex.lib.utils.logging import make_logger
 
 logger = make_logger(__name__)
@@ -30,6 +28,13 @@ def setup_debug_if_enabled() -> None:
         Any exception from debugpy setup (will bubble up naturally)
     """
     if os.getenv("AGENTEX_DEBUG_ENABLED") == "true":
+        # Imported lazily: debugpy is a development-only tool, so a normal
+        # worker startup must not require it to be installed.  Importing it at
+        # module scope forced it onto every worker (it used to be satisfied
+        # transitively via ipykernel; that dep was dropped in agentex-sdk
+        # 0.11.5, surfacing this as "No module named 'debugpy'").
+        import debugpy  # type: ignore
+
         debug_port = int(os.getenv("AGENTEX_DEBUG_PORT", "5678"))
         debug_type = os.getenv("AGENTEX_DEBUG_TYPE", "worker")
         wait_for_attach = os.getenv("AGENTEX_DEBUG_WAIT_FOR_ATTACH", "false").lower() == "true"


### PR DESCRIPTION
## Summary

`agentex-sdk` **0.11.5** (published `2026-05-29T04:29:08Z`, release #369) correctly dropped a set of test/dev-only packages from its **runtime** dependencies (cleanup from #367). Two things in the tutorial CI were silently relying on those packages being pulled in transitively, so every "Test Tutorial Agents" job started failing the moment 0.11.5 hit PyPI — across `main` and every open PR, regardless of diff. This PR fixes both.

The tutorials depend on `agentex-sdk` **unpinned**, so they resolve to whatever PyPI serves latest.

### Fix 1 — pytest (all tutorials)

`run_agent_test.sh` runs `uv run pytest`, but pytest is only in each tutorial's optional `dev` extra (which `uv run` doesn't install). It used to come in transitively because `agentex-sdk` ≤0.11.4 listed `pytest`/`pytest-asyncio` as runtime deps. 0.11.5 dropped them → `error: Failed to spawn: pytest`.

Fix: request the test deps explicitly — `uv run --with pytest --with pytest-asyncio [--with <wheel>] pytest`. Robust across all tutorials regardless of how each declares test deps (one, `100_gemini_litellm`, has no `dev` extra, so a blanket `--extra dev` would break it).

### Fix 2 — debugpy (Temporal tutorials)

`src/agentex/lib/utils/debug.py` imported `debugpy` at **module scope**, so every Temporal worker (`run_worker.py` → `from agentex.lib.utils.debug import setup_debug_if_enabled`) required debugpy at startup. debugpy is a dev-only tool that was only ever satisfied transitively via `ipykernel` (an `agentex-sdk` ≤0.11.4 runtime dep, also dropped in 0.11.5). Result: workers crashed with `ModuleNotFoundError: No module named 'debugpy'` → "Timeout waiting for agent to be ready".

Fix: import `debugpy` lazily, inside the `AGENTEX_DEBUG_ENABLED` branch where it's actually used. Normal (non-debug) worker startup no longer needs it — this also fixes the same failure for real users running Temporal agents without debugpy installed.

Evidence (PyPI `requires_dist`):

| agentex-sdk | uploaded | pytest | ipykernel (→ debugpy) |
|---|---|---|---|
| 0.11.4 | 2026-05-26 20:11 | ✅ | ✅ |
| 0.11.5 | 2026-05-29 04:29 | ❌ | ❌ |

(Surfaced while investigating #374, whose own unit/lint/build checks pass.)

## Test plan

- [x] `bash -n run_agent_test.sh` — syntax valid
- [x] `ruff check` + `pyright` on `debug.py` — clean
- [x] Verified non-debug `setup_debug_if_enabled()` runs without debugpy importable
- [x] Fix 1 confirmed in CI: all `00_sync/*` and `10_async/00_base/*` tutorials now pass
- [ ] Fix 2: confirm the `10_async/10_temporal/*` jobs go green on this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related breakages caused by `agentex-sdk` 0.11.5 dropping `pytest` and `debugpy` from its runtime dependencies — correct cleanups that inadvertently removed transitive availability of those tools in consumers.

- **`run_agent_test.sh`**: Adds `--with pytest --with pytest-asyncio` to both `uv run` invocations, restoring pytest availability across all tutorials regardless of whether each individual tutorial declares it under an optional `dev` extra (one tutorial has no `dev` extra at all, so `--extra dev` wasn't viable).
- **`src/agentex/lib/utils/debug.py`**: Converts the top-level `import debugpy` to a lazy import inside the `AGENTEX_DEBUG_ENABLED == "true"` branch, so production workers no longer fail to start if `debugpy` is not installed.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are surgical, well-scoped fixes to a CI breakage and a missing lazy-import guard; neither touches any application logic.

The shell script change only adds explicit --with flags to uv run, restoring exactly what used to be provided transitively. The debug.py change narrows the import of a dev-only tool to the branch that actually needs it, which is strictly safer than the previous module-level import.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/tutorials/run_agent_test.sh | Adds `--with pytest --with pytest-asyncio` to both `uv run` invocations so pytest is always available regardless of whether each tutorial declares it under an optional `dev` extra. |
| src/agentex/lib/utils/debug.py | Moves `import debugpy` from module scope to inside the debug-enabled branch, making it a lazy import so production workers no longer require debugpy to be installed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run_test called] --> B{BUILD_CLI?}
    B -- No --> C["pytest_cmd = uv run\n--with pytest\n--with pytest-asyncio\npytest"]
    B -- Yes --> D{wheel_file found?}
    D -- Yes --> E["pytest_cmd = uv run\n--with wheel_file\n--with pytest\n--with pytest-asyncio\npytest"]
    D -- No --> C
    C --> F[Execute pytest with retry]
    E --> F
    F --> G{Test pass?}
    G -- Yes --> H[Return 0]
    G -- No, retries left --> F
    G -- No, out of retries --> I[Return 1]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(debug): import debugpy lazily so wor..."](https://github.com/scaleapi/scale-agentex-python/commit/5363438c52b1f3833fb3eee5a2ea8384df9057be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34611759)</sub>

<!-- /greptile_comment -->