### PR TITLE
fix(tutorials): install dev extras when running tutorial pytest

### DIFF
--- a/examples/tutorials/run_agent_test.sh
+++ b/examples/tutorials/run_agent_test.sh
@@ -260,7 +260,7 @@ run_test() {
 
 
     # Run the tests with retry mechanism
-    local -a pytest_cmd=("uv" "run" "pytest")
+    local -a pytest_cmd=("uv" "run" "--extra" "dev" "pytest")
     if [ "$BUILD_CLI" = true ]; then
         local wheel_file
         wheel_file=$(ls /home/runner/work/*/*/dist/agentex_sdk-*.whl 2>/dev/null | head -n1)
@@ -268,7 +268,7 @@ run_test() {
             wheel_file=$(ls "${SCRIPT_DIR}/../../dist/agentex_sdk-*.whl" 2>/dev/null | head -n1)
         fi
         if [[ -n "$wheel_file" ]]; then
-            pytest_cmd=("uv" "run" "--with" "$wheel_file" "pytest")
+            pytest_cmd=("uv" "run" "--extra" "dev" "--with" "$wheel_file" "pytest")
         fi
     fi
 


### PR DESCRIPTION
## Summary
- Tutorial CI has been red on every job since 2026-05-29 with `error: Failed to spawn: pytest / No such file or directory`.
- Root cause: #367 dropped `pytest`/`pytest-asyncio` from `agentex-sdk`'s runtime deps. Tutorials used to get pytest transitively via `agentex-sdk`; now pytest lives only in each tutorial's `[project.optional-dependencies] dev`, and `run_agent_test.sh` invoked `uv run pytest` without `--extra dev`, so uv never installed it.
- Fix: pass `--extra dev` to both `uv run` invocations in `examples/tutorials/run_agent_test.sh` so the tutorial's dev extras get synced before pytest is spawned.

Last green tutorial-test run on main: `26472427908` (2026-05-26, immediately before #367). First red run: `26617979690` (2026-05-29).

## Test plan
- [ ] CI tutorial-test matrix turns green on this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes broken tutorial CI by adding `--extra dev` to both `uv run` invocations in `run_agent_test.sh`, ensuring the tutorial's dev dependencies (pytest, pytest-asyncio) are installed before pytest is spawned.

- Both the standard code path (`uv run --extra dev pytest`) and the wheel-override path (`uv run --extra dev --with <wheel> pytest`) are updated consistently, so neither branch is left without dev extras.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix to a CI script with no impact on production code.

Both `uv run` invocations are updated consistently. The fix directly maps to the stated root cause, and the standard and wheel-override paths are treated identically. No production code is touched.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/tutorials/run_agent_test.sh | Adds `--extra dev` to both `uv run` invocations so tutorial dev-dependencies (pytest, pytest-asyncio) are installed before running tests; correctly applied to both the standard and wheel-override code paths. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as CI Runner
    participant Script as run_agent_test.sh
    participant uv as uv (package manager)
    participant pytest as pytest

    CI->>Script: run_test(tutorial_path)
    Script->>Script: build pytest_cmd with --extra dev
    Script->>uv: uv run --extra dev pytest tests/test_agent.py
    uv->>uv: sync [project.optional-dependencies] dev
    Note over uv: installs pytest, pytest-asyncio
    uv->>pytest: spawn pytest
    pytest-->>Script: exit_code
    Script-->>CI: pass / fail
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tutorials): install dev extras when ..."](https://github.com/scaleapi/scale-agentex-python/commit/4f1ac7c8f13dbc6815a521f30ea977b7f7a22a0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34615159)</sub>

<!-- /greptile_comment -->