### PR TITLE
fix: cap Python test matrix at 3.13 and align dev tooling versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-ARG VARIANT="3.9"
+ARG VARIANT="3.12"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 USER vscode
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.10.2 /uv /uvx /bin/
 
 RUN echo "[[ -d .venv ]] && source .venv/bin/activate || export PATH=\$PATH" >> /home/vscode/.bashrc

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          version: '0.9.13'
+          version: '0.10.2'
 
       - name: Publish to PyPI
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
   "Operating System :: POSIX",
   "Operating System :: MacOS",

--- a/scripts/test
+++ b/scripts/test
@@ -10,8 +10,8 @@ export DEFER_PYDANTIC_BUILD=false
 
 # Note that we need to specify the patch version here so that uv
 # won't use unstable (alpha, beta, rc) releases for the tests
-PY_VERSION_MIN=">=3.9.0"
-PY_VERSION_MAX=">=3.14.0"
+PY_VERSION_MIN=">=3.12.0,<3.13"
+PY_VERSION_MAX=">=3.13.0,<3.14"
 
 function run_tests() {
     echo "==> Running tests with Pydantic v2"


### PR DESCRIPTION
## What & why
The rye→uv migration's generated test matrix runs a Python **3.14** leg, but the dependency tree can't build on 3.14 (`watchfiles 0.24.0` → `pyo3-ffi 0.22.2`, which maxes at 3.13). That broke the `test` check on the 0.12.0 release PR and would break it on **every** future release. This caps the matrix at the supported range and aligns dev tooling.

## Changes
- **`scripts/test`**: matrix legs bounded to `>=3.12.0,<3.13` / `>=3.13.0,<3.14` (was `>=3.9.0` / `>=3.14.0`) so uv can't resolve a leg up to 3.14.
- **`pyproject.toml`**: drop the `Python :: 3.14` classifier.
- **`.github/workflows/publish-pypi.yml`**: uv `0.9.13` → `0.10.2` (match CI; publish was building with a different uv than CI validated).
- **`.devcontainer/Dockerfile`**: pin `uv:latest` → `uv:0.10.2`; base Python `3.9` → `3.12` (a 3.9 devcontainer can't install this package).

## Deliberately not here
`requires-python` is left at the template default (`>= 3.11,<4`). The accurate range is `>=3.12,<3.14` (the adk needs 3.12; 3.14 is unsupported), but raising the **floor** to `>=3.12` breaks Stainless's codegen build environment — so the `requires-python` tightening stays a per-release patch on the generated release branch. This PR is the durable home for everything that survives regen via 3-way merge.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken test matrix caused by the rye→uv migration generating a Python 3.14 test leg that can't build `watchfiles 0.24.0` (via `pyo3-ffi 0.22.2`, which only supports up to 3.13). It also aligns uv versions across CI, the publish workflow, and the devcontainer.

- **`scripts/test`**: Bounds the MIN leg to `>=3.12.0,<3.13` and MAX leg to `>=3.13.0,<3.14`, preventing uv from resolving a 3.14 interpreter. The floor moves from 3.9 to 3.12 to match the actual `adk` requirement.
- **`.github/workflows/publish-pypi.yml` / `.devcontainer/Dockerfile`**: Align uv to `0.10.2`; devcontainer base Python bumped from `3.9` to `3.12`.
- **`pyproject.toml`**: Drops the `Python :: 3.14` classifier; `Python :: 3.11` and the `requires-python >= 3.11` floor are intentionally left in place (Stainless codegen constraint, noted in PR description).

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are version constraint tightening and tooling alignment with no logic changes.

The diff is entirely version pins and matrix bounds. The `Python :: 3.11` classifier inconsistency with the test matrix is noted but pre-existing, explicitly documented in the PR description, and not a runtime defect. The uv version bumps are conservative and consistent across all three locations.

No files require special attention; `pyproject.toml` has the minor classifier inconsistency but it is acknowledged in the PR description.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/test | Python test matrix legs narrowed: MIN bounded to `>=3.12.0,<3.13` and MAX to `>=3.13.0,<3.14`, preventing uv from resolving a 3.14 interpreter that can't build `watchfiles`/`pyo3-ffi`. |
| pyproject.toml | Removes `Programming Language :: Python :: 3.14` classifier; `Python :: 3.11` classifier still present even though the test matrix no longer covers 3.11. |
| .github/workflows/publish-pypi.yml | Aligns publish workflow's uv version from `0.9.13` to `0.10.2` to match the CI-validated version. |
| .devcontainer/Dockerfile | Upgrades devcontainer base Python from `3.9` (unable to install this package) to `3.12`, and pins uv from `latest` to `0.10.2`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scripts/test invoked] --> B{Select Python leg}
    B -->|MIN leg| C["uv resolve >=3.12.0,<3.13\n(was >=3.9.0)"]
    B -->|MAX leg| D["uv resolve >=3.13.0,<3.14\n(was >=3.14.0 — builds failed)"]
    C --> E[Run tests on Python 3.12.x]
    D --> F[Run tests on Python 3.13.x]
    E --> G[Pass]
    F --> H[Pass]

    subgraph publish [publish-pypi.yml]
        I[astral-sh/setup-uv] -->|was 0.9.13| J["uv 0.10.2 (aligned with CI)"]
    end

    subgraph devcontainer [.devcontainer/Dockerfile]
        K[Base Python] -->|was 3.9| L["Python 3.12\n(3.9 could not install package)"]
        M[uv] -->|was :latest| N["uv:0.10.2 (pinned)"]
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apyproject.toml%3A54%0A**%60Python%20%3A%3A%203.11%60%20classifier%20no%20longer%20matches%20the%20tested%20range**%0A%0AThe%20test%20matrix%20now%20only%20runs%203.12%20and%203.13%2C%20but%20the%20%60Programming%20Language%20%3A%3A%20Python%20%3A%3A%203.11%60%20classifier%20%28and%20the%20%60requires-python%20%3E%3D%203.11%60%20floor%29%20remains.%20This%20isn't%20introduced%20by%20this%20PR%20%E2%80%94%20the%20description%20explicitly%20documents%20the%20constraint%20%E2%80%94%20but%20it%20means%20users%20targeting%203.11%20will%20see%20a%20supported-version%20claim%20in%20PyPI%20metadata%20that%20isn't%20backed%20by%20CI.%20A%20follow-up%20that%20removes%20this%20classifier%20when%20the%20Stainless%20codegen%20constraint%20is%20resolved%20would%20close%20the%20gap.%0A%0A&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apyproject.toml%3A54%0A**%60Python%20%3A%3A%203.11%60%20classifier%20no%20longer%20matches%20the%20tested%20range**%0A%0AThe%20test%20matrix%20now%20only%20runs%203.12%20and%203.13%2C%20but%20the%20%60Programming%20Language%20%3A%3A%20Python%20%3A%3A%203.11%60%20classifier%20%28and%20the%20%60requires-python%20%3E%3D%203.11%60%20floor%29%20remains.%20This%20isn't%20introduced%20by%20this%20PR%20%E2%80%94%20the%20description%20explicitly%20documents%20the%20constraint%20%E2%80%94%20but%20it%20means%20users%20targeting%203.11%20will%20see%20a%20supported-version%20claim%20in%20PyPI%20metadata%20that%20isn't%20backed%20by%20CI.%20A%20follow-up%20that%20removes%20this%20classifier%20when%20the%20Stainless%20codegen%20constraint%20is%20resolved%20would%20close%20the%20gap.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22fix%2Fpython-test-matrix-and-tooling-versions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpython-test-matrix-and-tooling-versions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apyproject.toml%3A54%0A**%60Python%20%3A%3A%203.11%60%20classifier%20no%20longer%20matches%20the%20tested%20range**%0A%0AThe%20test%20matrix%20now%20only%20runs%203.12%20and%203.13%2C%20but%20the%20%60Programming%20Language%20%3A%3A%20Python%20%3A%3A%203.11%60%20classifier%20%28and%20the%20%60requires-python%20%3E%3D%203.11%60%20floor%29%20remains.%20This%20isn't%20introduced%20by%20this%20PR%20%E2%80%94%20the%20description%20explicitly%20documents%20the%20constraint%20%E2%80%94%20but%20it%20means%20users%20targeting%203.11%20will%20see%20a%20supported-version%20claim%20in%20PyPI%20metadata%20that%20isn't%20backed%20by%20CI.%20A%20follow-up%20that%20removes%20this%20classifier%20when%20the%20Stainless%20codegen%20constraint%20is%20resolved%20would%20close%20the%20gap.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pyproject.toml:54
**`Python :: 3.11` classifier no longer matches the tested range**

The test matrix now only runs 3.12 and 3.13, but the `Programming Language :: Python :: 3.11` classifier (and the `requires-python >= 3.11` floor) remains. This isn't introduced by this PR — the description explicitly documents the constraint — but it means users targeting 3.11 will see a supported-version claim in PyPI metadata that isn't backed by CI. A follow-up that removes this classifier when the Stainless codegen constraint is resolved would close the gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: cap Python test matrix at 3.13 and ..."](https://github.com/scaleapi/scale-agentex-python/commit/53a445d2452943141cd29583ceea086779f7f5e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35256968)</sub>

<!-- /greptile_comment -->