### PR TITLE
docs: clarify task name is optional in adk.acp.create_task

### DIFF
--- a/src/agentex/lib/adk/_modules/acp.py
+++ b/src/agentex/lib/adk/_modules/acp.py
@@ -68,7 +68,11 @@ class ACPModule:
         Create a new task.
 
         Args:
-            name: The name of the task.
+            name: Optional human-readable name for the task. task/create is
+                get-or-create by name: omit it (or make it unique, e.g. append a
+                UUID) for a fresh task on each call; passing a name that already
+                exists returns that task with its prior history instead of
+                creating a new one. Keep it globally unique when set.
             agent_id: The ID of the agent to create the task for.
             agent_name: The name of the agent to create the task for.
             params: The parameters for the task.


### PR DESCRIPTION
## Summary

`task/create` is get-or-create keyed on the task `name`, and `name` is optional. Reusing an existing name returns that task **with its prior message history** instead of creating a new one — a common cause of accidental duplicate / stale tasks, especially in multi-agent delegation where names are derived from prompts.

This documents that contract on `adk.acp.create_task`, the hand-written ADK entry point orchestrators call (the generated `types/`/`resources/` layer inherits the matching wording from the OpenAPI spec on the next Stainless regen, so this is the durable, hand-authored counterpart).

## Change

- `src/agentex/lib/adk/_modules/acp.py`: expand the `name` arg docstring — name is optional; omit it (or make it unique, e.g. append a UUID) for a fresh task each call; keep it globally unique when set.

## Test plan

- [ ] Docstring-only change; no behavior change. Verify rendering / no lint errors.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR clarifies the `name` parameter semantics for `adk.acp.create_task` via an expanded docstring. No behavior changes are introduced.

- The `name` arg docstring now explains that `task/create` is get-or-create keyed on name, that omitting the name (or appending a UUID) is the correct way to guarantee a fresh task, and that a reused name returns the existing task along with its prior message history.
- This is the hand-authored ADK entry point; the generated `types/`/`resources/` layer will pick up matching wording from the OpenAPI spec on the next Stainless regen.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Docstring-only change with no runtime code modified — safe to merge.

The single changed line range is a docstring expansion that accurately describes the existing get-or-create behavior of the `task/create` endpoint. No logic, imports, or signatures are touched.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/adk/_modules/acp.py | Docstring-only: expands the `name` param description in `create_task` to document the get-or-create semantics and recommend omitting or uniquifying the name for a fresh task. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["adk.acp.create_task(name=...)"] --> B{name provided?}
    B -- No --> C["Always creates a fresh task"]
    B -- Yes --> D{Name already exists?}
    D -- No --> E["Creates a new task"]
    D -- Yes --> F["Returns existing task\n(with prior message history)"]
    C --> G[Task returned]
    E --> G
    F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: clarify task name is optional in a..."](https://github.com/scaleapi/scale-agentex-python/commit/15ec1792539e0c4e60f2fec3c7dfd71ae31473ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35386947)</sub>

<!-- /greptile_comment -->