### PR TITLE
perf(tracing): raise span-queue batch defaults and make batch_size env-tunable

### DIFF
--- a/src/agentex/lib/core/tracing/span_queue.py
+++ b/src/agentex/lib/core/tracing/span_queue.py
@@ -15,8 +15,18 @@ from agentex.lib.core.tracing.processors.tracing_processor_interface import (
 
 logger = make_logger(__name__)
 
-_DEFAULT_BATCH_SIZE = 50
-_DEFAULT_LINGER_MS = 100
+# Max spans coalesced into one ``upsert_batch`` HTTP call (one
+# ``INSERT ... ON CONFLICT`` statement server-side).  Larger batches amortize
+# the per-request round trip and the per-statement parse/plan + index
+# maintenance overhead, which dominates at high span volume.  Kept well under
+# the EGP backend's 1000-row cap; tune per-deploy via
+# ``AGENTEX_SPAN_QUEUE_BATCH_SIZE``.
+_DEFAULT_BATCH_SIZE = 200
+# Max time the drain lingers after the first span to let a batch fill.  Spans
+# typically arrive a few ms apart, so a longer linger fills the larger batch
+# above rather than shipping near-size-1 batches; bounded so worst-case ingest
+# latency (and the in-flight loss window) stays sub-second.
+_DEFAULT_LINGER_MS = 250
 # 0 == unbounded (preserves prior behavior).  A bound makes backpressure
 # visible (dropped spans are counted) and caps worst-case memory.
 _DEFAULT_MAX_SIZE = 0
@@ -114,7 +124,7 @@ class AsyncSpanQueue:
 
     def __init__(
         self,
-        batch_size: int = _DEFAULT_BATCH_SIZE,
+        batch_size: int | None = None,
         linger_ms: int | None = None,
         max_size: int | None = None,
         max_retries: int | None = None,
@@ -126,7 +136,11 @@ class AsyncSpanQueue:
         self._queue: asyncio.Queue[_SpanQueueItem] = asyncio.Queue(maxsize=resolved_max_size)
         self._drain_task: asyncio.Task[None] | None = None
         self._stopping = False
-        self._batch_size = batch_size
+        self._batch_size = (
+            _read_int_env("AGENTEX_SPAN_QUEUE_BATCH_SIZE", _DEFAULT_BATCH_SIZE, minimum=1)
+            if batch_size is None
+            else max(1, batch_size)
+        )
         self._linger_ms = _read_linger_ms_env() if linger_ms is None else max(0, linger_ms)
         self._max_retries = (
             _read_int_env("AGENTEX_SPAN_QUEUE_MAX_RETRIES", _DEFAULT_MAX_RETRIES, minimum=1)

--- a/tests/lib/core/tracing/test_span_queue.py
+++ b/tests/lib/core/tracing/test_span_queue.py
@@ -8,7 +8,11 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agentex.types.span import Span
-from agentex.lib.core.tracing.span_queue import SpanEventType, AsyncSpanQueue
+from agentex.lib.core.tracing.span_queue import (
+    _DEFAULT_BATCH_SIZE,
+    SpanEventType,
+    AsyncSpanQueue,
+)
 
 
 def _make_span(span_id: str | None = None) -> Span:
@@ -859,3 +863,31 @@ class TestAsyncSpanQueueMetrics:
 
         assert elapsed < 0.05, f"disabled metrics enqueue too slow: {elapsed:.3f}s"
         mock_get.assert_not_called()
+
+
+class TestAsyncSpanQueueBatchSizeConfig:
+    """batch_size resolution: explicit arg > AGENTEX_SPAN_QUEUE_BATCH_SIZE env > default."""
+
+    async def test_default_batch_size(self, monkeypatch):
+        monkeypatch.delenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", raising=False)
+        assert AsyncSpanQueue()._batch_size == _DEFAULT_BATCH_SIZE
+
+    async def test_explicit_arg_overrides_default(self, monkeypatch):
+        monkeypatch.delenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", raising=False)
+        assert AsyncSpanQueue(batch_size=10)._batch_size == 10
+
+    async def test_explicit_arg_clamped_to_min_one(self, monkeypatch):
+        monkeypatch.delenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", raising=False)
+        assert AsyncSpanQueue(batch_size=0)._batch_size == 1
+
+    async def test_env_used_when_arg_is_none(self, monkeypatch):
+        monkeypatch.setenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", "500")
+        assert AsyncSpanQueue()._batch_size == 500
+
+    async def test_explicit_arg_beats_env(self, monkeypatch):
+        monkeypatch.setenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", "500")
+        assert AsyncSpanQueue(batch_size=7)._batch_size == 7
+
+    async def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", "not-an-int")
+        assert AsyncSpanQueue()._batch_size == _DEFAULT_BATCH_SIZE


### PR DESCRIPTION
## Summary

Tune the async span-queue's batching so high-volume span ingest sends fewer, fuller batches, and make the batch size configurable per-deploy.

**Defaults raised** (`span_queue.py`):
- `_DEFAULT_BATCH_SIZE` 50 → **200**
- `_DEFAULT_LINGER_MS` 100 → **250**

At 50 spans / 100ms, the queue ships many small `upsert_batch` PUTs — each a separate HTTP round trip and a separate `INSERT ... ON CONFLICT` statement on the backend, and (downstream) more, smaller ClickHouse parts to merge. Spans typically arrive a few ms apart, so a 100ms linger rarely fills a batch. Raising to 200 / 250ms lets batches fill before flushing, amortizing per-request and per-statement overhead. 200 stays well under the backend's 1000-row batch cap.

**`batch_size` is now env-tunable.** It was the only queue knob without an `AGENTEX_SPAN_QUEUE_*` override — every other parameter (`linger_ms`, `max_size`, `max_retries`, `concurrency`) already reads one. Added `AGENTEX_SPAN_QUEUE_BATCH_SIZE` with the same `_read_int_env` pattern, so the batch size can be tuned per-deploy without an SDK release.

Resolution order (matches the other knobs): **explicit constructor arg > `AGENTEX_SPAN_QUEUE_BATCH_SIZE` env > default**, clamped to a minimum of 1.

## Trade-offs

Larger batches + longer linger slightly increase worst-case in-memory dwell and the loss window if a producer crashes before a flush (bounded by linger + queue semantics). The values keep worst-case ingest latency sub-second.

## Tests

`TestAsyncSpanQueueBatchSizeConfig`: default, explicit-arg override, min-1 clamp, env override, explicit-arg-beats-env, and invalid-env-falls-back-to-default. All 37 tests in `test_span_queue.py` pass; `ruff check` clean.

## Note

Independent of #394 (skip span-start upsert) — that changes *whether* a write happens; this changes *how writes are batched*. Branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the default `batch_size` (50→200) and `linger_ms` (100→250) for the async span queue to reduce the number of small `upsert_batch` HTTP round trips under high span volume. It also closes the only knob that lacked an `AGENTEX_SPAN_QUEUE_*` env override by adding `AGENTEX_SPAN_QUEUE_BATCH_SIZE`, following the identical resolution pattern (`explicit arg > env > default`, clamped to minimum 1) used by every other parameter.

- **`span_queue.py`**: Default constants raised with detailed rationale comments; `batch_size` constructor parameter changed from `int = _DEFAULT_BATCH_SIZE` to `int | None = None` to support env-driven resolution.
- **`test_span_queue.py`**: New `TestAsyncSpanQueueBatchSizeConfig` class covers default, explicit override, min-1 clamp, env override, explicit-beats-env, and invalid-env-fallback scenarios, all consistent with patterns used for other queue knobs.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are limited to tuning constants and adding a missing env-var override that follows an established, well-tested pattern already used by every other queue knob.

Both changes are narrow and mechanical: the constant bumps are well-justified and bounded below the backend's documented 1000-row cap, and the new env-override path mirrors the identical pattern applied to linger_ms, max_retries, and concurrency. Six dedicated tests cover all resolution-order branches, and asyncio_mode=auto ensures they actually run.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/span_queue.py | Default constants raised (batch_size 50→200, linger_ms 100→250); batch_size constructor parameter made nullable to support env-var resolution, fully consistent with the existing pattern for all other queue knobs. |
| tests/lib/core/tracing/test_span_queue.py | New TestAsyncSpanQueueBatchSizeConfig class with 6 focused tests; asyncio_mode=auto is configured so async def methods run correctly; covers all resolution-order branches for the new env knob. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AsyncSpanQueue.__init__ called] --> B{batch_size arg provided?}
    B -- "None (default)" --> C["Read AGENTEX_SPAN_QUEUE_BATCH_SIZE env"]
    C --> D{Env var set?}
    D -- "Yes, valid int" --> E["max(1, int(env)) → _batch_size"]
    D -- "Yes, invalid" --> F["Log warning → _DEFAULT_BATCH_SIZE (200)"]
    D -- "Not set" --> G["_DEFAULT_BATCH_SIZE (200)"]
    B -- "Explicit int" --> H["max(1, batch_size) → _batch_size"]
    E --> Z[_batch_size resolved]
    F --> Z
    G --> Z
    H --> Z
    Z --> I["Drain loop uses _batch_size as batch fill cap"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(tracing): raise span-queue batch de..."](https://github.com/scaleapi/scale-agentex-python/commit/9f7b020d3c1c557a6e9433020de81c500c2fba0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35703389)</sub>

<!-- /greptile_comment -->