### PR TITLE
refactor(config): promote deployment-config models to agentex.config.*

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,19 +63,32 @@ The package provides the `agentex` CLI with these main commands:
     `SendEventParams`, `CancelTaskParams`, `RPC_SYNC_METHODS`,
     `PARAMS_MODEL_BY_METHOD`
   - `json_rpc.py` - `JSONRPCRequest`, `JSONRPCResponse`, `JSONRPCError`
+- `/src/agentex/config/` - **Canonical** location for deployment/agent
+  configuration models (manifest shapes). Depends only on `pydantic`, so it is
+  safe to import from a slim REST-only install.
+  - `agent_config.py`, `build_config.py`, `deployment_config.py`,
+    `local_development_config.py`, `environment_config.py`, `agent_manifest.py`
+    (model classes only), plus their model deps `credentials.py` and
+    `agent_configs.py`
+  - yaml loaders / build machinery (`load_environments_config*`,
+    `load_agent_manifest`, `build_context_manager`, `BuildContextManager`) stay
+    in `agentex.lib.sdk.config.*` so these models stay slim-safe
 - `/src/agentex/lib/` - Custom library code (not modified by code generator)
   - `/cli/` - Command-line interface implementation
   - `/core/` - Core services, adapters, and temporal workflows
   - `/sdk/` - SDK utilities and FastACP implementation
+    - `config/` - manifest loaders + Docker build machinery (`agent_manifest`'s
+      `load_agent_manifest`/`build_context_manager`/`BuildContextManager`,
+      `validation`, `project_config`) plus **back-compat shims** for the model
+      classes now canonical under `agentex.config.*`
   - `/types/` - Custom type definitions
     - `acp.py`, `json_rpc.py` - **back-compat shims** re-exporting from
-      `agentex.protocol.*`. Existing `from agentex.lib.types.{acp,json_rpc}
-      import ...` keeps working; new code should import from the canonical
-      `agentex.protocol.*` paths.
-    - Other modules (`tracing`, `agent_card`, `credentials`, `fastacp`,
-      `llm_messages`, `converters`, etc.) stay here — they have heavier
-      transitive deps (temporal, openai-agents, model_utils/yaml) and
-      aren't slim-safe.
+      `agentex.protocol.*`. `credentials.py`, `agent_configs.py` - shims
+      re-exporting from `agentex.config.*`. Existing `from agentex.lib...`
+      imports keep working; new code should import from the canonical paths.
+    - Other modules (`tracing`, `agent_card`, `fastacp`, `llm_messages`,
+      `converters`, etc.) stay here — they have heavier transitive deps
+      (temporal, openai-agents, model_utils/yaml) and aren't slim-safe.
   - `/utils/` - Utility functions
 - `/examples/` - Example implementations and tutorials
 - `/tests/` - Test suites

--- a/src/agentex/config/__init__.py
+++ b/src/agentex/config/__init__.py
@@ -1,0 +1,14 @@
+"""Deployment & agent configuration shapes for Agentex.
+
+The modules under `agentex.config.*` are the typed manifest/deployment
+configuration models (agent, build, deployment, environment, local-dev) plus
+their leaf model deps (credentials, temporal). They depend only on pydantic,
+so they are safe to import from a slim REST-only install without the ADK
+runtime.
+
+For back-compat, the same classes are re-exported from their historical
+locations under `agentex.lib.sdk.config.*` and
+`agentex.lib.types.{agent_configs,credentials}`. The yaml-loading helpers
+(`load_environments_config*`) stay in `agentex.lib.sdk.config.environment_config`
+so the promoted models remain slim-safe.
+"""

--- a/src/agentex/config/_base.py
+++ b/src/agentex/config/_base.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class ConfigBaseModel(BaseModel):
+    # Preserves the config the former agentex.lib.utils.model_utils.BaseModel
+    # applied; deployment_config's `global` alias relies on populate_by_name.
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/src/agentex/config/agent_config.py
+++ b/src/agentex/config/agent_config.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field
+
+from agentex.config._base import ConfigBaseModel
+from agentex.config.credentials import CredentialMapping
+from agentex.config.agent_configs import TemporalConfig, TemporalWorkflowConfig
+
+
+class AgentConfig(ConfigBaseModel):
+    name: str = Field(
+        ...,
+        description="The name of the agent.",
+        pattern=r"^[a-z0-9-]+$",
+    )
+    acp_type: Literal["sync", "async", "agentic"] = Field(..., description="The type of agent.")
+    agent_input_type: Literal["text", "json"] | None = Field(
+        default=None,
+        description="The type of input the agent accepts."
+    )
+    description: str = Field(..., description="The description of the agent.")
+    env: dict[str, str] | None = Field(
+        default=None, description="Environment variables to set directly in the agent deployment"
+    )
+    credentials: list[CredentialMapping | dict[str, Any]] | None = Field(
+        default=None,
+        description="List of credential mappings to mount to the agent deployment. Supports both legacy format and new typed credentials.",
+    )
+    temporal: TemporalConfig | None = Field(
+        default=None, description="Temporal workflow configuration for this agent"
+    )
+
+    def is_temporal_agent(self) -> bool:
+        """Check if this agent uses Temporal workflows"""
+        # Check temporal config with enabled flag
+        if self.temporal and self.temporal.enabled:
+            return True
+        return False
+
+    def get_temporal_workflow_config(self) -> TemporalWorkflowConfig | None:
+        """Get temporal workflow configuration, checking both new and legacy formats"""
+        # Check new workflows list first
+        if self.temporal and self.temporal.enabled and self.temporal.workflows:
+            return self.temporal.workflows[0]  # Return first workflow for backward compatibility
+
+        # Check legacy single workflow
+        if self.temporal and self.temporal.enabled and self.temporal.workflow:
+            return self.temporal.workflow
+
+        return None
+
+    def get_temporal_workflows(self) -> list[TemporalWorkflowConfig]:
+        """Get all temporal workflow configurations"""
+        # Check new workflows list first
+        if self.temporal and self.temporal.enabled and self.temporal.workflows:
+            return self.temporal.workflows
+
+        # Check legacy single workflow
+        if self.temporal and self.temporal.enabled and self.temporal.workflow:
+            return [self.temporal.workflow]
+
+        return []

--- a/src/agentex/config/agent_configs.py
+++ b/src/agentex/config/agent_configs.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pydantic import Field, BaseModel, field_validator, model_validator
+
+
+class TemporalWorkflowConfig(BaseModel):
+    """
+    Configuration for the temporal workflow that defines the agent.
+
+    Attributes:
+        name: The name of the temporal workflow that defines the agent.
+        queue_name: The name of the temporal queue to send tasks to.
+    """
+
+    name: str = Field(
+        ..., description="The name of the temporal workflow that defines the agent."
+    )
+    queue_name: str = Field(
+        ..., description="The name of the temporal queue to send tasks to."
+    )
+
+
+# TODO: Remove this class when we remove the agentex agents create
+class TemporalWorkerConfig(BaseModel):
+    """
+    Configuration for temporal worker deployment
+
+    Attributes:
+        image: The image to use for the temporal worker
+        workflow: The temporal workflow configuration
+    """
+
+    image: str | None = Field(
+        default=None, description="Image to use for the temporal worker"
+    )
+    workflow: TemporalWorkflowConfig | None = Field(
+        default=None,
+        description="Configuration for the temporal workflow that defines the agent. Only required for agents that leverage Temporal.",
+    )
+
+
+class TemporalConfig(BaseModel):
+    """
+    Simplified temporal configuration for agents
+
+    Attributes:
+        enabled: Whether this agent uses Temporal workflows
+        workflow: The temporal workflow configuration
+        workflows: The list of temporal workflow configurations
+        health_check_port: Port for temporal worker health check endpoint
+    """
+
+    enabled: bool = Field(
+        default=False, description="Whether this agent uses Temporal workflows"
+    )
+    workflow: TemporalWorkflowConfig | None = Field(
+        default=None,
+        description="Temporal workflow configuration. Required when enabled=True. (deprecated: use workflows instead)",
+    )
+    workflows: list[TemporalWorkflowConfig] | None = Field(
+        default=None,
+        description="List of temporal workflow configurations. Used when enabled=true.",
+    )
+    health_check_port: int | None = Field(
+        default=None,
+        description="Port for temporal worker health check endpoint. Defaults to 80 if not specified.",
+    )
+
+    @field_validator("workflows")
+    @classmethod
+    def validate_workflows_not_empty(cls, v):
+        """Ensure workflows list is not empty when provided"""
+        if v is not None and len(v) == 0:
+            raise ValueError("workflows list cannot be empty when provided")
+        return v
+
+    @model_validator(mode="after")
+    def validate_temporal_config_when_enabled(self):
+        """Validate that workflow configuration exists when enabled=true"""
+        if self.enabled:
+            # Must have either workflow (legacy) or workflows (new)
+            if not self.workflow and (not self.workflows or len(self.workflows) == 0):
+                raise ValueError(
+                    "When temporal.enabled=true, either 'workflow' or 'workflows' must be provided and non-empty"
+                )
+
+        return self

--- a/src/agentex/config/agent_manifest.py
+++ b/src/agentex/config/agent_manifest.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from agentex.config._base import ConfigBaseModel
+from agentex.config.agent_config import AgentConfig
+from agentex.config.build_config import BuildConfig
+from agentex.config.deployment_config import DeploymentConfig
+from agentex.config.local_development_config import LocalDevelopmentConfig
+
+
+class AgentManifest(ConfigBaseModel):
+    """
+    Represents a manifest file that describes how to build and deploy an agent.
+    """
+
+    build: BuildConfig
+    agent: AgentConfig
+    local_development: LocalDevelopmentConfig | None = Field(
+        default=None, description="Configuration for local development"
+    )
+    deployment: DeploymentConfig | None = Field(
+        default=None, description="Deployment configuration for the agent"
+    )

--- a/src/agentex/config/build_config.py
+++ b/src/agentex/config/build_config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from agentex.config._base import ConfigBaseModel
+
+
+class BuildContext(ConfigBaseModel):
+    """
+    Represents the context in which the Docker image should be built.
+    """
+
+    root: str = Field(
+        ...,
+        description="The root directory of the build context. Should be specified relative to the location of the "
+        "build config file.",
+    )
+    include_paths: list[str] = Field(
+        default_factory=list,
+        description="The paths to include in the build context. Should be specified relative to the root directory.",
+    )
+    dockerfile: str = Field(
+        ...,
+        description="The path to the Dockerfile. Should be specified relative to the root directory.",
+    )
+    dockerignore: str | None = Field(
+        None,
+        description="The path to the .dockerignore file. Should be specified relative to the root directory.",
+    )
+
+
+class BuildConfig(ConfigBaseModel):
+    """
+    Represents a configuration for building the action as a Docker image.
+    """
+
+    context: BuildContext

--- a/src/agentex/config/credentials.py
+++ b/src/agentex/config/credentials.py
@@ -1,0 +1,34 @@
+from pydantic import Field, BaseModel
+
+
+class CredentialMapping(BaseModel):
+    """Maps a Kubernetes secret to an environment variable in the agent container.
+
+    This allows agents to securely access credentials stored in Kubernetes secrets
+    by mapping them to environment variables. For example, you can map a secret
+    containing an API key to an environment variable that your agent code expects.
+
+    Example:
+        A mapping of {"env_var_name": "OPENAI_API_KEY",
+                     "secret_name": "ai-credentials",
+                     "secret_key": "openai-key"}
+        will make the value from the "openai-key" field in the "ai-credentials"
+        Kubernetes secret available to the agent as OPENAI_API_KEY environment variable.
+
+    Attributes:
+        env_var_name: The name of the environment variable that will be available to the agent
+        secret_name: The name of the Kubernetes secret containing the credential
+        secret_key: The key within the Kubernetes secret that contains the credential value
+    """
+
+    env_var_name: str = Field(
+        ...,
+        description="Name of the environment variable that will be available to the agent",
+    )
+    secret_name: str = Field(
+        ..., description="Name of the Kubernetes secret containing the credential"
+    )
+    secret_key: str = Field(
+        ...,
+        description="Key within the Kubernetes secret that contains the credential value",
+    )

--- a/src/agentex/config/deployment_config.py
+++ b/src/agentex/config/deployment_config.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pydantic import Field
+
+from agentex.config._base import ConfigBaseModel
+
+
+class ImageConfig(ConfigBaseModel):
+    """Configuration for container images"""
+
+    repository: str = Field(..., description="Container image repository URL")
+    tag: str = Field(default="latest", description="Container image tag")
+
+
+class ImagePullSecretConfig(ConfigBaseModel):
+    """Configuration for image pull secrets"""
+
+    name: str = Field(..., description="Name of the image pull secret")
+
+
+class ResourceRequirements(ConfigBaseModel):
+    """Resource requirements for containers"""
+
+    cpu: str = Field(
+        default="500m", description="CPU request/limit (e.g., '500m', '1')"
+    )
+    memory: str = Field(
+        default="1Gi", description="Memory request/limit (e.g., '1Gi', '512Mi')"
+    )
+
+
+class ResourceConfig(ConfigBaseModel):
+    """Resource configuration for containers"""
+
+    requests: ResourceRequirements = Field(
+        default_factory=ResourceRequirements, description="Resource requests"
+    )
+    limits: ResourceRequirements = Field(
+        default_factory=ResourceRequirements, description="Resource limits"
+    )
+
+
+class GlobalDeploymentConfig(ConfigBaseModel):
+    """Global deployment configuration that applies to all clusters"""
+
+    agent: dict[str, str] = Field(
+        default_factory=dict, description="Agent metadata (name, description)"
+    )
+    replicaCount: int = Field(default=1, description="Number of replicas to deploy")
+    resources: ResourceConfig = Field(
+        default_factory=ResourceConfig, description="Resource requirements"
+    )
+
+
+class DeploymentConfig(ConfigBaseModel):
+    """Main deployment configuration in the manifest"""
+
+    image: ImageConfig = Field(..., description="Container image configuration")
+    imagePullSecrets: list[ImagePullSecretConfig] | None = Field(
+        default=None, description="Image pull secrets to use for the deployment"
+    )
+    global_config: GlobalDeploymentConfig = Field(
+        default_factory=GlobalDeploymentConfig,
+        description="Global deployment settings",
+        alias="global",
+    )
+
+
+class ClusterConfig(ConfigBaseModel):
+    """Per-cluster deployment overrides"""
+
+    image: ImageConfig | None = Field(
+        default=None, description="Cluster-specific image overrides"
+    )
+    replicaCount: int | None = Field(
+        default=None, description="Cluster-specific replica count"
+    )
+    resources: ResourceConfig | None = Field(
+        default=None, description="Cluster-specific resource overrides"
+    )
+    env: list[dict[str, str]] | None = Field(
+        default=None, description="Additional environment variables for this cluster"
+    )
+    # Allow additional arbitrary overrides for advanced users
+    additional_overrides: dict[str, Any] | None = Field(
+        default=None, description="Additional helm chart value overrides"
+    )
+
+
+class AuthenticationConfig(ConfigBaseModel):
+    principal: Dict[str, Any] = Field(description="Principal used for authorization on registration")
+
+
+class InjectedImagePullSecretValues(ConfigBaseModel):
+    """Values for image pull secrets"""
+
+    registry: str = Field(..., description="Registry of the image pull secret")
+    username: str = Field(..., description="Username of the image pull secret")
+    password: str = Field(..., description="Password of the image pull secret")
+    email: str | None = Field(
+        default=None, description="Email of the image pull secret"
+    )
+
+
+class InjectedSecretsValues(ConfigBaseModel):
+    """Values for injected secrets"""
+
+    # Defined as a dictionary because the names need to be unique
+    credentials: dict[str, Any] = Field(
+        default_factory=dict, description="Secrets to inject into the deployment"
+    )
+    imagePullSecrets: dict[str, InjectedImagePullSecretValues] = Field(
+        default_factory=dict,
+        description="Image pull secrets to inject into the deployment",
+    )

--- a/src/agentex/config/environment_config.py
+++ b/src/agentex/config/environment_config.py
@@ -1,0 +1,217 @@
+"""
+Environment-specific configuration models for agent deployments.
+
+This module provides Pydantic models for managing environment-specific
+configurations that are separate from the main manifest.yaml file. The
+yaml-loading helpers live in `agentex.lib.sdk.config.environment_config`
+so these models stay slim-safe.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Literal
+
+from pydantic import Field, BaseModel, field_validator
+
+from agentex.config._base import ConfigBaseModel
+
+
+class AgentAuthConfig(BaseModel):
+    """Authentication configuration for an agent in a specific environment."""
+
+    principal: Dict[str, Any] = Field(
+        ..., description="Principal configuration for agent authorization and registration"
+    )
+
+    @field_validator("principal")
+    @classmethod
+    def validate_principal_required_fields(cls, v: Any) -> Dict[str, Any]:
+        """Ensure principal has required fields for agent registration."""
+        if not isinstance(v, dict):
+            raise ValueError("Principal must be a dictionary")
+        return v
+
+
+class AgentKubernetesConfig(BaseModel):
+    """Kubernetes configuration for an agent in a specific environment."""
+
+    namespace: str = Field(..., description="Kubernetes namespace where the agent will be deployed")
+
+    @field_validator("namespace")
+    @classmethod
+    def validate_namespace_format(cls, v: str) -> str:
+        """Ensure namespace follows Kubernetes naming conventions."""
+        if not v or not v.strip():
+            raise ValueError("Namespace cannot be empty")
+
+        # Basic Kubernetes namespace validation
+        namespace = v.strip().lower()
+        if not namespace.replace("-", "").replace(".", "").isalnum():
+            raise ValueError(f"Namespace '{v}' must contain only lowercase letters, numbers, hyphens, and periods")
+
+        if len(namespace) > 63:
+            raise ValueError(f"Namespace '{v}' cannot exceed 63 characters")
+
+        return namespace
+
+
+class OciRegistryConfig(BaseModel):
+    """OCI registry configuration for Helm chart deployments."""
+
+    url: str = Field(
+        ...,
+        description="OCI registry URL for Helm charts (e.g., 'us-west1-docker.pkg.dev/project/repo'). "
+        "When set, OCI mode is used instead of classic helm repo.",
+    )
+    provider: Literal["gar"] | None = Field(
+        default=None,
+        description="OCI registry provider for provider-specific features. "
+        "Set to 'gar' for Google Artifact Registry to enable auto-authentication via gcloud "
+        "and latest version fetching. When not set, assumes user has already authenticated.",
+    )
+    chart_version: str | None = Field(
+        default=None, description="Helm chart version to deploy. If not set, uses the default version from the CLI."
+    )
+
+
+class AgentEnvironmentConfig(BaseModel):
+    """Complete configuration for an agent in a specific environment."""
+
+    kubernetes: AgentKubernetesConfig | None = Field(default=None, description="Kubernetes deployment configuration")
+    environment: str | None = Field(
+        default=None,
+        description="The environment keyword that this specific environment maps to: either dev, staging, prod",
+    )
+    auth: AgentAuthConfig = Field(..., description="Authentication and authorization configuration")
+    helm_repository_name: str = Field(default="scale-egp", description="Helm repository name for the environment")
+    helm_repository_url: str = Field(
+        default="https://scale-egp-helm-charts-us-west-2.s3.amazonaws.com/charts",
+        description="Helm repository url for the environment (classic mode)",
+    )
+    oci_registry: OciRegistryConfig | None = Field(
+        default=None, description="OCI registry configuration. When set, OCI mode is used instead of classic helm repo."
+    )
+    helm_overrides: Dict[str, Any] = Field(
+        default_factory=dict, description="Helm chart value overrides for environment-specific tuning"
+    )
+
+
+class AgentEnvironmentsConfig(ConfigBaseModel):
+    """All environment configurations for an agent."""
+
+    schema_version: str = Field(default="v1", description="Schema version for validation and compatibility")
+    environments: Dict[str, AgentEnvironmentConfig] = Field(
+        ..., description="Environment-specific configurations (dev, prod, etc.)"
+    )
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, v: str) -> str:
+        """Ensure schema version is supported."""
+        supported_versions = ["v1"]
+        if v not in supported_versions:
+            raise ValueError(f"Schema version '{v}' not supported. Supported versions: {', '.join(supported_versions)}")
+        return v
+
+    @field_validator("environments")
+    @classmethod
+    def validate_environments_not_empty(cls, v: Dict[str, AgentEnvironmentConfig]) -> Dict[str, AgentEnvironmentConfig]:
+        """Ensure at least one environment is defined."""
+        if not v:
+            raise ValueError("At least one environment must be defined")
+        return v
+
+    def get_config_for_env(self, env_name: str) -> AgentEnvironmentConfig:
+        """Get configuration for a specific environment.
+
+        Args:
+            env_name: Name of the environment (e.g., 'dev', 'prod')
+
+        Returns:
+            AgentEnvironmentConfig for the specified environment
+
+        Raises:
+            ValueError: If environment is not found
+        """
+        if env_name not in self.environments:
+            available_envs = ", ".join(self.environments.keys())
+            raise ValueError(
+                f"Environment '{env_name}' not found in environments.yaml. Available environments: {available_envs}"
+            )
+        return self.environments[env_name]
+
+    def get_configs_for_env(self, env_target: str) -> dict[str, AgentEnvironmentConfig]:
+        """Get configuration for a specific environment based on the expected mapping.
+        The environment is either:
+        1. explicitly specified like so using a key-map in the environments conifg:
+        environments:
+        dev-aws:
+            environment: "dev"
+            kubernetes:
+            namespace: "sgp-000-hello-acp"
+            auth:
+            principal:
+                user_id: 73d0c8bd-4726-434c-9686-eb627d89f078
+                account_id: 6887f093600ecd59bbbd3095
+            helm_overrides:
+
+        or: it it can be defined at the top level:
+        dev:
+            kubernetes:
+            namespace: "sgp-000-hello-acp"
+            auth:
+            principal:
+                user_id: 73d0c8bd-4726-434c-9686-eb627d89f078
+                account_id: 6887f093600ecd59bbbd3095
+            helm_overrides:
+
+        The principal must contain exactly one of `user_id` or `service_account_id`.
+        Use `service_account_id` to register an agent under a service account
+        instead of a personal user identity:
+        dev:
+            kubernetes:
+            namespace: "sgp-000-hello-acp"
+            auth:
+            principal:
+                service_account_id: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+                account_id: 6887f093600ecd59bbbd3095
+
+        if the environment field is not explicitly set, we assume its the same as
+        the name of the environment
+        Args:
+            env_target: Name of the environment target (e.g., 'dev', 'prod')
+
+        Returns:
+            AgentEnvironmentConfig for the specified environment
+
+        Raises:
+            ValueError: If environment is not found
+        """
+        envs_to_deploy = {}
+        if env_target in self.environments:
+            # this supports if the top-level key is just "dev, staging, etc" and matches
+            # the environment name exactly without any explicit mapping
+            envs_to_deploy[env_target] = self.environments[env_target]
+
+        for env_name, config in self.environments.items():
+            if config.environment == env_target:
+                envs_to_deploy[env_name] = config
+
+        if len(envs_to_deploy) == 0:
+            ## this just finds environments for each target, so "available_envs" refers to each target environment
+
+            available_envs = set()
+            for env_name, config in self.environments.items():
+                if config.environment is not None:
+                    available_envs.add(config.environment)
+                else:
+                    available_envs.add(env_name)
+            raise ValueError(
+                f"Environment '{env_target}' not found in environments.yaml. Available environments: {available_envs}"
+            )
+
+        return envs_to_deploy
+
+    def list_environments(self) -> list[str]:
+        """Get list of all configured environment names."""
+        return list(self.environments.keys())

--- a/src/agentex/config/local_development_config.py
+++ b/src/agentex/config/local_development_config.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import Field, field_validator
+
+from agentex.config._base import ConfigBaseModel
+
+
+class LocalAgentConfig(ConfigBaseModel):
+    """Configuration for local agent development"""
+
+    port: int = Field(
+        ...,
+        description="The port where the agent's ACP server is running locally",
+        gt=0,
+        lt=65536,
+    )
+    host_address: str = Field(
+        default="host.docker.internal",
+        description="The host address where the agent's ACP server can be reached (e.g., host.docker.internal for Docker, localhost for direct)",
+    )
+
+
+class LocalPathsConfig(ConfigBaseModel):
+    """Configuration for local file paths"""
+
+    acp: str = Field(
+        default="project/acp.py",
+        description="Path to the ACP server file. Can be relative to manifest directory or absolute.",
+    )
+    worker: str | None = Field(
+        default=None,
+        description="Path to the temporal worker file. Can be relative to manifest directory or absolute. (only for temporal agents)",
+    )
+
+    @field_validator("acp", "worker")
+    @classmethod
+    def validate_path_format(cls, v):
+        """Validate that the path is a reasonable format"""
+        if v is None:
+            return v
+
+        # Convert to Path to validate format
+        try:
+            Path(v)
+        except Exception as e:
+            raise ValueError(f"Invalid path format: {v}") from e
+
+        return v
+
+
+class LocalDevelopmentConfig(ConfigBaseModel):
+    """Configuration for local development environment"""
+
+    agent: LocalAgentConfig = Field(..., description="Local agent configuration")
+    paths: LocalPathsConfig | None = Field(
+        default=None, description="File paths for local development"
+    )

--- a/src/agentex/lib/cli/commands/agents.py
+++ b/src/agentex/lib/cli/commands/agents.py
@@ -22,7 +22,7 @@ from agentex.lib.cli.utils.kubectl_utils import (
     validate_namespace,
     check_and_switch_cluster_context,
 )
-from agentex.lib.sdk.config.agent_manifest import AgentManifest
+from agentex.lib.sdk.config.agent_manifest import load_agent_manifest
 from agentex.lib.cli.handlers.agent_handlers import (
     run_agent,
     build_agent,
@@ -281,7 +281,7 @@ def run(
     if cleanup_on_start:
         try:
             # Parse manifest to get agent name
-            manifest_obj = AgentManifest.from_yaml(file_path=manifest)
+            manifest_obj = load_agent_manifest(file_path=manifest)
             agent_name = manifest_obj.agent.name
 
             console.print(f"[yellow]Cleaning up existing workflows for agent '{agent_name}'...[/yellow]")
@@ -374,7 +374,7 @@ def deploy(
             raise typer.Exit(1) from e
 
         # Load manifest for credential validation
-        manifest_obj = AgentManifest.from_yaml(str(manifest_path))
+        manifest_obj = load_agent_manifest(str(manifest_path))
 
         # Use namespace from environment config if not overridden
         if not namespace and agent_env_config:

--- a/src/agentex/lib/cli/commands/secrets.py
+++ b/src/agentex/lib/cli/commands/secrets.py
@@ -14,7 +14,7 @@ from agentex.lib.cli.utils.kubectl_utils import (
     validate_namespace,
     check_and_switch_cluster_context,
 )
-from agentex.lib.sdk.config.agent_manifest import AgentManifest
+from agentex.lib.sdk.config.agent_manifest import load_agent_manifest
 from agentex.lib.cli.handlers.secret_handlers import (
     get_secret,
     sync_secrets,
@@ -157,7 +157,7 @@ def sync(
         )
         raise typer.Exit(1)
 
-    agent_manifest = AgentManifest.from_yaml(file_path=manifest)
+    agent_manifest = load_agent_manifest(file_path=manifest)
 
     # Always call sync_secrets - it will handle the case of no credentials
     sync_secrets(

--- a/src/agentex/lib/cli/handlers/agent_handlers.py
+++ b/src/agentex/lib/cli/handlers/agent_handlers.py
@@ -9,7 +9,7 @@ from python_on_whales import DockerException, docker
 from agentex.lib.cli.debug import DebugConfig
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.cli.handlers.run_handlers import RunError, run_agent as _run_agent
-from agentex.lib.sdk.config.agent_manifest import AgentManifest, BuildContextManager
+from agentex.lib.sdk.config.agent_manifest import BuildContextManager, load_agent_manifest, build_context_manager
 
 logger = make_logger(__name__)
 console = Console()
@@ -53,7 +53,7 @@ def build_agent(
     Returns:
         The image URL
     """
-    agent_manifest = AgentManifest.from_yaml(file_path=manifest_path)
+    agent_manifest = load_agent_manifest(file_path=manifest_path)
     build_context_root = (Path(manifest_path).parent / agent_manifest.build.context.root).resolve()
 
     repository_name = repository_name or agent_manifest.agent.name
@@ -69,7 +69,7 @@ def build_agent(
     else:
         image_name = f"{image_name}:latest"
 
-    with agent_manifest.context_manager(build_context_root) as build_context:
+    with build_context_manager(agent_manifest, build_context_root) as build_context:
         logger.info(f"Building image {image_name} locally...")
 
         # Log build context information for debugging
@@ -208,7 +208,7 @@ def prepare_cloud_build_context(
     Returns:
         CloudBuildContext containing the archive bytes, dockerfile path, and metadata
     """
-    agent_manifest = AgentManifest.from_yaml(file_path=manifest_path)
+    agent_manifest = load_agent_manifest(file_path=manifest_path)
     build_context_root = (Path(manifest_path).parent / agent_manifest.build.context.root).resolve()
 
     agent_name = agent_manifest.agent.name
@@ -260,7 +260,7 @@ def prepare_cloud_build_context(
 
     logger.info("Preparing build context...")
 
-    with agent_manifest.context_manager(build_context_root) as build_context:
+    with build_context_manager(agent_manifest, build_context_root) as build_context:
         # Compress the prepared context using the static zipped method
         with BuildContextManager.zipped(root_path=build_context.path) as archive_buffer:
             archive_bytes = archive_buffer.read()

--- a/src/agentex/lib/cli/handlers/deploy_handlers.py
+++ b/src/agentex/lib/cli/handlers/deploy_handlers.py
@@ -11,13 +11,15 @@ from pydantic import Field, BaseModel
 from rich.console import Console
 
 from agentex.lib.utils.logging import make_logger
+from agentex.config.agent_config import AgentConfig
+from agentex.config.agent_manifest import AgentManifest
 from agentex.lib.cli.utils.exceptions import HelmError, DeploymentError
 from agentex.lib.cli.utils.path_utils import PathResolutionError, calculate_docker_acp_module
+from agentex.config.environment_config import OciRegistryConfig, AgentEnvironmentConfig
 from agentex.lib.environment_variables import EnvVarKeys
 from agentex.lib.cli.utils.kubectl_utils import check_and_switch_cluster_context
-from agentex.lib.sdk.config.agent_config import AgentConfig
-from agentex.lib.sdk.config.agent_manifest import AgentManifest
-from agentex.lib.sdk.config.environment_config import OciRegistryConfig, AgentEnvironmentConfig
+from agentex.lib.sdk.config.agent_manifest import load_agent_manifest
+from agentex.lib.sdk.config.environment_config import load_environments_config_from_manifest_dir
 
 logger = make_logger(__name__)
 console = Console()
@@ -461,13 +463,13 @@ def deploy_agent(
     # Switch to the specified cluster context
     check_and_switch_cluster_context(cluster_name)
 
-    manifest = AgentManifest.from_yaml(file_path=manifest_path)
+    manifest = load_agent_manifest(file_path=manifest_path)
 
     # Load agent environment configuration
     agent_env_config = None
     if environment_name:
         manifest_dir = Path(manifest_path).parent
-        environments_config = manifest.load_environments_config(manifest_dir)
+        environments_config = load_environments_config_from_manifest_dir(manifest_dir)
         if environments_config:
             agent_env_config = environments_config.get_config_for_env(environment_name)
             console.print(f"[green]✓[/green] Using environment config: {environment_name}")

--- a/src/agentex/lib/cli/handlers/run_handlers.py
+++ b/src/agentex/lib/cli/handlers/run_handlers.py
@@ -11,12 +11,13 @@ from rich.console import Console
 # Import debug functionality
 from agentex.lib.cli.debug import DebugConfig, start_acp_server_debug, start_temporal_worker_debug
 from agentex.lib.utils.logging import make_logger
+from agentex.config.agent_manifest import AgentManifest
 from agentex.lib.cli.utils.path_utils import (
     get_file_paths,
     calculate_uvicorn_target_for_local,
 )
 from agentex.lib.environment_variables import EnvVarKeys
-from agentex.lib.sdk.config.agent_manifest import AgentManifest
+from agentex.lib.sdk.config.agent_manifest import load_agent_manifest
 from agentex.lib.cli.handlers.cleanup_handlers import cleanup_agent_workflows, should_cleanup_on_restart
 
 logger = make_logger(__name__)
@@ -263,7 +264,7 @@ async def run_agent(manifest_path: str, debug_config: "DebugConfig | None" = Non
 
     # Parse manifest
     try:
-        manifest = AgentManifest.from_yaml(file_path=manifest_path)
+        manifest = load_agent_manifest(file_path=manifest_path)
     except Exception as e:
         raise RunError(f"Failed to parse manifest: {str(e)}") from e
 

--- a/src/agentex/lib/cli/handlers/secret_handlers.py
+++ b/src/agentex/lib/cli/handlers/secret_handlers.py
@@ -13,16 +13,16 @@ from rich.console import Console
 from kubernetes.client.rest import ApiException
 
 from agentex.lib.utils.logging import make_logger
-from agentex.lib.types.credentials import CredentialMapping
+from agentex.config.credentials import CredentialMapping
+from agentex.config.agent_config import AgentConfig
+from agentex.config.agent_manifest import AgentManifest
 from agentex.lib.cli.utils.cli_utils import handle_questionary_cancellation
-from agentex.lib.cli.utils.kubectl_utils import get_k8s_client
-from agentex.lib.sdk.config.agent_config import AgentConfig
-from agentex.lib.sdk.config.agent_manifest import AgentManifest
-from agentex.lib.sdk.config.deployment_config import (
+from agentex.config.deployment_config import (
     DeploymentConfig,
     ImagePullSecretConfig,
     InjectedSecretsValues,
 )
+from agentex.lib.cli.utils.kubectl_utils import get_k8s_client
 from agentex.lib.cli.utils.kubernetes_secrets_utils import (
     VALID_SECRET_TYPES,
     KUBERNETES_SECRET_TYPE_OPAQUE,

--- a/src/agentex/lib/cli/utils/auth_utils.py
+++ b/src/agentex/lib/cli/utils/auth_utils.py
@@ -4,8 +4,8 @@ import json
 import base64
 from typing import Any, Dict
 
-from agentex.lib.sdk.config.agent_manifest import AgentManifest
-from agentex.lib.sdk.config.environment_config import AgentAuthConfig
+from agentex.config.agent_manifest import AgentManifest
+from agentex.config.environment_config import AgentAuthConfig
 
 
 # DEPRECATED: Old function for backward compatibility

--- a/src/agentex/lib/cli/utils/credential_utils.py
+++ b/src/agentex/lib/cli/utils/credential_utils.py
@@ -3,7 +3,7 @@ import subprocess
 from rich.prompt import Prompt, Confirm
 from rich.console import Console
 
-from agentex.lib.types.credentials import CredentialMapping
+from agentex.config.credentials import CredentialMapping
 
 console = Console()
 

--- a/src/agentex/lib/cli/utils/path_utils.py
+++ b/src/agentex/lib/cli/utils/path_utils.py
@@ -4,7 +4,7 @@ from typing import Dict
 from pathlib import Path
 
 from agentex.lib.utils.logging import make_logger
-from agentex.lib.sdk.config.agent_manifest import AgentManifest
+from agentex.config.agent_manifest import AgentManifest
 
 logger = make_logger(__name__)
 

--- a/src/agentex/lib/sdk/config/agent_config.py
+++ b/src/agentex/lib/sdk/config/agent_config.py
@@ -1,67 +1,7 @@
-from __future__ import annotations
+"""Back-compat shim. The canonical location is :mod:`agentex.config.agent_config`.
 
-from typing import Any, Literal
+Kept here so existing ``from agentex.lib.sdk.config.agent_config import ...``
+imports continue to work. New code should import from the canonical path.
+"""
 
-from pydantic import Field
-
-from agentex.lib.utils.logging import make_logger
-from agentex.lib.types.credentials import CredentialMapping
-from agentex.lib.utils.model_utils import BaseModel
-from agentex.lib.types.agent_configs import TemporalConfig, TemporalWorkflowConfig
-
-logger = make_logger(__name__)
-
-
-class AgentConfig(BaseModel):
-    name: str = Field(
-        ...,
-        description="The name of the agent.",
-        pattern=r"^[a-z0-9-]+$",
-    )
-    acp_type: Literal["sync", "async", "agentic"] = Field(..., description="The type of agent.")
-    agent_input_type: Literal["text", "json"] | None = Field(
-        default=None,
-        description="The type of input the agent accepts."
-    )
-    description: str = Field(..., description="The description of the agent.")
-    env: dict[str, str] | None = Field(
-        default=None, description="Environment variables to set directly in the agent deployment"
-    )
-    credentials: list[CredentialMapping | dict[str, Any]] | None = Field(
-        default=None,
-        description="List of credential mappings to mount to the agent deployment. Supports both legacy format and new typed credentials.",
-    )
-    temporal: TemporalConfig | None = Field(
-        default=None, description="Temporal workflow configuration for this agent"
-    )
-
-    def is_temporal_agent(self) -> bool:
-        """Check if this agent uses Temporal workflows"""
-        # Check temporal config with enabled flag
-        if self.temporal and self.temporal.enabled:
-            return True
-        return False
-
-    def get_temporal_workflow_config(self) -> TemporalWorkflowConfig | None:
-        """Get temporal workflow configuration, checking both new and legacy formats"""
-        # Check new workflows list first
-        if self.temporal and self.temporal.enabled and self.temporal.workflows:
-            return self.temporal.workflows[0]  # Return first workflow for backward compatibility
-
-        # Check legacy single workflow
-        if self.temporal and self.temporal.enabled and self.temporal.workflow:
-            return self.temporal.workflow
-
-        return None
-
-    def get_temporal_workflows(self) -> list[TemporalWorkflowConfig]:
-        """Get all temporal workflow configurations"""
-        # Check new workflows list first
-        if self.temporal and self.temporal.enabled and self.temporal.workflows:
-            return self.temporal.workflows
-
-        # Check legacy single workflow
-        if self.temporal and self.temporal.enabled and self.temporal.workflow:
-            return [self.temporal.workflow]
-
-        return []
+from agentex.config.agent_config import AgentConfig  # noqa: F401

--- a/src/agentex/lib/sdk/config/agent_manifest.py
+++ b/src/agentex/lib/sdk/config/agent_manifest.py
@@ -1,3 +1,13 @@
+"""Back-compat shim, manifest loader, and Docker build-context machinery.
+
+The :class:`AgentManifest` model's canonical location is
+:mod:`agentex.config.agent_manifest`; it is re-exported here so existing
+``from agentex.lib.sdk.config.agent_manifest import AgentManifest`` imports keep
+working. The yaml loader (`load_agent_manifest`) and build machinery
+(`build_context_manager`, `BuildContextManager`) stay here (CLI/build-side) so
+the promoted model remains slim-safe.
+"""
+
 from __future__ import annotations
 
 import io
@@ -11,58 +21,21 @@ from pathlib import Path
 from contextlib import contextmanager
 from collections.abc import Iterator
 
-from pydantic import Field
-
+from agentex.lib.utils.io import load_yaml_file
 from agentex.lib.utils.logging import make_logger
-from agentex.lib.utils.model_utils import BaseModel
-from agentex.lib.sdk.config.agent_config import AgentConfig
-from agentex.lib.sdk.config.build_config import BuildConfig
-from agentex.lib.sdk.config.deployment_config import DeploymentConfig
-from agentex.lib.sdk.config.environment_config import AgentEnvironmentsConfig
-from agentex.lib.sdk.config.local_development_config import LocalDevelopmentConfig
+from agentex.config.agent_manifest import AgentManifest  # noqa: F401
 
 logger = make_logger(__name__)
 
 
-class AgentManifest(BaseModel):
-    """
-    Represents a manifest file that describes how to build and deploy an agent.
-    """
-
-    build: BuildConfig
-    agent: AgentConfig
-    local_development: LocalDevelopmentConfig | None = Field(
-        default=None, description="Configuration for local development"
-    )
-    deployment: DeploymentConfig | None = Field(
-        default=None, description="Deployment configuration for the agent"
-    )
+def load_agent_manifest(file_path: str) -> AgentManifest:
+    """Load and validate a manifest.yaml file into an AgentManifest."""
+    return AgentManifest.model_validate(load_yaml_file(file_path=file_path))
 
 
-    def context_manager(self, build_context_root: Path) -> BuildContextManager:
-        """
-        Creates a build context manager
-        """
-        return BuildContextManager(
-            agent_manifest=self, build_context_root=build_context_root
-        )
-    
-    def load_environments_config(self, manifest_dir: Path) -> "AgentEnvironmentsConfig | None":
-        """Load environments.yaml from same directory as manifest.yaml.
-        
-        Args:
-            manifest_dir: Directory containing manifest.yaml
-            
-        Returns:
-            AgentEnvironmentsConfig if environments.yaml exists, None otherwise
-            
-        Raises:
-            ValueError: If environments.yaml exists but is invalid
-        """
-        # Import here to avoid circular imports
-        from agentex.lib.sdk.config.environment_config import load_environments_config_from_manifest_dir
-        
-        return load_environments_config_from_manifest_dir(manifest_dir)
+def build_context_manager(agent_manifest: AgentManifest, build_context_root: Path) -> BuildContextManager:
+    """Create a build context manager for the given manifest."""
+    return BuildContextManager(agent_manifest=agent_manifest, build_context_root=build_context_root)
 
 
 class BuildContextManager:

--- a/src/agentex/lib/sdk/config/build_config.py
+++ b/src/agentex/lib/sdk/config/build_config.py
@@ -1,37 +1,10 @@
-from __future__ import annotations
+"""Back-compat shim. The canonical location is :mod:`agentex.config.build_config`.
 
-from pydantic import Field
+Kept here so existing ``from agentex.lib.sdk.config.build_config import ...``
+imports continue to work. New code should import from the canonical path.
+"""
 
-from agentex.lib.utils.model_utils import BaseModel
-
-
-class BuildContext(BaseModel):
-    """
-    Represents the context in which the Docker image should be built.
-    """
-
-    root: str = Field(
-        ...,
-        description="The root directory of the build context. Should be specified relative to the location of the "
-        "build config file.",
-    )
-    include_paths: list[str] = Field(
-        default_factory=list,
-        description="The paths to include in the build context. Should be specified relative to the root directory.",
-    )
-    dockerfile: str = Field(
-        ...,
-        description="The path to the Dockerfile. Should be specified relative to the root directory.",
-    )
-    dockerignore: str | None = Field(
-        None,
-        description="The path to the .dockerignore file. Should be specified relative to the root directory.",
-    )
-
-
-class BuildConfig(BaseModel):
-    """
-    Represents a configuration for building the action as a Docker image.
-    """
-
-    context: BuildContext
+from agentex.config.build_config import (  # noqa: F401
+    BuildConfig,
+    BuildContext,
+)

--- a/src/agentex/lib/sdk/config/deployment_config.py
+++ b/src/agentex/lib/sdk/config/deployment_config.py
@@ -1,123 +1,18 @@
-from __future__ import annotations
+"""Back-compat shim. The canonical location is :mod:`agentex.config.deployment_config`.
 
-from typing import Any, Dict
+Kept here so existing ``from agentex.lib.sdk.config.deployment_config import ...``
+imports continue to work. New code should import from the canonical path.
+"""
 
-from pydantic import Field
-
-from agentex.lib.utils.model_utils import BaseModel
-
-
-class ImageConfig(BaseModel):
-    """Configuration for container images"""
-
-    repository: str = Field(..., description="Container image repository URL")
-    tag: str = Field(default="latest", description="Container image tag")
-
-
-class ImagePullSecretConfig(BaseModel):
-    """Configuration for image pull secrets"""
-
-    name: str = Field(..., description="Name of the image pull secret")
-
-
-class ResourceRequirements(BaseModel):
-    """Resource requirements for containers"""
-
-    cpu: str = Field(
-        default="500m", description="CPU request/limit (e.g., '500m', '1')"
-    )
-    memory: str = Field(
-        default="1Gi", description="Memory request/limit (e.g., '1Gi', '512Mi')"
-    )
-
-
-class ResourceConfig(BaseModel):
-    """Resource configuration for containers"""
-
-    requests: ResourceRequirements = Field(
-        default_factory=ResourceRequirements, description="Resource requests"
-    )
-    limits: ResourceRequirements = Field(
-        default_factory=ResourceRequirements, description="Resource limits"
-    )
-
-
-class GlobalDeploymentConfig(BaseModel):
-    """Global deployment configuration that applies to all clusters"""
-
-    agent: dict[str, str] = Field(
-        default_factory=dict, description="Agent metadata (name, description)"
-    )
-    replicaCount: int = Field(default=1, description="Number of replicas to deploy")
-    resources: ResourceConfig = Field(
-        default_factory=ResourceConfig, description="Resource requirements"
-    )
-
-
-class DeploymentConfig(BaseModel):
-    """Main deployment configuration in the manifest"""
-
-    image: ImageConfig = Field(..., description="Container image configuration")
-    imagePullSecrets: list[ImagePullSecretConfig] | None = Field(
-        default=None, description="Image pull secrets to use for the deployment"
-    )
-    global_config: GlobalDeploymentConfig = Field(
-        default_factory=GlobalDeploymentConfig,
-        description="Global deployment settings",
-        alias="global",
-    )
-
-    class Config:
-        validate_by_name = True
-
-
-class ClusterConfig(BaseModel):
-    """Per-cluster deployment overrides"""
-
-    image: ImageConfig | None = Field(
-        default=None, description="Cluster-specific image overrides"
-    )
-    replicaCount: int | None = Field(
-        default=None, description="Cluster-specific replica count"
-    )
-    resources: ResourceConfig | None = Field(
-        default=None, description="Cluster-specific resource overrides"
-    )
-    env: list[dict[str, str]] | None = Field(
-        default=None, description="Additional environment variables for this cluster"
-    )
-    # Allow additional arbitrary overrides for advanced users
-    additional_overrides: dict[str, Any] | None = Field(
-        default=None, description="Additional helm chart value overrides"
-    )
-
-
-class AuthenticationConfig(BaseModel):
-    principal: Dict[str, Any] = Field(description="Principal used for authorization on registration")
-
-
-class InjectedImagePullSecretValues(BaseModel):
-    """Values for image pull secrets"""
-
-    registry: str = Field(..., description="Registry of the image pull secret")
-    username: str = Field(..., description="Username of the image pull secret")
-    password: str = Field(..., description="Password of the image pull secret")
-    email: str | None = Field(
-        default=None, description="Email of the image pull secret"
-    )
-
-
-class InjectedSecretsValues(BaseModel):
-    """Values for injected secrets"""
-
-    # Defined as a dictionary because the names need to be unique
-    credentials: dict[str, Any] = Field(
-        default_factory=dict, description="Secrets to inject into the deployment"
-    )
-    imagePullSecrets: dict[str, InjectedImagePullSecretValues] = Field(
-        default_factory=dict,
-        description="Image pull secrets to inject into the deployment",
-    )
-
-    class Config:
-        validate_by_name = True
+from agentex.config.deployment_config import (  # noqa: F401
+    ImageConfig,
+    ClusterConfig,
+    ResourceConfig,
+    DeploymentConfig,
+    AuthenticationConfig,
+    ResourceRequirements,
+    ImagePullSecretConfig,
+    InjectedSecretsValues,
+    GlobalDeploymentConfig,
+    InjectedImagePullSecretValues,
+)

--- a/src/agentex/lib/sdk/config/environment_config.py
+++ b/src/agentex/lib/sdk/config/environment_config.py
@@ -1,253 +1,57 @@
-"""
-Environment-specific configuration models for agent deployments.
+"""Back-compat shim and yaml loaders for environment configuration.
 
-This module provides Pydantic models for managing environment-specific
-configurations that are separate from the main manifest.yaml file.
+The model classes' canonical location is
+:mod:`agentex.config.environment_config`; they are re-exported here so existing
+``from agentex.lib.sdk.config.environment_config import ...`` imports keep
+working. The yaml-loading helpers stay here (CLI/build-side) so the promoted
+models remain slim-safe.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, override
 from pathlib import Path
 
 import yaml
-from pydantic import Field, BaseModel, field_validator
 
-from agentex.lib.utils.model_utils import BaseModel as UtilsBaseModel
-
-
-class AgentAuthConfig(BaseModel):
-    """Authentication configuration for an agent in a specific environment."""
-
-    principal: Dict[str, Any] = Field(
-        ..., description="Principal configuration for agent authorization and registration"
-    )
-
-    @field_validator("principal")
-    @classmethod
-    def validate_principal_required_fields(cls, v: Any) -> Dict[str, Any]:
-        """Ensure principal has required fields for agent registration."""
-        if not isinstance(v, dict):
-            raise ValueError("Principal must be a dictionary")
-        return v
+from agentex.config.environment_config import (  # noqa: F401
+    AgentAuthConfig,
+    OciRegistryConfig,
+    AgentKubernetesConfig,
+    AgentEnvironmentConfig,
+    AgentEnvironmentsConfig,
+)
 
 
-class AgentKubernetesConfig(BaseModel):
-    """Kubernetes configuration for an agent in a specific environment."""
+def load_environments_config(file_path: str) -> AgentEnvironmentsConfig:
+    """Load and validate an environments.yaml into an AgentEnvironmentsConfig.
 
-    namespace: str = Field(..., description="Kubernetes namespace where the agent will be deployed")
+    Args:
+        file_path: Path to environments.yaml file
 
-    @field_validator("namespace")
-    @classmethod
-    def validate_namespace_format(cls, v: str) -> str:
-        """Ensure namespace follows Kubernetes naming conventions."""
-        if not v or not v.strip():
-            raise ValueError("Namespace cannot be empty")
+    Returns:
+        Parsed and validated AgentEnvironmentsConfig
 
-        # Basic Kubernetes namespace validation
-        namespace = v.strip().lower()
-        if not namespace.replace("-", "").replace(".", "").isalnum():
-            raise ValueError(f"Namespace '{v}' must contain only lowercase letters, numbers, hyphens, and periods")
+    Raises:
+        FileNotFoundError: If file doesn't exist
+        ValueError: If file is invalid or doesn't validate
+    """
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"environments.yaml not found: {file_path}")
 
-        if len(namespace) > 63:
-            raise ValueError(f"Namespace '{v}' cannot exceed 63 characters")
+    try:
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
 
-        return namespace
+        if not data:
+            raise ValueError("environments.yaml file is empty")
 
+        return AgentEnvironmentsConfig.model_validate(data)
 
-class OciRegistryConfig(BaseModel):
-    """OCI registry configuration for Helm chart deployments."""
-
-    url: str = Field(
-        ...,
-        description="OCI registry URL for Helm charts (e.g., 'us-west1-docker.pkg.dev/project/repo'). "
-        "When set, OCI mode is used instead of classic helm repo.",
-    )
-    provider: Literal["gar"] | None = Field(
-        default=None,
-        description="OCI registry provider for provider-specific features. "
-        "Set to 'gar' for Google Artifact Registry to enable auto-authentication via gcloud "
-        "and latest version fetching. When not set, assumes user has already authenticated.",
-    )
-    chart_version: str | None = Field(
-        default=None, description="Helm chart version to deploy. If not set, uses the default version from the CLI."
-    )
-
-
-class AgentEnvironmentConfig(BaseModel):
-    """Complete configuration for an agent in a specific environment."""
-
-    kubernetes: AgentKubernetesConfig | None = Field(default=None, description="Kubernetes deployment configuration")
-    environment: str | None = Field(
-        default=None,
-        description="The environment keyword that this specific environment maps to: either dev, staging, prod",
-    )
-    auth: AgentAuthConfig = Field(..., description="Authentication and authorization configuration")
-    helm_repository_name: str = Field(default="scale-egp", description="Helm repository name for the environment")
-    helm_repository_url: str = Field(
-        default="https://scale-egp-helm-charts-us-west-2.s3.amazonaws.com/charts",
-        description="Helm repository url for the environment (classic mode)",
-    )
-    oci_registry: OciRegistryConfig | None = Field(
-        default=None, description="OCI registry configuration. When set, OCI mode is used instead of classic helm repo."
-    )
-    helm_overrides: Dict[str, Any] = Field(
-        default_factory=dict, description="Helm chart value overrides for environment-specific tuning"
-    )
-
-
-class AgentEnvironmentsConfig(UtilsBaseModel):
-    """All environment configurations for an agent."""
-
-    schema_version: str = Field(default="v1", description="Schema version for validation and compatibility")
-    environments: Dict[str, AgentEnvironmentConfig] = Field(
-        ..., description="Environment-specific configurations (dev, prod, etc.)"
-    )
-
-    @field_validator("schema_version")
-    @classmethod
-    def validate_schema_version(cls, v: str) -> str:
-        """Ensure schema version is supported."""
-        supported_versions = ["v1"]
-        if v not in supported_versions:
-            raise ValueError(f"Schema version '{v}' not supported. Supported versions: {', '.join(supported_versions)}")
-        return v
-
-    @field_validator("environments")
-    @classmethod
-    def validate_environments_not_empty(cls, v: Dict[str, AgentEnvironmentConfig]) -> Dict[str, AgentEnvironmentConfig]:
-        """Ensure at least one environment is defined."""
-        if not v:
-            raise ValueError("At least one environment must be defined")
-        return v
-
-    def get_config_for_env(self, env_name: str) -> AgentEnvironmentConfig:
-        """Get configuration for a specific environment.
-
-        Args:
-            env_name: Name of the environment (e.g., 'dev', 'prod')
-
-        Returns:
-            AgentEnvironmentConfig for the specified environment
-
-        Raises:
-            ValueError: If environment is not found
-        """
-        if env_name not in self.environments:
-            available_envs = ", ".join(self.environments.keys())
-            raise ValueError(
-                f"Environment '{env_name}' not found in environments.yaml. Available environments: {available_envs}"
-            )
-        return self.environments[env_name]
-
-    def get_configs_for_env(self, env_target: str) -> dict[str, AgentEnvironmentConfig]:
-        """Get configuration for a specific environment based on the expected mapping.
-        The environment is either:
-        1. explicitly specified like so using a key-map in the environments conifg:
-        environments:
-        dev-aws:
-            environment: "dev"
-            kubernetes:
-            namespace: "sgp-000-hello-acp"
-            auth:
-            principal:
-                user_id: 73d0c8bd-4726-434c-9686-eb627d89f078
-                account_id: 6887f093600ecd59bbbd3095
-            helm_overrides:
-
-        or: it it can be defined at the top level:
-        dev:
-            kubernetes:
-            namespace: "sgp-000-hello-acp"
-            auth:
-            principal:
-                user_id: 73d0c8bd-4726-434c-9686-eb627d89f078
-                account_id: 6887f093600ecd59bbbd3095
-            helm_overrides:
-
-        The principal must contain exactly one of `user_id` or `service_account_id`.
-        Use `service_account_id` to register an agent under a service account
-        instead of a personal user identity:
-        dev:
-            kubernetes:
-            namespace: "sgp-000-hello-acp"
-            auth:
-            principal:
-                service_account_id: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
-                account_id: 6887f093600ecd59bbbd3095
-
-        if the environment field is not explicitly set, we assume its the same as
-        the name of the environment
-        Args:
-            env_target: Name of the environment target (e.g., 'dev', 'prod')
-
-        Returns:
-            AgentEnvironmentConfig for the specified environment
-
-        Raises:
-            ValueError: If environment is not found
-        """
-        envs_to_deploy = {}
-        if env_target in self.environments:
-            # this supports if the top-level key is just "dev, staging, etc" and matches
-            # the environment name exactly without any explicit mapping
-            envs_to_deploy[env_target] = self.environments[env_target]
-
-        for env_name, config in self.environments.items():
-            if config.environment == env_target:
-                envs_to_deploy[env_name] = config
-
-        if len(envs_to_deploy) == 0:
-            ## this just finds environments for each target, so "available_envs" refers to each target environment
-
-            available_envs = set()
-            for env_name, config in self.environments.items():
-                if config.environment is not None:
-                    available_envs.add(config.environment)
-                else:
-                    available_envs.add(env_name)
-            raise ValueError(
-                f"Environment '{env_target}' not found in environments.yaml. Available environments: {available_envs}"
-            )
-
-        return envs_to_deploy
-
-    def list_environments(self) -> list[str]:
-        """Get list of all configured environment names."""
-        return list(self.environments.keys())
-
-    @classmethod
-    @override
-    def from_yaml(cls, file_path: str) -> "AgentEnvironmentsConfig":
-        """Load configuration from environments.yaml file.
-
-        Args:
-            file_path: Path to environments.yaml file
-
-        Returns:
-            Parsed and validated AgentEnvironmentsConfig
-
-        Raises:
-            FileNotFoundError: If file doesn't exist
-            ValueError: If file is invalid or doesn't validate
-        """
-        path = Path(file_path)
-        if not path.exists():
-            raise FileNotFoundError(f"environments.yaml not found: {file_path}")
-
-        try:
-            with open(path, "r") as f:
-                data = yaml.safe_load(f)
-
-            if not data:
-                raise ValueError("environments.yaml file is empty")
-
-            return cls.model_validate(data)
-
-        except yaml.YAMLError as e:
-            raise ValueError(f"Invalid YAML format in {file_path}: {e}") from e
-        except Exception as e:
-            raise ValueError(f"Failed to load environments.yaml from {file_path}: {e}") from e
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML format in {file_path}: {e}") from e
+    except Exception as e:
+        raise ValueError(f"Failed to load environments.yaml from {file_path}: {e}") from e
 
 
 def load_environments_config_from_manifest_dir(manifest_dir: Path) -> AgentEnvironmentsConfig | None:
@@ -266,4 +70,4 @@ def load_environments_config_from_manifest_dir(manifest_dir: Path) -> AgentEnvir
     if not environments_file.exists():
         return None
 
-    return AgentEnvironmentsConfig.from_yaml(str(environments_file))
+    return load_environments_config(str(environments_file))

--- a/src/agentex/lib/sdk/config/local_development_config.py
+++ b/src/agentex/lib/sdk/config/local_development_config.py
@@ -1,58 +1,11 @@
-from __future__ import annotations
+"""Back-compat shim. The canonical location is :mod:`agentex.config.local_development_config`.
 
-from pathlib import Path
+Kept here so existing ``from agentex.lib.sdk.config.local_development_config
+import ...`` imports continue to work. New code should import from the canonical path.
+"""
 
-from pydantic import Field, validator
-
-from agentex.lib.utils.model_utils import BaseModel
-
-
-class LocalAgentConfig(BaseModel):
-    """Configuration for local agent development"""
-
-    port: int = Field(
-        ...,
-        description="The port where the agent's ACP server is running locally",
-        gt=0,
-        lt=65536,
-    )
-    host_address: str = Field(
-        default="host.docker.internal",
-        description="The host address where the agent's ACP server can be reached (e.g., host.docker.internal for Docker, localhost for direct)",
-    )
-
-
-class LocalPathsConfig(BaseModel):
-    """Configuration for local file paths"""
-
-    acp: str = Field(
-        default="project/acp.py",
-        description="Path to the ACP server file. Can be relative to manifest directory or absolute.",
-    )
-    worker: str | None = Field(
-        default=None,
-        description="Path to the temporal worker file. Can be relative to manifest directory or absolute. (only for temporal agents)",
-    )
-
-    @validator("acp", "worker")
-    def validate_path_format(cls, v):
-        """Validate that the path is a reasonable format"""
-        if v is None:
-            return v
-
-        # Convert to Path to validate format
-        try:
-            Path(v)
-        except Exception as e:
-            raise ValueError(f"Invalid path format: {v}") from e
-
-        return v
-
-
-class LocalDevelopmentConfig(BaseModel):
-    """Configuration for local development environment"""
-
-    agent: LocalAgentConfig = Field(..., description="Local agent configuration")
-    paths: LocalPathsConfig | None = Field(
-        default=None, description="File paths for local development"
-    )
+from agentex.config.local_development_config import (  # noqa: F401
+    LocalAgentConfig,
+    LocalPathsConfig,
+    LocalDevelopmentConfig,
+)

--- a/src/agentex/lib/sdk/config/validation.py
+++ b/src/agentex/lib/sdk/config/validation.py
@@ -11,7 +11,8 @@ from typing import Any, Dict, List, Optional
 from pathlib import Path
 
 from agentex.lib.utils.logging import make_logger
-from agentex.lib.sdk.config.environment_config import AgentEnvironmentConfig, AgentEnvironmentsConfig
+from agentex.config.environment_config import AgentEnvironmentConfig, AgentEnvironmentsConfig
+from agentex.lib.sdk.config.environment_config import load_environments_config
 
 logger = make_logger(__name__)
 
@@ -166,7 +167,7 @@ def validate_environments_yaml_file(file_path: str) -> AgentEnvironmentsConfig:
         EnvironmentsValidationError: If file is invalid
     """
     try:
-        environments_config = AgentEnvironmentsConfig.from_yaml(file_path)
+        environments_config = load_environments_config(file_path)
         validate_environments_config(environments_config)
         return environments_config
     except FileNotFoundError:

--- a/src/agentex/lib/types/agent_configs.py
+++ b/src/agentex/lib/types/agent_configs.py
@@ -1,86 +1,11 @@
-from __future__ import annotations
+"""Back-compat shim. The canonical location is :mod:`agentex.config.agent_configs`.
 
-from pydantic import Field, BaseModel, validator, model_validator
+Kept here so existing ``from agentex.lib.types.agent_configs import ...`` imports
+continue to work. New code should import from the canonical path.
+"""
 
-
-class TemporalWorkflowConfig(BaseModel):
-    """
-    Configuration for the temporal workflow that defines the agent.
-
-    Attributes:
-        name: The name of the temporal workflow that defines the agent.
-        queue_name: The name of the temporal queue to send tasks to.
-    """
-
-    name: str = Field(
-        ..., description="The name of the temporal workflow that defines the agent."
-    )
-    queue_name: str = Field(
-        ..., description="The name of the temporal queue to send tasks to."
-    )
-
-
-# TODO: Remove this class when we remove the agentex agents create
-class TemporalWorkerConfig(BaseModel):
-    """
-    Configuration for temporal worker deployment
-
-    Attributes:
-        image: The image to use for the temporal worker
-        workflow: The temporal workflow configuration
-    """
-
-    image: str | None = Field(
-        default=None, description="Image to use for the temporal worker"
-    )
-    workflow: TemporalWorkflowConfig | None = Field(
-        default=None,
-        description="Configuration for the temporal workflow that defines the agent. Only required for agents that leverage Temporal.",
-    )
-
-
-class TemporalConfig(BaseModel):
-    """
-    Simplified temporal configuration for agents
-
-    Attributes:
-        enabled: Whether this agent uses Temporal workflows
-        workflow: The temporal workflow configuration
-        workflows: The list of temporal workflow configurations
-        health_check_port: Port for temporal worker health check endpoint
-    """
-
-    enabled: bool = Field(
-        default=False, description="Whether this agent uses Temporal workflows"
-    )
-    workflow: TemporalWorkflowConfig | None = Field(
-        default=None,
-        description="Temporal workflow configuration. Required when enabled=True. (deprecated: use workflows instead)",
-    )
-    workflows: list[TemporalWorkflowConfig] | None = Field(
-        default=None,
-        description="List of temporal workflow configurations. Used when enabled=true.",
-    )
-    health_check_port: int | None = Field(
-        default=None,
-        description="Port for temporal worker health check endpoint. Defaults to 80 if not specified.",
-    )
-
-    @validator("workflows")
-    def validate_workflows_not_empty(cls, v):
-        """Ensure workflows list is not empty when provided"""
-        if v is not None and len(v) == 0:
-            raise ValueError("workflows list cannot be empty when provided")
-        return v
-
-    @model_validator(mode="after")
-    def validate_temporal_config_when_enabled(self):
-        """Validate that workflow configuration exists when enabled=true"""
-        if self.enabled:
-            # Must have either workflow (legacy) or workflows (new)
-            if not self.workflow and (not self.workflows or len(self.workflows) == 0):
-                raise ValueError(
-                    "When temporal.enabled=true, either 'workflow' or 'workflows' must be provided and non-empty"
-                )
-
-        return self
+from agentex.config.agent_configs import (  # noqa: F401
+    TemporalConfig,
+    TemporalWorkerConfig,
+    TemporalWorkflowConfig,
+)

--- a/src/agentex/lib/types/credentials.py
+++ b/src/agentex/lib/types/credentials.py
@@ -1,34 +1,7 @@
-from pydantic import Field, BaseModel
+"""Back-compat shim. The canonical location is :mod:`agentex.config.credentials`.
 
+Kept here so existing ``from agentex.lib.types.credentials import ...`` imports
+continue to work. New code should import from the canonical path.
+"""
 
-class CredentialMapping(BaseModel):
-    """Maps a Kubernetes secret to an environment variable in the agent container.
-
-    This allows agents to securely access credentials stored in Kubernetes secrets
-    by mapping them to environment variables. For example, you can map a secret
-    containing an API key to an environment variable that your agent code expects.
-
-    Example:
-        A mapping of {"env_var_name": "OPENAI_API_KEY",
-                     "secret_name": "ai-credentials",
-                     "secret_key": "openai-key"}
-        will make the value from the "openai-key" field in the "ai-credentials"
-        Kubernetes secret available to the agent as OPENAI_API_KEY environment variable.
-
-    Attributes:
-        env_var_name: The name of the environment variable that will be available to the agent
-        secret_name: The name of the Kubernetes secret containing the credential
-        secret_key: The key within the Kubernetes secret that contains the credential value
-    """
-
-    env_var_name: str = Field(
-        ...,
-        description="Name of the environment variable that will be available to the agent",
-    )
-    secret_name: str = Field(
-        ..., description="Name of the Kubernetes secret containing the credential"
-    )
-    secret_key: str = Field(
-        ...,
-        description="Key within the Kubernetes secret that contains the credential value",
-    )
+from agentex.config.credentials import CredentialMapping  # noqa: F401

--- a/tests/lib/cli/test_environment_config.py
+++ b/tests/lib/cli/test_environment_config.py
@@ -9,6 +9,7 @@ from agentex.lib.sdk.config.environment_config import (
     AgentKubernetesConfig,
     AgentEnvironmentConfig,
     AgentEnvironmentsConfig,
+    load_environments_config,
 )
 
 
@@ -119,8 +120,8 @@ class TestAgentEnvironmentsConfig:
         assert set(envs) == {"dev", "staging", "prod"}
 
 
-class TestAgentEnvironmentsConfigFromYaml:
-    """Test cases for AgentEnvironmentsConfig.from_yaml method."""
+class TestLoadEnvironmentsConfig:
+    """Test cases for the load_environments_config yaml loader."""
 
     def test_load_single_env_yaml(self):
         """Test loading a YAML file with a single environment."""
@@ -139,7 +140,7 @@ environments:
             f.write(yaml_content)
             f.flush()
 
-            config = AgentEnvironmentsConfig.from_yaml(f.name)
+            config = load_environments_config(f.name)
 
             assert config.schema_version == "v1"
             assert "dev" in config.environments
@@ -170,7 +171,7 @@ environments:
             f.write(yaml_content)
             f.flush()
 
-            config = AgentEnvironmentsConfig.from_yaml(f.name)
+            config = load_environments_config(f.name)
 
             assert "dev" in config.environments
             assert "prod" in config.environments
@@ -201,7 +202,7 @@ environments:
             f.write(yaml_content)
             f.flush()
 
-            config = AgentEnvironmentsConfig.from_yaml(f.name)
+            config = load_environments_config(f.name)
 
             assert config.environments["dev-aws"].environment == "dev"
             assert config.environments["dev-gcp"].environment == "dev"
@@ -230,7 +231,7 @@ environments:
             f.write(yaml_content)
             f.flush()
 
-            config = AgentEnvironmentsConfig.from_yaml(f.name)
+            config = load_environments_config(f.name)
 
             assert config.environments["dev"].helm_overrides["replicaCount"] == 3
             assert config.environments["dev"].helm_overrides["resources"]["requests"]["cpu"] == "500m"
@@ -253,7 +254,7 @@ environments:
             f.write(yaml_content)
             f.flush()
 
-            config = AgentEnvironmentsConfig.from_yaml(f.name)
+            config = load_environments_config(f.name)
 
             assert config.environments["dev"].helm_repository_name == "custom-repo"
             assert config.environments["dev"].helm_repository_url == "https://custom.example.com/charts"
@@ -261,7 +262,7 @@ environments:
     def test_load_nonexistent_yaml_raises_file_not_found(self):
         """Test that loading non-existent file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError, match="environments.yaml not found"):
-            AgentEnvironmentsConfig.from_yaml("/nonexistent/path/environments.yaml")
+            load_environments_config("/nonexistent/path/environments.yaml")
 
     def test_load_empty_yaml_raises_value_error(self):
         """Test that loading empty YAML file raises ValueError."""
@@ -270,7 +271,7 @@ environments:
             f.flush()
 
             with pytest.raises(ValueError, match="empty"):
-                AgentEnvironmentsConfig.from_yaml(f.name)
+                load_environments_config(f.name)
 
     def test_load_invalid_yaml_syntax_raises_value_error(self):
         """Test that loading invalid YAML syntax raises ValueError."""
@@ -279,7 +280,7 @@ environments:
             f.flush()
 
             with pytest.raises(ValueError, match="Invalid YAML"):
-                AgentEnvironmentsConfig.from_yaml(f.name)
+                load_environments_config(f.name)
 
     def test_load_yaml_missing_required_auth_raises_error(self):
         """Test that YAML missing required 'auth' field raises validation error."""
@@ -295,7 +296,7 @@ environments:
             f.flush()
 
             with pytest.raises(ValueError, match="Failed to load"):
-                AgentEnvironmentsConfig.from_yaml(f.name)
+                load_environments_config(f.name)
 
     def test_load_yaml_with_oci_registry(self):
         """Test loading YAML with nested oci_registry configuration."""
@@ -317,7 +318,7 @@ environments:
             f.write(yaml_content)
             f.flush()
 
-            config = AgentEnvironmentsConfig.from_yaml(f.name)
+            config = load_environments_config(f.name)
 
             env = config.environments["dev"]
             assert env.oci_registry is not None
@@ -341,5 +342,5 @@ environments:
             f.write(yaml_content)
             f.flush()
 
-            config = AgentEnvironmentsConfig.from_yaml(f.name)
+            config = load_environments_config(f.name)
             assert config.environments["dev"].oci_registry is None

--- a/tests/test_config_shims.py
+++ b/tests/test_config_shims.py
@@ -1,0 +1,117 @@
+"""Tests that pin the back-compat contract for config-model shims.
+
+The canonical location for deployment/agent configuration models is
+:mod:`agentex.config` (mirroring PR scaleapi/scale-agentex-python#371, which
+did this for protocol types). The historical locations under
+:mod:`agentex.lib.sdk.config.*` and :mod:`agentex.lib.types.*` are preserved as
+re-export shims so external consumers' existing imports continue to work.
+
+These tests enforce:
+
+1. **Symbol parity** — every public name the original modules exported is
+   still importable from the old path.
+2. **Identity** — the class objects at the shim path are the *same* objects as
+   the canonical path, so ``isinstance`` stays correct across import styles.
+3. **Config preservation** — the swap from ``model_utils.BaseModel`` to plain
+   pydantic kept ``populate_by_name`` (``DeploymentConfig``'s ``global`` alias
+   relies on it; it previously also carried a now-removed
+   ``class Config: validate_by_name``).
+"""
+
+from __future__ import annotations
+
+
+def test_config_shims_re_export_all_original_symbols() -> None:
+    """Every name historically exported from the old paths must still be
+    importable from those paths via the back-compat shims."""
+    from agentex.lib.types.credentials import CredentialMapping  # noqa: F401
+    from agentex.lib.types.agent_configs import (  # noqa: F401
+        TemporalConfig,
+        TemporalWorkerConfig,
+        TemporalWorkflowConfig,
+    )
+    from agentex.lib.sdk.config.agent_config import AgentConfig  # noqa: F401
+    from agentex.lib.sdk.config.build_config import (  # noqa: F401
+        BuildConfig,
+        BuildContext,
+    )
+    from agentex.lib.sdk.config.agent_manifest import (  # noqa: F401
+        AgentManifest,
+        BuildContextManager,
+        load_agent_manifest,
+        build_context_manager,
+    )
+    from agentex.lib.sdk.config.deployment_config import (  # noqa: F401
+        ImageConfig,
+        ClusterConfig,
+        ResourceConfig,
+        DeploymentConfig,
+        AuthenticationConfig,
+        ResourceRequirements,
+        ImagePullSecretConfig,
+        InjectedSecretsValues,
+        GlobalDeploymentConfig,
+        InjectedImagePullSecretValues,
+    )
+    from agentex.lib.sdk.config.environment_config import (  # noqa: F401
+        AgentAuthConfig,
+        OciRegistryConfig,
+        AgentKubernetesConfig,
+        AgentEnvironmentConfig,
+        AgentEnvironmentsConfig,
+        load_environments_config,
+        load_environments_config_from_manifest_dir,
+    )
+    from agentex.lib.sdk.config.local_development_config import (  # noqa: F401
+        LocalAgentConfig,
+        LocalPathsConfig,
+        LocalDevelopmentConfig,
+    )
+
+
+def test_config_shim_classes_are_identical_to_canonical() -> None:
+    """Shim re-exports must be the *same* class objects as the canonical path.
+    Different objects would break ``isinstance`` for code that mixes import
+    styles."""
+    from agentex.config import (
+        credentials,
+        agent_config,
+        build_config,
+        agent_configs as canon_agent_configs,
+        agent_manifest as canon_manifest,
+        deployment_config as canon_deploy,
+        environment_config as canon_env,
+        local_development_config as canon_local,
+    )
+    from agentex.lib.types import credentials as shim_creds, agent_configs as shim_agent_configs
+    from agentex.lib.sdk.config import (
+        agent_config as shim_agent_config,
+        build_config as shim_build,
+        agent_manifest as shim_manifest,
+        deployment_config as shim_deploy,
+        environment_config as shim_env,
+        local_development_config as shim_local,
+    )
+
+    assert shim_agent_config.AgentConfig is agent_config.AgentConfig
+    assert shim_build.BuildConfig is build_config.BuildConfig
+    assert shim_deploy.DeploymentConfig is canon_deploy.DeploymentConfig
+    assert shim_local.LocalDevelopmentConfig is canon_local.LocalDevelopmentConfig
+    assert shim_env.AgentEnvironmentsConfig is canon_env.AgentEnvironmentsConfig
+    assert shim_env.AgentEnvironmentConfig is canon_env.AgentEnvironmentConfig
+    assert shim_agent_configs.TemporalConfig is canon_agent_configs.TemporalConfig
+    assert shim_creds.CredentialMapping is credentials.CredentialMapping
+    assert shim_manifest.AgentManifest is canon_manifest.AgentManifest
+
+
+def test_deployment_config_populates_global_by_name_and_alias() -> None:
+    """``populate_by_name`` (inherited via ConfigBaseModel) must let the
+    ``global``-aliased field be set by either its field name or its alias —
+    the swap dropped the legacy ``class Config: validate_by_name``."""
+    from agentex.config.deployment_config import DeploymentConfig
+
+    by_name = DeploymentConfig.model_validate({"image": {"repository": "r"}, "global_config": {"replicaCount": 2}})
+    assert by_name.global_config.replicaCount == 2
+
+    by_alias = DeploymentConfig.model_validate({"image": {"repository": "r"}, "global": {"replicaCount": 3}})
+    assert by_alias.global_config.replicaCount == 3


### PR DESCRIPTION
## Summary

Promotes the deployment/agent **configuration model classes** out of the heavy ADK (`agentex.lib.sdk.config`) into a new canonical, hand-authored namespace `agentex.config.*` that ships in the slim `agentex-client` wheel. REST-only consumers can now import these models without installing the ADK runtime (temporalio / fastapi / litellm / …). Back-compat shims at the old paths keep existing imports working.

Deployment-models analog of #371 (which did this for protocol types). Tracking: AGX1-292.

**Downstream:** [`egp-api-backend`](https://github.com/scaleapi/scaleapi/tree/master/packages/egp-api-backend) (SGP-5970) currently hand-copies these models in `agentex_sdk_deployment_models.py` because importing them required the full ADK. This promotion lets it drop the copy.

## What moved

Promoted to `agentex.config.*` (pure pydantic models):

| New module | Classes |
|---|---|
| `agent_config.py` | `AgentConfig` |
| `build_config.py` | `BuildContext`, `BuildConfig` |
| `deployment_config.py` | `ImageConfig`, `DeploymentConfig`, `ClusterConfig`, `InjectedSecretsValues`, … |
| `local_development_config.py` | `LocalAgentConfig`, `LocalPathsConfig`, `LocalDevelopmentConfig` |
| `environment_config.py` | `AgentAuthConfig`, `AgentKubernetesConfig`, `OciRegistryConfig`, `AgentEnvironmentConfig`, `AgentEnvironmentsConfig` (**model classes only**) |
| `agent_manifest.py` | `AgentManifest` (**model only** — `egp-api-backend` validates manifest dicts with it; build/loader stay in lib) |
| `credentials.py` | `CredentialMapping` (moved from `agentex.lib.types`) |
| `agent_configs.py` | `TemporalConfig`, `TemporalWorkerConfig`, `TemporalWorkflowConfig` (moved from `agentex.lib.types`) |

`ConfigBaseModel` (`agentex/config/_base.py`) inlines the `ConfigDict(from_attributes=True, populate_by_name=True)` the former `model_utils.BaseModel` provided — the behavior-preserving swap #371 established. `DeploymentConfig` / `InjectedSecretsValues`' nested `class Config: validate_by_name = True` is folded into it (redundant with `populate_by_name`; keeping both `model_config` and a nested `Config` on one class raises in pydantic v2).

The promoted `agent_configs.py` / `local_development_config.py` validators are also modernized from the deprecated pydantic-v1 `@validator` to `@field_validator`, so the new public surface emits no `PydanticDeprecatedSince20` warnings for importers.

### `environment_config` split
The module mixed pure models with a yaml-loading `from_yaml`. The model classes (incl. `AgentEnvironmentsConfig` with its accessors/validators) are promoted; the `from_yaml`/yaml loading stays in `lib` as the **`load_environments_config` free function** (+ `load_environments_config_from_manifest_dir`) so the promoted models stay slim-safe.

**Back-compat delta:** the promoted `AgentEnvironmentsConfig` no longer carries a `.from_yaml()` classmethod. The two in-repo callers (`validation.py` + the manifest-dir helper) and the loader tests are repointed to `load_environments_config`; an external caller via the lib path would switch to the free function.

### `agent_manifest` split (same pattern)
`egp-api-backend` needs the `AgentManifest` **model** (it validates manifest dicts; it does its own yaml parsing and never touches an agentex loader). So the model is promoted to `agentex.config.agent_manifest`, while the yaml loader and Docker build-context machinery stay in lib:

- `AgentManifest.from_yaml()` → **`load_agent_manifest()`** free function in lib (7 callers repointed).
- `AgentManifest.context_manager()` → **`build_context_manager()`** free function in lib (2 callers); `BuildContextManager` stays in lib.
- `AgentManifest.load_environments_config()` method dropped; its 1 caller uses the existing `load_environments_config_from_manifest_dir`.

**Back-compat delta:** like `AgentEnvironmentsConfig`, the promoted `AgentManifest` drops `from_yaml`/`context_manager`/`load_environments_config` methods (all CLI-internal; no examples/tutorials use them). The `AgentManifest` type is still re-exported from the lib path.

### Left in `lib` (CLI/build machinery)
`agent_manifest.py` (loader + `BuildContextManager`), `validation.py`, `project_config.py` — they use yaml / jinja2 / subprocess / tar and are CLI-only.

### Shims
Back-compat re-export shims at the old `agentex.lib.sdk.config.{agent_config,build_config,deployment_config,local_development_config,environment_config}` and `agentex.lib.types.{credentials,agent_configs}` paths. In-repo lib consumers are repointed to the canonical `agentex.config.*` paths, so the shims are purely external-facing.

## ⚠️ Stainless dashboard action required

`agentex.config` is **hand-authored** and must be protected from codegen regen the same way `agentex.protocol` / `adk/**` are. That protection lives in the **Stainless dashboard `keep_files`**, not this repo (confirmed: no `.stainless` config exists locally; the `pyproject.toml` comments document `keep_files: ["adk/**"]` as dashboard config, and #371 added `agentex.protocol` with no repo-side codegen change).

**Action:** add `src/agentex/config/**` to the dashboard `keep_files`. Until that lands, codegen can clobber the new directory. This intersects the open codegen-conflict PR `stainless-sdks/agentex-sdk-python#44` — flagging rather than silently resolving.

## Verification (local)

- **Slim-safety (decisive):** `uv build --all-packages --wheel` → all `agentex/config/*` files ship in `agentex_client-*.whl` and are **absent** from the ADK wheel. Installed *only* the slim wheel in a clean venv (6 deps: httpx, pydantic, anyio, distro, sniffio, typing-extensions — no temporalio/fastapi/litellm/yaml/ddtrace) and imported every promoted model: OK.
- `./scripts/lint` (ruff + pyright + `import agentex`) and `./scripts/check-slim-deps` pass. (The lone pyright error is `httpx_aiohttp` in untouched generated `_base_client.py` — pre-existing, unrelated.)
- Old `agentex.lib.*` imports still resolve via shims with class identity preserved — pinned by new `tests/test_config_shims.py`.
- Full `./scripts/test` (3.12) locally: **918 passed, 1376 skipped** (skips are the API-endpoint tests requiring the prism mock server; all runnable tests pass, including the new shim tests).

## Test plan
- [x] `./scripts/test` (3.12) passes locally; CI to confirm across 3.12 / 3.13 + ruff/pyright/slim-deps.
- [x] Slim wheel contains `agentex/config/*`; importable with only the 6 slim deps.
- [x] Old `agentex.lib.sdk.config.*` / `agentex.lib.types.*` imports keep working via shims.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes deployment/agent configuration Pydantic model classes from the heavy ADK namespace (`agentex.lib.sdk.config.*`, `agentex.lib.types.*`) into a new slim-safe `agentex.config.*` package so REST-only consumers can import them without pulling in the full ADK runtime. Back-compat shims at all original module paths preserve class identity for existing imports.

- **New `agentex.config.*` package**: pure-pydantic models for `AgentConfig`, `BuildConfig`, `DeploymentConfig`, `AgentManifest`, `AgentEnvironmentsConfig`, `TemporalConfig`, `CredentialMapping`, etc., backed by `ConfigBaseModel` with `from_attributes=True` / `populate_by_name=True` to preserve prior behaviour.
- **Method extraction**: yaml-loading logic and Docker build machinery extracted to free functions (`load_agent_manifest`, `build_context_manager`, `load_environments_config`) in `agentex.lib.sdk.config.*`, keeping the promoted models slim-safe; all internal callers repointed.
- **Shim tests added** (`tests/test_config_shims.py`) to assert symbol parity and class-object identity across both import paths.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactor is well-contained, all internal callers are repointed, and shim tests verify class-object identity and config preservation across both import paths.

The structural split is clean: pure pydantic models land in the slim wheel, yaml-loading and Docker build machinery stay in lib, and every public class is re-exported from its original path with the same object identity. The new shim tests directly assert the contracts that could break. The only observations are a missing ticket number on an existing TODO and a minor question about whether the Temporal leaf-type classes intentionally drop from_attributes=True — neither affects runtime correctness for current callers.

src/agentex/config/agent_configs.py — uses plain pydantic.BaseModel instead of ConfigBaseModel for the Temporal config types; worth a quick confirmation that this is intentional.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/config/_base.py | Introduces ConfigBaseModel with from_attributes=True and populate_by_name=True, preserving the former model_utils.BaseModel contract. |
| src/agentex/config/agent_config.py | Promoted AgentConfig using ConfigBaseModel; logic for is_temporal_agent / get_temporal_workflows faithfully carried over from lib. |
| src/agentex/config/agent_configs.py | TemporalConfig / TemporalWorkerConfig / TemporalWorkflowConfig promoted; uses plain pydantic BaseModel rather than ConfigBaseModel, dropping from_attributes=True from these leaf types; has a TODO without a ticket number. |
| src/agentex/config/deployment_config.py | DeploymentConfig and related classes promoted; global alias correctly preserved via populate_by_name in ConfigBaseModel; test validates both alias and field-name access. |
| src/agentex/config/environment_config.py | AgentEnvironmentsConfig and sub-models promoted with all validators and accessors intact; yaml loading correctly stays in lib shim. |
| src/agentex/config/agent_manifest.py | Slim AgentManifest model only; yaml loader and build context machinery correctly left in lib. |
| src/agentex/lib/sdk/config/environment_config.py | Reduced to a re-export shim plus load_environments_config / load_environments_config_from_manifest_dir yaml helpers; clean split. |
| src/agentex/lib/sdk/config/agent_manifest.py | Reduced to shim + load_agent_manifest / build_context_manager free functions + BuildContextManager class; all internal callers repointed correctly. |
| src/agentex/lib/types/agent_configs.py | Pure re-export shim to agentex.config.agent_configs; correct and minimal. |
| src/agentex/lib/types/credentials.py | Pure re-export shim to agentex.config.credentials; correct and minimal. |
| tests/test_config_shims.py | New shim tests cover symbol parity, class identity, and populate_by_name preservation — exactly the right contract tests for this refactor. |
| tests/lib/cli/test_environment_config.py | Test class renamed and all from_yaml calls replaced with load_environments_config; parity maintained. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Fconfig%2Fagent_configs.py%3A23%0AThe%20%60TODO%60%20comment%20lacks%20a%20ticket%20number.%20The%20team's%20convention%20is%20to%20include%20a%20Linear%2FJira%20ticket%20reference%20so%20the%20cleanup%20work%20is%20trackable%20by%20searching%20for%20the%20ID.%0A%0A%60%60%60suggestion%0A%23%20TODO%28AGX1-%3F%3F%3F%29%3A%20Remove%20this%20class%20when%20we%20remove%20the%20agentex%20agents%20create%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Fconfig%2Fagent_configs.py%3A1-7%0A**%60ConfigBaseModel%60%20not%20used%20for%20%60TemporalConfig%60%20%2F%20%60TemporalWorkerConfig%60%20%2F%20%60TemporalWorkflowConfig%60**%0A%0AThese%20classes%20use%20plain%20%60pydantic.BaseModel%60%20rather%20than%20%60ConfigBaseModel%60%20%28which%20carries%20%60from_attributes%3DTrue%60%20and%20%60populate_by_name%3DTrue%60%29.%20All%20other%20promoted%20models%20in%20this%20PR%20use%20%60ConfigBaseModel%60%20to%20preserve%20the%20behaviour%20of%20the%20old%20%60model_utils.BaseModel%60.%20Worth%20confirming%20this%20is%20intentional%20and%20that%20no%20downstream%20consumers%20rely%20on%20either%20config%20flag%20for%20these%20specific%20types.%0A%0A&pr=396&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Fconfig%2Fagent_configs.py%3A23%0AThe%20%60TODO%60%20comment%20lacks%20a%20ticket%20number.%20The%20team's%20convention%20is%20to%20include%20a%20Linear%2FJira%20ticket%20reference%20so%20the%20cleanup%20work%20is%20trackable%20by%20searching%20for%20the%20ID.%0A%0A%60%60%60suggestion%0A%23%20TODO%28AGX1-%3F%3F%3F%29%3A%20Remove%20this%20class%20when%20we%20remove%20the%20agentex%20agents%20create%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Fconfig%2Fagent_configs.py%3A1-7%0A**%60ConfigBaseModel%60%20not%20used%20for%20%60TemporalConfig%60%20%2F%20%60TemporalWorkerConfig%60%20%2F%20%60TemporalWorkflowConfig%60**%0A%0AThese%20classes%20use%20plain%20%60pydantic.BaseModel%60%20rather%20than%20%60ConfigBaseModel%60%20%28which%20carries%20%60from_attributes%3DTrue%60%20and%20%60populate_by_name%3DTrue%60%29.%20All%20other%20promoted%20models%20in%20this%20PR%20use%20%60ConfigBaseModel%60%20to%20preserve%20the%20behaviour%20of%20the%20old%20%60model_utils.BaseModel%60.%20Worth%20confirming%20this%20is%20intentional%20and%20that%20no%20downstream%20consumers%20rely%20on%20either%20config%20flag%20for%20these%20specific%20types.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=396&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22mparke%2Freverent-mclaren-50328a%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mparke%2Freverent-mclaren-50328a%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Fconfig%2Fagent_configs.py%3A23%0AThe%20%60TODO%60%20comment%20lacks%20a%20ticket%20number.%20The%20team's%20convention%20is%20to%20include%20a%20Linear%2FJira%20ticket%20reference%20so%20the%20cleanup%20work%20is%20trackable%20by%20searching%20for%20the%20ID.%0A%0A%60%60%60suggestion%0A%23%20TODO%28AGX1-%3F%3F%3F%29%3A%20Remove%20this%20class%20when%20we%20remove%20the%20agentex%20agents%20create%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Fconfig%2Fagent_configs.py%3A1-7%0A**%60ConfigBaseModel%60%20not%20used%20for%20%60TemporalConfig%60%20%2F%20%60TemporalWorkerConfig%60%20%2F%20%60TemporalWorkflowConfig%60**%0A%0AThese%20classes%20use%20plain%20%60pydantic.BaseModel%60%20rather%20than%20%60ConfigBaseModel%60%20%28which%20carries%20%60from_attributes%3DTrue%60%20and%20%60populate_by_name%3DTrue%60%29.%20All%20other%20promoted%20models%20in%20this%20PR%20use%20%60ConfigBaseModel%60%20to%20preserve%20the%20behaviour%20of%20the%20old%20%60model_utils.BaseModel%60.%20Worth%20confirming%20this%20is%20intentional%20and%20that%20no%20downstream%20consumers%20rely%20on%20either%20config%20flag%20for%20these%20specific%20types.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=396&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/agentex/config/agent_configs.py:23
The `TODO` comment lacks a ticket number. The team's convention is to include a Linear/Jira ticket reference so the cleanup work is trackable by searching for the ID.

```suggestion
# TODO(AGX1-???): Remove this class when we remove the agentex agents create
```

### Issue 2 of 2
src/agentex/config/agent_configs.py:1-7
**`ConfigBaseModel` not used for `TemporalConfig` / `TemporalWorkerConfig` / `TemporalWorkflowConfig`**

These classes use plain `pydantic.BaseModel` rather than `ConfigBaseModel` (which carries `from_attributes=True` and `populate_by_name=True`). All other promoted models in this PR use `ConfigBaseModel` to preserve the behaviour of the old `model_utils.BaseModel`. Worth confirming this is intentional and that no downstream consumers rely on either config flag for these specific types.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(config): promote deployment-con..."](https://github.com/scaleapi/scale-agentex-python/commit/43abffc31a5717a8791839fa7ea6aaa1eb88f0d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36388165)</sub>

<!-- /greptile_comment -->
