### PR TITLE
perf(tracing): larger span batch + linger_ms for high-volume ingest

### DIFF
--- a/src/agentex/lib/core/tracing/span_queue.py
+++ b/src/agentex/lib/core/tracing/span_queue.py
@@ -15,8 +15,18 @@ from agentex.lib.core.tracing.processors.tracing_processor_interface import (
 
 logger = make_logger(__name__)
 
-_DEFAULT_BATCH_SIZE = 50
-_DEFAULT_LINGER_MS = 100
+# Max spans coalesced into one ``upsert_batch`` HTTP call (one
+# ``INSERT ... ON CONFLICT`` statement server-side).  Larger batches amortize
+# the per-request round trip and the per-statement parse/plan + index
+# maintenance overhead, which dominates at high span volume.  Kept well under
+# the EGP backend's 1000-row cap; tune per-deploy via
+# ``AGENTEX_SPAN_QUEUE_BATCH_SIZE``.
+_DEFAULT_BATCH_SIZE = 200
+# Max time the drain lingers after the first span to let a batch fill.  Spans
+# typically arrive a few ms apart, so a longer linger fills the larger batch
+# above rather than shipping near-size-1 batches; bounded so worst-case ingest
+# latency (and the in-flight loss window) stays sub-second.
+_DEFAULT_LINGER_MS = 250
 # 0 == unbounded (preserves prior behavior).  A bound makes backpressure
 # visible (dropped spans are counted) and caps worst-case memory.
 _DEFAULT_MAX_SIZE = 0
@@ -114,7 +124,7 @@ class AsyncSpanQueue:
 
     def __init__(
         self,
-        batch_size: int = _DEFAULT_BATCH_SIZE,
+        batch_size: int | None = None,
         linger_ms: int | None = None,
         max_size: int | None = None,
         max_retries: int | None = None,
@@ -126,7 +136,11 @@ class AsyncSpanQueue:
         self._queue: asyncio.Queue[_SpanQueueItem] = asyncio.Queue(maxsize=resolved_max_size)
         self._drain_task: asyncio.Task[None] | None = None
         self._stopping = False
-        self._batch_size = batch_size
+        self._batch_size = (
+            _read_int_env("AGENTEX_SPAN_QUEUE_BATCH_SIZE", _DEFAULT_BATCH_SIZE, minimum=1)
+            if batch_size is None
+            else max(1, batch_size)
+        )
         self._linger_ms = _read_linger_ms_env() if linger_ms is None else max(0, linger_ms)
         self._max_retries = (
             _read_int_env("AGENTEX_SPAN_QUEUE_MAX_RETRIES", _DEFAULT_MAX_RETRIES, minimum=1)

--- a/tests/lib/core/tracing/test_span_queue.py
+++ b/tests/lib/core/tracing/test_span_queue.py
@@ -8,7 +8,11 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agentex.types.span import Span
-from agentex.lib.core.tracing.span_queue import SpanEventType, AsyncSpanQueue
+from agentex.lib.core.tracing.span_queue import (
+    _DEFAULT_BATCH_SIZE,
+    SpanEventType,
+    AsyncSpanQueue,
+)
 
 
 def _make_span(span_id: str | None = None) -> Span:
@@ -859,3 +863,31 @@ class TestAsyncSpanQueueMetrics:
 
         assert elapsed < 0.05, f"disabled metrics enqueue too slow: {elapsed:.3f}s"
         mock_get.assert_not_called()
+
+
+class TestAsyncSpanQueueBatchSizeConfig:
+    """batch_size resolution: explicit arg > AGENTEX_SPAN_QUEUE_BATCH_SIZE env > default."""
+
+    async def test_default_batch_size(self, monkeypatch):
+        monkeypatch.delenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", raising=False)
+        assert AsyncSpanQueue()._batch_size == _DEFAULT_BATCH_SIZE
+
+    async def test_explicit_arg_overrides_default(self, monkeypatch):
+        monkeypatch.delenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", raising=False)
+        assert AsyncSpanQueue(batch_size=10)._batch_size == 10
+
+    async def test_explicit_arg_clamped_to_min_one(self, monkeypatch):
+        monkeypatch.delenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", raising=False)
+        assert AsyncSpanQueue(batch_size=0)._batch_size == 1
+
+    async def test_env_used_when_arg_is_none(self, monkeypatch):
+        monkeypatch.setenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", "500")
+        assert AsyncSpanQueue()._batch_size == 500
+
+    async def test_explicit_arg_beats_env(self, monkeypatch):
+        monkeypatch.setenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", "500")
+        assert AsyncSpanQueue(batch_size=7)._batch_size == 7
+
+    async def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("AGENTEX_SPAN_QUEUE_BATCH_SIZE", "not-an-int")
+        assert AsyncSpanQueue()._batch_size == _DEFAULT_BATCH_SIZE


### PR DESCRIPTION
## Summary
Splits the **span batch-size / linger tuning** out of #394 (which is now scoped to end-only ingest) so each change ships and reverts independently.

Changes in `span_queue.py`:
- `_DEFAULT_BATCH_SIZE` 50 → **200** — coalesce more spans per `upsert_batch` HTTP call (one `INSERT … ON CONFLICT` server-side), amortizing the per-request round trip + per-statement parse/plan + index maintenance that dominates at high span volume. Kept well under the EGP backend's 1000-row cap.
- `_DEFAULT_LINGER_MS` 100 → **250** — let a batch fill (spans arrive a few ms apart) instead of shipping near-size-1 batches; bounded so worst-case ingest latency / in-flight loss window stays sub-second.
- `batch_size` is now **env-tunable** via `AGENTEX_SPAN_QUEUE_BATCH_SIZE` (arg > env > default), clamped to ≥1.

Tests: `test_span_queue.py` — batch_size resolution (explicit arg > env > default, min-clamp).

## Why separate
#394 is the *end-only ingest* change (skip span-start upsert); this is independent batching throughput tuning. Splitting keeps each reviewable and revertable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tunes the `AsyncSpanQueue`'s default batch parameters and makes `batch_size` configurable at runtime via an environment variable. The implementation is straightforward and well-tested.

- `_DEFAULT_BATCH_SIZE` raised from 50 → 200 and `_DEFAULT_LINGER_MS` from 100 → 250, with detailed inline rationale for each value.
- `batch_size` in `AsyncSpanQueue.__init__` changed from `int = _DEFAULT_BATCH_SIZE` to `int | None = None`, resolved via the new `AGENTEX_SPAN_QUEUE_BATCH_SIZE` env var (arg > env > default, clamped to ≥1) using the existing `_read_int_env` helper.
- Six new unit tests cover all resolution paths: default, explicit arg, env var, arg-beats-env, zero-clamp, and invalid-env fallback.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are bounded config tuning with no logic alterations to the drain loop or export path.

The batch size and linger defaults are raised within documented safe limits, the env-var resolution follows the exact same pattern already used for linger_ms, max_retries, concurrency, and max_size, and all resolution paths are covered by dedicated unit tests. No callers outside the test suite pass batch_size explicitly, so the signature change is non-breaking.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/span_queue.py | Default constants bumped and batch_size wired to env var via existing _read_int_env helper; logic is correct and consistent with linger_ms/max_retries/concurrency patterns already present. |
| tests/lib/core/tracing/test_span_queue.py | New TestAsyncSpanQueueBatchSizeConfig class covers all six batch_size resolution paths cleanly; follows the existing async-test pattern used across the file. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AsyncSpanQueue.__init__] --> B{batch_size arg provided?}
    B -->|No - None| C[_read_int_env AGENTEX_SPAN_QUEUE_BATCH_SIZE default=200 min=1]
    C --> D{Env var set?}
    D -->|Yes valid int| E[max 1 int env]
    D -->|Yes invalid| F[log warning use 200]
    D -->|Not set| G[use 200]
    B -->|Yes explicit int| H[max 1 batch_size]
    E --> I[self._batch_size]
    F --> I
    G --> I
    H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["perf(tracing): larger span batch (50→200..."](https://github.com/scaleapi/scale-agentex-python/commit/cdb3bc30d56eba91939e281261d9fc7049a076c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36484052)</sub>

<!-- /greptile_comment -->