### PR TITLE
fix(tutorials): stop at130-langgraph workflow deadlock on graph compile

### DIFF
--- a/examples/tutorials/10_async/10_temporal/130_langgraph/project/graph.py
+++ b/examples/tutorials/10_async/10_temporal/130_langgraph/project/graph.py
@@ -78,7 +78,13 @@ async def tools_node(state: AgentState) -> dict[str, Any]:
     last = state["messages"][-1]
     results: list[Any] = []
     for call in getattr(last, "tool_calls", None) or []:
-        output = await _TOOLS_BY_NAME[call["name"]].ainvoke(call["args"])
+        tool = _TOOLS_BY_NAME.get(call["name"])
+        # Mirror ToolNode: surface an unknown/hallucinated tool name as an error
+        # ToolMessage so the graph keeps running instead of crashing the node.
+        if tool is None:
+            output = f"Error: unknown tool {call['name']!r}. Available: {list(_TOOLS_BY_NAME)}"
+        else:
+            output = await tool.ainvoke(call["args"])
         results.append(
             ToolMessage(content=str(output), tool_call_id=call["id"], name=call["name"])
         )

--- a/examples/tutorials/10_async/10_temporal/130_langgraph/project/graph.py
+++ b/examples/tutorials/10_async/10_temporal/130_langgraph/project/graph.py
@@ -10,6 +10,15 @@ The ``temporalio.contrib.langgraph`` plugin runs each node where its
 The router and tools are ``async`` so LangGraph awaits them directly — a sync
 callable would be offloaded via ``run_in_executor``, which Temporal's workflow
 event loop does not support.
+
+The in-workflow ``tools`` node is a plain ``async`` function rather than
+LangGraph's ``ToolNode`` prebuilt on purpose. The plugin wraps an in-workflow
+node in ``wrap_workflow``, whose closure captures the wrapped object. When that
+object is itself a LangChain ``Runnable`` (as ``ToolNode`` is), LangGraph's
+``compile()`` subgraph detection (``find_subgraph_pregel`` →
+``get_function_nonlocals``) recurses through that wrapper without cycle
+detection and never terminates, tripping Temporal's deadlock detector. A plain
+function isn't a ``Runnable``, so compile stays trivial.
 """
 
 from __future__ import annotations
@@ -26,11 +35,13 @@ from typing_extensions import TypedDict
 
 from langgraph.graph import END, START, StateGraph
 from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import ToolNode
-from langchain_core.messages import SystemMessage
+from langchain_core.messages import ToolMessage, SystemMessage
 from langgraph.graph.message import add_messages
 
 from project.tools import TOOLS
+
+# Look up tools by name for the in-workflow tools node.
+_TOOLS_BY_NAME = {tool.name: tool for tool in TOOLS}
 
 # Name this graph is registered under in the LangGraphPlugin (acp.py / run_worker.py).
 GRAPH_NAME = "at130-langgraph"
@@ -58,6 +69,22 @@ async def agent_node(state: AgentState) -> dict[str, Any]:
     return {"messages": [await llm.ainvoke(messages)]}
 
 
+async def tools_node(state: AgentState) -> dict[str, Any]:
+    """Run the tool calls the model requested. Runs inline in the workflow.
+
+    A plain ``async`` function (not LangGraph's ``ToolNode``) — see the module
+    docstring for why a ``Runnable`` tools node can't be compiled here.
+    """
+    last = state["messages"][-1]
+    results: list[Any] = []
+    for call in getattr(last, "tool_calls", None) or []:
+        output = await _TOOLS_BY_NAME[call["name"]].ainvoke(call["args"])
+        results.append(
+            ToolMessage(content=str(output), tool_call_id=call["id"], name=call["name"])
+        )
+    return {"messages": results}
+
+
 async def route_after_agent(state: AgentState) -> str:
     """Go to the tools node if the model requested tools, else finish (async router)."""
     last = state["messages"][-1]
@@ -72,7 +99,7 @@ def build_graph() -> StateGraph:
         agent_node,
         metadata={"execute_in": "activity", "start_to_close_timeout": timedelta(minutes=5)},
     )
-    builder.add_node("tools", ToolNode(TOOLS), metadata={"execute_in": "workflow"})
+    builder.add_node("tools", tools_node, metadata={"execute_in": "workflow"})
     builder.add_edge(START, "agent")
     builder.add_conditional_edges("agent", route_after_agent, {"tools": "tools", END: END})
     builder.add_edge("tools", "agent")


### PR DESCRIPTION
## Problem

The `10_async/10_temporal/130_langgraph` tutorial test fails in CI: the agent never emits a `tool_request`, so `test_send_event_and_poll` times out on every retry.

## Root cause

The CI "Print agent logs on failure" step shows the workflow deadlocking during graph compile:

```
project/workflow.py:55  compiled = lg_graph(GRAPH_NAME).compile()
  → langgraph find_subgraph_pregel → get_function_nonlocals → inspect.getsource
temporalio.worker._workflow._DeadlockError: [TMPRL1101] ... didn't yield within 2 second(s)
```

Reproduced offline:

- Raw `build_graph().compile()` = **2ms**.
- After `LangGraphPlugin` wires the nodes, `compile()` **never terminates** (37k+ `get_function_nonlocals` calls in 15s and climbing).
- The infinite recursion is entirely on the **`tools` node** (`ToolNode`, a LangChain `Runnable`, running `execute_in="workflow"`). The plugin wraps it in `wrap_workflow.<locals>.wrapper`, whose closure captures the `ToolNode`, and the wrapper has no `functools.wraps`/`__wrapped__`. LangGraph's compile-time subgraph detection then re-introspects that wrapper endlessly with no cycle detection. The `agent` node (activity-wrapped, closes over an activity-defn, not a Runnable) introspects once and stops.

This is an upstream interaction bug in `temporalio.contrib.langgraph` (reproduces on the latest 1.28.0, and on both langgraph 1.1.x and 1.2.x). Note: bumping/disabling Temporal's deadlock detector is **not** a fix, since compile genuinely never terminates, the workflow would just hang forever instead of erroring.

## Fix

Replace the `ToolNode(TOOLS)` tools node with a plain `async def tools_node(state)` that dispatches the requested tool calls and returns `ToolMessage`s. A plain function isn't a `Runnable`, so the plugin-wired graph compiles in ~2ms while preserving the tutorial's intended activity(LLM)/workflow(tools) split.

## Verification

- Edited `graph.py` wired compile: non-terminating → **2ms**.
- Hermetic `TestGraphLogic` ReAct-loop test still passes.
- This PR's tutorial CI provides the end-to-end confirmation against a live agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a workflow deadlock in the `130_langgraph` tutorial by replacing the `ToolNode(TOOLS)` prebuilt (a LangChain `Runnable`) with a plain `async def tools_node` function, preventing LangGraph's compile-time `find_subgraph_pregel` introspection from recursing endlessly through the plugin-wired wrapper closure.

- Replaces `ToolNode(TOOLS)` with a hand-rolled `async def tools_node(state)` that dispatches tool calls by name and returns `ToolMessage` results, preserving the activity/workflow split.
- Adds `_TOOLS_BY_NAME` lookup dict and mirrors `ToolNode`'s error-handling behavior for unknown/hallucinated tool names by returning an error `ToolMessage` instead of crashing.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the tutorial's graph definition and directly resolves a CI-blocking hang.

The replacement of ToolNode with a plain async function is well-understood and correctly implemented: unknown tool names are surfaced as error ToolMessages (matching the original ToolNode behaviour), tool dispatch uses the same ainvoke path, and the module docstring clearly explains the upstream interaction bug being worked around. No correctness regressions were identified.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/tutorials/10_async/10_temporal/130_langgraph/project/graph.py | Replaces ToolNode with a plain async function to unblock graph compilation; adds graceful error ToolMessage for unknown tool names. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Temporal Workflow
    participant A as agent_node (Activity)
    participant R as route_after_agent
    participant T as tools_node (Workflow)

    W->>A: invoke(state)
    A-->>W: "{messages: [AIMessage + tool_calls]}"
    W->>R: route(state)
    R-->>W: "tools"
    W->>T: invoke(state)
    Note over T: Plain async fn — no Runnable,<br/>compile() stays O(1)
    T->>T: _TOOLS_BY_NAME.get(call["name"])
    alt tool found
        T->>T: await tool.ainvoke(call["args"])
    else unknown tool
        T->>T: build error ToolMessage
    end
    T-->>W: "{messages: [ToolMessage(s)]}"
    W->>A: invoke(state) — next ReAct turn
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tutorials): handle unknown tool name..."](https://github.com/scaleapi/scale-agentex-python/commit/7fff2f9be4f151d42abc35c92ed21e221db5016c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36494766)</sub>

<!-- /greptile_comment -->