### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Brewfile.lock.json
 
 # Claude workspace directories
 .claude-workspace/
+
+# Claude Code local scheduled-task lock
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Claude Code writes a local `.claude/scheduled_tasks.lock` runtime lock next to the tracked `.claude/settings.json`. It currently shows up as untracked in `git status` and risks being swept into a `git add -A`. This adds a targeted ignore for it.

Scoped to the lock file only — `.claude/settings.json` stays tracked, and `.claude/settings.local.json` is already ignored.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `.claude/scheduled_tasks.lock` to `.gitignore` to prevent Claude Code's runtime lock file from appearing as untracked and accidentally being staged. Also fixes a missing trailing newline from the prior `.claude-workspace/` entry.

- Scoped ignore targets only the lock file, leaving `.claude/settings.json` tracked and `.claude/settings.local.json` (already ignored) unaffected.
- No logic or source code changes; purely a housekeeping update to the ignore list.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a single targeted `.gitignore` entry with no effect on tracked files or source code.

The change is limited to one line in `.gitignore` plus a comment, correctly scoped to the Claude Code runtime lock file. It also fixes a pre-existing missing newline. No source files, configs, or tracked `.claude/` files are affected.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .gitignore | Adds `.claude/scheduled_tasks.lock` to the ignore list with a descriptive comment; also fixes the missing newline at end of file from the previous entry. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Claude Code runs] --> B[Writes .claude/scheduled_tasks.lock]
    B --> C{git status}
    C -->|Before PR| D[Lock file appears as untracked]
    C -->|After PR| E[Lock file ignored by .gitignore]
    D --> F[Risk: accidentally staged by git add -A]
    E --> G[Safe: never staged or committed]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: gitignore .claude/scheduled\_tasks..."](https://github.com/scaleapi/scale-agentex-python/commit/b55e774e1a0d7f791bc823959fc377457884fd9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36512565)</sub>

<!-- /greptile_comment -->