### PR TITLE
docs: drop stale keep_files / dashboard-config comments

### DIFF
--- a/adk/README.md
+++ b/adk/README.md
@@ -29,4 +29,4 @@ The two packages contribute disjoint files to the `agentex.*` namespace — `age
 
 ## Repo layout
 
-This package is hand-authored and lives at `adk/` inside [scaleapi/scale-agentex-python](https://github.com/scaleapi/scale-agentex-python). The Stainless generator preserves `adk/**` via `keep_files` so its codegen never touches anything here. The sibling `agentex-client` package lives at the repo root and IS Stainless-generated.
+This package is hand-authored and lives at `adk/` inside [scaleapi/scale-agentex-python](https://github.com/scaleapi/scale-agentex-python). Stainless codegen never touches `adk/**` — it's outside the generated surface. The sibling `agentex-client` package lives at the repo root and IS Stainless-generated.

--- a/adk/pyproject.toml
+++ b/adk/pyproject.toml
@@ -3,9 +3,6 @@
 # `agentex/lib/*` to the agentex.* namespace; the REST client surface
 # (agentex/{__init__.py, _*.py, types/, resources/}) ships from the slim
 # sibling package `agentex-client` which is pinned as a runtime dep.
-#
-# This entire `adk/` directory must be preserved across Stainless codegen
-# via `keep_files: ["adk/**"]` in the Stainless dashboard config.
 name = "agentex-sdk"
 version = "0.13.0"
 description = "Agent Development Kit (ADK) overlay for the Agentex API — FastACP server, Temporal workflows, LLM provider integrations, observability"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,6 @@
 # This is the Stainless-generated REST client. The hand-authored ADK
 # overlay (formerly `src/agentex/lib/*`) now lives in `adk/` and ships
 # as the sibling `agentex-sdk` package — see `adk/pyproject.toml`.
-#
-# Stainless dashboard config must:
-#   - Rename `package_name` from `agentex-sdk` to `agentex-client`
-#   - Reduce the dep list to the 6 bare-client deps below
-#   - Add `adk/**` to `keep_files` so the ADK overlay persists across codegen
 name = "agentex-client"
 version = "0.13.0"
 description = "The official Python REST client for the Agentex API"


### PR DESCRIPTION
The `keep_files` comments in `pyproject.toml` and `adk/pyproject.toml`, plus the matching claim in `adk/README.md`, were incorrect — this repo doesn't use `keep_files` at all. Stainless codegen never generates `adk/**`, `agentex/lib/*`, or `agentex/protocol/*` (no codegen header on those files), so they're never touched and need no protection. Hand-authored edits that *do* live in codegen-managed files (`pyproject.toml`, `README.md`, the locks) are reconciled by Stainless's custom-code 3-way merge, not `keep_files`.

- root `pyproject.toml`: drop the now-completed "Stainless dashboard config must…" TODO (incl. the false `keep_files` line)
- `adk/pyproject.toml`: drop the `keep_files` preservation note
- `adk/README.md`: correct the sentence to state the real reason (`adk/` is outside the generated surface)

Comment/doc-only — no behavior change.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes stale comments referencing `keep_files` and a Stainless dashboard TODO from `pyproject.toml`, `adk/pyproject.toml`, and `adk/README.md`. It corrects the documentation to reflect that `adk/**` is simply outside the Stainless-generated surface and therefore never touched by codegen — no `keep_files` entry is needed.

- **`pyproject.toml`**: Drops a now-completed TODO block that incorrectly described pending dashboard configuration including a `keep_files` entry.
- **`adk/pyproject.toml`** and **`adk/README.md`**: Remove/correct the false claim that `adk/**` is preserved via `keep_files`; the accurate reason (outside generated surface) is now documented.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure comment/documentation cleanup with no code changes — safe to merge.

All three files have only comment or prose deletions/corrections. No logic, configuration, or runtime behaviour is touched. The removed text was already inaccurate (the repo doesn't use `keep_files`), so deleting it strictly improves documentation accuracy.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Removes stale 4-line TODO comment block about Stainless dashboard configuration and `keep_files`; no functional change. |
| adk/pyproject.toml | Removes 3-line comment asserting `adk/` must be preserved via `keep_files`; no functional change. |
| adk/README.md | Corrects one sentence: replaces the `keep_files` explanation with the accurate statement that `adk/**` is outside the generated surface. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stainless Codegen] -->|generates| B[agentex-client\npyproject.toml / REST surface]
    A -->|never touches| C[adk/**\nagentex-sdk]
    B -->|runtime dep| C
    C --> D[agentex.lib.*\nagentex.protocol.*\nFastACP / Temporal / LLM]
    B --> E[agentex.__init__\nagentex._*\nagentex.types / resources]

    style C fill:#d4edda,stroke:#28a745
    style B fill:#cce5ff,stroke:#004085
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: drop stale keep\_files / dashboard-..."](https://github.com/scaleapi/scale-agentex-python/commit/e20f3cbfbe33dbfd5e3125de94f085162c72f4e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36613678)</sub>

<!-- /greptile_comment -->