### PR TITLE
fix(temporal): disable OpenAI Agents SDK trace exporter under Temporal workers

### DIFF
--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -112,6 +112,23 @@ async def get_temporal_client(
 
     has_openai_plugin = any(isinstance(p, OpenAIAgentsPlugin) for p in (plugins or []))
 
+    if has_openai_plugin:
+        # Disable the OpenAI Agents SDK's built-in trace exporter. That exporter
+        # is process-global and POSTs spans to api.openai.com/v1/traces. Under
+        # Temporal the run's trace context does not survive the workflow->activity
+        # hop, so spans created in activities have no active trace and are emitted
+        # as NoOpSpans (trace_id="no-op"); the exporter then rejects every turn
+        # with "Invalid 'data[0].trace_id': 'no-op'". We never want this exporter:
+        # Agentex has its own SGP tracing pipeline (AsyncTracer / SGPTracingProcessor)
+        # that is wholly separate from the OpenAI SDK trace provider.
+        #
+        # This must be an env var, not agents.set_tracing_disabled(): the plugin
+        # installs a fresh TemporalTraceProvider at worker/client startup whose
+        # `_disabled` is re-read from OPENAI_AGENTS_DISABLE_TRACING in __init__, so
+        # any prior set_tracing_disabled() call is discarded. setdefault preserves
+        # an explicit operator override (e.g. =0 to re-enable).
+        os.environ.setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")
+
     if has_openai_plugin and payload_codec is not None and data_converter is None:
         raise ValueError(
             "payload_codec passed as a kwarg alongside OpenAIAgentsPlugin would "


### PR DESCRIPTION
## Problem

Agents running under the Temporal `OpenAIAgentsPlugin` flood worker logs with, on **every turn**:

```
No active trace. Make sure to start a trace with `trace()` first Returning NoOpSpan.
Tracing client error 400: Invalid 'data[0].trace_id': 'no-op'. Expected an ID that begins with 'trace_'.
```

The OpenAI Agents SDK registers a **process-global** `BackendSpanExporter` that POSTs spans to `api.openai.com/v1/traces`. Under Temporal, the run's trace context does not survive the workflow→activity hop, so spans created in activities have no active trace and come out as `NoOpSpan`s (`trace_id="no-op"`). The exporter then 400s on every turn and runs a failing background export thread.

Agentex never uses this exporter — it has its own SGP tracing pipeline (`AsyncTracer` / `SGPTracingProcessor`), wholly separate from the OpenAI SDK trace provider.

## Fix

In `get_temporal_client`, when an `OpenAIAgentsPlugin` is present, set `OPENAI_AGENTS_DISABLE_TRACING=1` (via `setdefault`, so an explicit operator override is preserved).

### Why the env var (and not `set_tracing_disabled()`)

The plugin installs a fresh `TemporalTraceProvider` at worker/client startup. Its `__init__` (via `DefaultTraceProvider`) re-reads `_disabled` from `OPENAI_AGENTS_DISABLE_TRACING` — so any prior `agents.set_tracing_disabled(True)` is **discarded**. The env var is the only mechanism that survives the provider swap. Verified:

```
env=1     -> DefaultTraceProvider()._disabled = True
env unset -> DefaultTraceProvider()._disabled = False
```

With `_disabled=True`, `create_trace`/`create_span` short-circuit to NoOp **before** the "No active trace" log and before any processor dispatch — so no spans are created and nothing is exported to OpenAI. SGP tracing is unaffected (separate pipeline).

## Testing

- `ruff check` clean on the changed file.
- `mypy` error count unchanged (21 → 21, all pre-existing `no-untyped-call`/missing-import); no new errors.
- Runtime-verified the env var disables a fresh `DefaultTraceProvider` (the base of `TemporalTraceProvider`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables OpenAI Agents SDK tracing when Temporal workers use the OpenAI Agents plugin. It changes:
- Adds an `OPENAI_AGENTS_DISABLE_TRACING` default in the worker Temporal client helper.
- Applies the setting only when an `OpenAIAgentsPlugin` is present.
- Preserves explicit operator overrides by using `setdefault`.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This is close, but I would fix this before merging.

- The worker path gets the new tracing disable behavior.
- The ACP/client Temporal helper still skips the same environment setting.
- ACP processes using `OpenAIAgentsPlugin` can keep the exporter enabled and still hit the noisy trace export path.

`src/agentex/lib/core/clients/temporal/utils.py` should mirror the worker helper behavior.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Identified that worker.py sets the OPENAI\_AGENTS\_DISABLE\_TRACING environment variable inside the has\_openai\_plugin block.
- Found that utils.py detects has\_openai\_plugin but does not set a corresponding environment variable in its function.
- Traced the Temporal client creation path through TemporalClient.create, confirming it is an active client creation path.
- Attempted a targeted runtime repro script but execution was blocked due to dependency constraints.
- Compared sources and observed that the worker path and ACP/client path behave differently for the same plugin configuration.

<a href="https://app.greptile.com/trex/runs/11338793/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/temporal/workers/worker.py | Adds the OpenAI Agents tracing disable for the worker-side Temporal client helper. |
| src/agentex/lib/core/clients/temporal/utils.py | The parallel ACP/client Temporal helper still lacks the tracing disable behavior. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agentex/lib/core/clients/temporal/utils.py`, line 124 ([link](https://github.com/scaleapi/scale-agentex-python/blob/b8144c79c899b3990654ddff53ba84f0e0acf429/src/agentex/lib/core/clients/temporal/utils.py#L124)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mirror tracing disable**

   The ACP/client helper has the same `OpenAIAgentsPlugin` detection path as the worker helper, but it never sets `OPENAI_AGENTS_DISABLE_TRACING`. `TemporalClient.create()` passes configured plugins through this helper, so an ACP process using `TemporalACPConfig(plugins=[OpenAIAgentsPlugin(...)])` can still leave the OpenAI Agents SDK exporter enabled and keep producing the trace export errors this PR is meant to stop. Please mirror the worker-side `setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")` behavior here as well.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro attempt output and source analysis summary](https://app.greptile.com/trex/artifacts/aa208364-cdb5-48fe-8362-4f4afe8cdaf9)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11338793/artifacts?artifact=aa208364-cdb5-48fe-8362-4f4afe8cdaf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/core/clients/temporal/utils.py
   Line: 124

   Comment:
   **Mirror tracing disable**

   The ACP/client helper has the same `OpenAIAgentsPlugin` detection path as the worker helper, but it never sets `OPENAI_AGENTS_DISABLE_TRACING`. `TemporalClient.create()` passes configured plugins through this helper, so an ACP process using `TemporalACPConfig(plugins=[OpenAIAgentsPlugin(...)])` can still leave the OpenAI Agents SDK exporter enabled and keep producing the trace export errors this PR is meant to stop. Please mirror the worker-side `setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")` behavior here as well.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Fclients%2Ftemporal%2Futils.py%0ALine%3A%20124%0A%0AComment%3A%0A**Mirror%20tracing%20disable**%0A%0AThe%20ACP%2Fclient%20helper%20has%20the%20same%20%60OpenAIAgentsPlugin%60%20detection%20path%20as%20the%20worker%20helper%2C%20but%20it%20never%20sets%20%60OPENAI_AGENTS_DISABLE_TRACING%60.%20%60TemporalClient.create%28%29%60%20passes%20configured%20plugins%20through%20this%20helper%2C%20so%20an%20ACP%20process%20using%20%60TemporalACPConfig%28plugins%3D%5BOpenAIAgentsPlugin%28...%29%5D%29%60%20can%20still%20leave%20the%20OpenAI%20Agents%20SDK%20exporter%20enabled%20and%20keep%20producing%20the%20trace%20export%20errors%20this%20PR%20is%20meant%20to%20stop.%20Please%20mirror%20the%20worker-side%20%60setdefault%28%22OPENAI_AGENTS_DISABLE_TRACING%22%2C%20%221%22%29%60%20behavior%20here%20as%20well.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=403&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fcore%2Fclients%2Ftemporal%2Futils.py%3A124%0A**Mirror%20tracing%20disable**%0A%0AThe%20ACP%2Fclient%20helper%20has%20the%20same%20%60OpenAIAgentsPlugin%60%20detection%20path%20as%20the%20worker%20helper%2C%20but%20it%20never%20sets%20%60OPENAI_AGENTS_DISABLE_TRACING%60.%20%60TemporalClient.create%28%29%60%20passes%20configured%20plugins%20through%20this%20helper%2C%20so%20an%20ACP%20process%20using%20%60TemporalACPConfig%28plugins%3D%5BOpenAIAgentsPlugin%28...%29%5D%29%60%20can%20still%20leave%20the%20OpenAI%20Agents%20SDK%20exporter%20enabled%20and%20keep%20producing%20the%20trace%20export%20errors%20this%20PR%20is%20meant%20to%20stop.%20Please%20mirror%20the%20worker-side%20%60setdefault%28%22OPENAI_AGENTS_DISABLE_TRACING%22%2C%20%221%22%29%60%20behavior%20here%20as%20well.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=403&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/agentex/lib/core/clients/temporal/utils.py:124
**Mirror tracing disable**

The ACP/client helper has the same `OpenAIAgentsPlugin` detection path as the worker helper, but it never sets `OPENAI_AGENTS_DISABLE_TRACING`. `TemporalClient.create()` passes configured plugins through this helper, so an ACP process using `TemporalACPConfig(plugins=[OpenAIAgentsPlugin(...)])` can still leave the OpenAI Agents SDK exporter enabled and keep producing the trace export errors this PR is meant to stop. Please mirror the worker-side `setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")` behavior here as well.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(temporal): disable OpenAI Agents SDK..."](https://github.com/scaleapi/scale-agentex-python/commit/b8144c79c899b3990654ddff53ba84f0e0acf429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38027104)</sub>

<!-- /greptile_comment -->