### PR TITLE
fix(adk): re-send task_id/agent_id in state updates for backend compatibility

### DIFF
--- a/src/agentex/lib/core/services/adk/state.py
+++ b/src/agentex/lib/core/services/adk/state.py
@@ -98,9 +98,12 @@ class StateService:
                 "state": state,
             },
         ) as span:
+            # Send task_id/agent_id in the body for backends predating
+            # scale-agentex#278, which still require them (newer ones ignore them).
             state_model = await self._agentex_client.states.update(
                 state_id=state_id,
                 state=state,
+                extra_body={"task_id": task_id, "agent_id": agent_id},
             )
             if span:
                 span.output = state_model.model_dump()

--- a/tests/lib/adk/test_state_service.py
+++ b/tests/lib/adk/test_state_service.py
@@ -1,0 +1,69 @@
+"""Tests for StateService forwarding task_id/agent_id to the SDK client.
+
+Regression guard for the 0.13.0 incident: the generated client dropped
+task_id/agent_id from states.update(), so the ADK stopped sending them in the
+body and every state write 422'd against backends predating scale-agentex#278.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import Mock, AsyncMock
+
+from agentex.types.state import State
+from agentex.lib.core.services.adk.state import StateService
+
+_TS = datetime(2026, 5, 13, 18, 30, 0, tzinfo=timezone.utc)
+
+
+def _make_state() -> State:
+    return State(
+        id="s1",
+        agent_id="a1",
+        task_id="t1",
+        state={"k": "v"},
+        created_at=_TS,
+    )
+
+
+def _mock_span():
+    span = Mock()
+    span.output = None
+
+    async def __aenter__(_self):
+        return span
+
+    async def __aexit__(_self, *args):
+        return None
+
+    span.__aenter__ = __aenter__
+    span.__aexit__ = __aexit__
+    return span
+
+
+def _make_service() -> tuple[AsyncMock, StateService]:
+    client = AsyncMock()
+    tracer = Mock()
+    trace = Mock()
+    trace.span.return_value = _mock_span()
+    tracer.trace.return_value = trace
+    return client, StateService(agentex_client=client, tracer=tracer)
+
+
+class TestUpdateStateSendsParentIdentifiers:
+    async def test_task_id_and_agent_id_sent_in_body(self) -> None:
+        client, svc = _make_service()
+        client.states.update.return_value = _make_state()
+
+        await svc.update_state(
+            state_id="s1",
+            task_id="t1",
+            agent_id="a1",
+            state={"k": "v"},
+        )
+
+        kwargs = client.states.update.call_args.kwargs
+        assert kwargs["state_id"] == "s1"
+        # task_id/agent_id must ride in extra_body — the generated client dropped
+        # them from the typed signature, but old backends still require them.
+        assert kwargs["extra_body"] == {"task_id": "t1", "agent_id": "a1"}


### PR DESCRIPTION
## What
`StateService.update_state` re-sends `task_id`/`agent_id` in the `states.update` request body (via `extra_body`).

## Why
0.13.0's Stainless-generated client dropped `task_id`/`agent_id` from `states.update()`, and the ADK stopped sending them. Backends predating [scale-agentex#278](https://github.com/scaleapi/scale-agentex/pull/278) still **require** those fields, so every state write returned `422 Field required`. On the Cengage agent (`centipede-student-assistant-agentex-agent`) this dropped multi-turn context on every turn — **~22k failures over ~21h**, logged at warn level so nothing alerted.

Backends post-#278 accept-and-ignore the fields, so re-sending is compatible with both old and new servers — it closes the version-skew window where the client outran the backend rollout reaching the customer (2.10.0-rc).

## Test
`tests/lib/adk/test_state_service.py` asserts `update_state` forwards `task_id`/`agent_id` in the request body — KeyErrors without the fix. `ruff check`, `pyright`, and the test pass locally.

## Notes
Issue #1 of 3 from the 0.13.0 incident; ships in the **0.13.1** hotfix. The namespace-version guard (issue #2) is a separate PR; the APM route-doubling (issue #3) is under investigation.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Restores ADK state update compatibility by sending `task_id` and `agent_id` in the `states.update` request body via `extra_body`.
- Keeps the generated `state` parameter while adding the legacy identifiers required by older backends.
- Adds regression coverage for forwarding the parent identifiers during `StateService.update_state`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped to restoring compatibility for ADK state updates and includes targeted regression coverage.

No correctness issues were identified in the changed service logic or test coverage, and the update preserves the generated state payload while adding the legacy identifiers expected by older backends.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the pre-change state-update test output, which exited with code 0 and showed mocked states.update kwargs without extra\_body.
- Observed the post-change state-update test output, which exited with code 0 and showed mocked states.update kwargs now including extra\_body with {'agent\_id': 'a1', 'task\_id': 't1'}, while state\_id and state remained unchanged (state\_id: 's1', state: {'k': 'v'}).
- Reviewed the regression-test attempt log, which documented the command and import blocker and did not contradict the direct head behavior shown by the before/after results.

<a href="https://app.greptile.com/trex/runs/11411140/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(adk): re-send task\_id/agent\_id in st..."](https://github.com/scaleapi/scale-agentex-python/commit/9110115158b13c2eac88dfa04cc1d5623bf7ba94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38172989)</sub>

<!-- /greptile_comment -->