### PR TITLE
fix(packaging): guard agentex-client surface, bump floor, smoke-test wheel install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
         # force-include can't build via the sdist-then-wheel default.
         run: uv build --all-packages --wheel
 
+      - name: Smoke-test wheel install
+        # Both wheels must install together into one working agentex.* namespace.
+        run: ./scripts/check-wheel-install
+
       - name: Get GitHub OIDC Token
         if: |-
           github.repository == 'stainless-sdks/agentex-sdk-python' &&

--- a/adk/pyproject.toml
+++ b/adk/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 dependencies = [
     # Co-released in lockstep; floor-only by design — a ceiling would
     # eventually exclude the co-versioned slim (release-please can't bump it).
-    "agentex-client>=0.12.0",
+    "agentex-client>=0.13.0",
     # CLI surface (agentex.lib.cli.*, agentex.lib.sdk.config.*)
     "typer>=0.16,<0.17",
     "questionary>=2.0.1,<3",

--- a/scripts/check-wheel-install
+++ b/scripts/check-wheel-install
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Smoke: agentex-client + agentex-sdk must install together into one working
+# agentex.* namespace. Builds + installs in a clean temp dir to avoid stale dist/.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+work="$(mktemp -d)"
+echo "==> building both wheels into $work/dist"
+uv build --all-packages --wheel --out-dir "$work/dist"
+
+venv="$work/venv"
+uv venv "$venv" >/dev/null
+echo "==> installing both wheels into a fresh venv"
+uv pip install --python "$venv" "$work"/dist/agentex_client-*.whl "$work"/dist/agentex_sdk-*.whl
+
+echo "==> importing the merged namespace from the installed wheels"
+"$venv/bin/python" - <<'PY'
+import agentex.lib.adk  # ADK overlay — ships in agentex-sdk
+from agentex.types import Event  # client surface — ships in agentex-client
+from agentex.resources import states  # client surface that "didn't land" in the incident
+
+print("agentex namespace OK:", Event.__name__, states.__name__)
+PY

--- a/src/agentex/lib/__init__.py
+++ b/src/agentex/lib/__init__.py
@@ -1,0 +1,4 @@
+from agentex.lib._version_guard import verify_client_compatibility
+
+# Fail fast + clearly on a skewed/incomplete agentex-client install.
+verify_client_compatibility()

--- a/src/agentex/lib/_version_guard.py
+++ b/src/agentex/lib/_version_guard.py
@@ -1,0 +1,28 @@
+"""Fail fast with a clear error on an incomplete agentex-client install instead
+of a cryptic `cannot import name ... from agentex.types`."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _installed(package: str) -> str:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def verify_client_compatibility() -> None:
+    # Canary on the client REST surface, not the version: newer clients are fine
+    # (additive); we only fail if a symbol/resource the ADK needs is absent.
+    try:
+        from agentex.types import Event as _Event  # noqa: F401
+        from agentex.resources import states as _states  # noqa: F401
+    except (ImportError, AttributeError) as exc:
+        raise ImportError(
+            f"agentex-sdk could not import the agentex-client REST surface it "
+            f"depends on (agentex-sdk={_installed('agentex-sdk')}, "
+            f"agentex-client={_installed('agentex-client')}). Reinstall both at a "
+            f"compatible version, e.g. `pip install --force-reinstall agentex-sdk`."
+        ) from exc

--- a/tests/lib/test_version_guard.py
+++ b/tests/lib/test_version_guard.py
@@ -1,0 +1,26 @@
+"""Tests for the agentex-client compatibility guard (0.13.0 split regression)."""
+
+from __future__ import annotations
+
+import pytest
+
+import agentex.lib._version_guard as guard
+
+
+def test_passes_when_surface_present() -> None:
+    guard.verify_client_compatibility()  # full client surface installed
+
+
+def test_newer_client_not_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Version is not a gate: a newer client (additive) with the full surface passes.
+    monkeypatch.setattr(guard, "version", lambda pkg: "0.14.0" if pkg == "agentex-client" else "0.13.0")
+    guard.verify_client_compatibility()
+
+
+def test_raises_when_client_surface_incomplete(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agentex.types
+
+    # A partial install missing a needed symbol fails with an actionable error.
+    monkeypatch.delattr(agentex.types, "Event", raising=False)
+    with pytest.raises(ImportError, match="could not import the agentex-client REST surface"):
+        guard.verify_client_compatibility()

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "agentex-client"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -91,7 +91,7 @@ dev = [
 
 [[package]]
 name = "agentex-sdk"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "adk" }
 dependencies = [
     { name = "agentex-client" },


### PR DESCRIPTION
## What
Hardens the 0.13.0 split (agentex-sdk + agentex-client share the agentex.* namespace), four ways:
1. **Floor bump** — `agentex-client>=0.13.0` (first release where it ships separately). Floor-only (no `==` ceiling: release-please can't bump it).
2. **Lock sync** — `uv.lock` lagged pyproject at `0.12.0`; synced to `0.13.0` so frozen installs resolve a client that satisfies the floor.
3. **Import-time guard** (`agentex.lib`) — canaries the `agentex-client` REST surface and raises a clear, actionable `ImportError` if a symbol/resource the ADK needs is absent, instead of a cryptic `cannot import name 'Event' from 'agentex.types'`. **It does not gate on version** — newer clients are additive and pass; versions are reported in the message for diagnosis only.
4. **Wheel-install smoke** (`scripts/check-wheel-install`, wired into the build CI job) — builds both wheels, installs them together into a fresh venv, imports `agentex.lib.adk` + the `agentex.types`/`resources` surface.

## Guard scope (honest)
Catches an **incomplete client surface** (a needed symbol/resource missing) — the incident's failure — regardless of version direction. **Newer clients are not rejected** (by design: clients are additive; removals aren't planned).

Does **not** catch a *fully* missing client surface: `import agentex` fails in the client's own `__init__` (eager `from . import types`) before `agentex.lib` runs. The **wheel smoke** covers that at the build layer — so guard + smoke are complementary.

## Tests
`tests/lib/test_version_guard.py`: passes with the full surface; passes for a newer client (version is not a gate); raises on a missing canary symbol. Wheel smoke verified locally (positive + sdk-only `--no-deps` teeth check). `ruff`/`pyright` clean.

## Notes
Issue #2 of 3 from the 0.13.0 incident; ships in **0.13.1** (#405 + #407 merged). Route-doubling (#3) is on a separate investigation.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Raises the ADK dependency floor to `agentex-client>=0.13.0` and syncs the lockfile metadata.
- Adds an import-time compatibility guard for `agentex-client` version skew and missing generated surface.
- Adds guard unit tests plus a CI wheel-install smoke test that builds and imports the split packages together.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are narrowly scoped to packaging metadata, an import compatibility guard, and CI smoke coverage for the split package install path.

No code issues were identified in the reviewed changes, and the added tests directly cover the intended version-skew and missing-surface behaviors.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the dependency floor checks to verify packaging metadata and resolver behavior across before and after states.
- Assessed the agentex import guard scenario when Event and states are missing, observed an ImportError, and later confirmed a complete surface run reported SUCCESS.
- Executed a wheel smoke test in CI to validate wheel builds and import readiness, resulting in successful builds for agentex\_client-0.13.0 and agentex\_sdk-0.13.0, a fresh venv install, and a final import that confirms the Event namespace OK.

<a href="https://app.greptile.com/trex/runs/11422838/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(packaging): guard agentex-client sur..."](https://github.com/scaleapi/scale-agentex-python/commit/17266892aeb0144a140c3d50b4ea3f111d3a18da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38174306)</sub>

<!-- /greptile_comment -->