### PR TITLE
fix(streaming): CoalescingBuffer hogs CPU — idle/orphaned ticker spins at 1/FLUSH_INTERVAL forever

### DIFF
--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -518,21 +518,23 @@ class StreamingTaskMessageContext:
                 await self._buffer.add(update)
                 return update
 
+        # A full message supersedes the streamed deltas and ends the stream.
+        # Drain and stop the coalescing buffer BEFORE publishing the Full, so any
+        # leftover buffered deltas land on the stream in order (deltas -> Full)
+        # rather than after the terminal Full — a consumer treating Full as the
+        # final message would otherwise see those trailing deltas as a stale
+        # duplicate tail. Closing here also stops the ticker, so it can't be
+        # orphaned when __aexit__'s close() later short-circuits on _is_closed.
+        if isinstance(update, StreamTaskMessageFull) and self._buffer is not None:
+            await self._buffer.close()
+            self._buffer = None
+
         result = await self._streaming_service.stream_update(update)
 
         if isinstance(update, StreamTaskMessageDone):
             await self.close()
             return update
         elif isinstance(update, StreamTaskMessageFull):
-            # A full message supersedes any buffered deltas and ends the stream.
-            # Close the coalescing buffer (stopping its ticker) BEFORE marking
-            # the context done — otherwise __aexit__'s close() early-returns on
-            # _is_closed and the ticker is never stopped, polling forever and
-            # leaking CPU (mirrors the StreamTaskMessageDone branch, which closes
-            # via self.close()).
-            if self._buffer is not None:
-                await self._buffer.close()
-                self._buffer = None
             await self._agentex_client.messages.update(
                 task_id=self.task_id,
                 message_id=update.parent_task_message.id,  # type: ignore[union-attr]

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -166,7 +166,12 @@ class CoalescingBuffer:
         self._first_flushed = False
         self._closed = False
         self._lock = asyncio.Lock()
-        self._flush_signal = asyncio.Event()
+        # Two events so the ticker can park at zero CPU when idle:
+        #   _wake      — buffer went empty -> non-empty; the ticker should run
+        #   _flush_now — flush immediately (first delta / size threshold / close),
+        #                bypassing the coalescing window
+        self._wake = asyncio.Event()
+        self._flush_now = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
 
     def start(self) -> None:
@@ -177,22 +182,42 @@ class CoalescingBuffer:
         if self._closed:
             return
         async with self._lock:
+            was_empty = not self._buf
             self._buf.append(update)
             self._buf_chars += _delta_char_len(update.delta)
             if not self._first_flushed or self._buf_chars >= self.MAX_BUFFERED_CHARS:
                 self._first_flushed = True
-                self._flush_signal.set()
+                self._flush_now.set()
+            # Wake the (possibly parked) ticker when the buffer goes from empty
+            # to non-empty; it then applies the coalescing window itself.
+            if was_empty:
+                self._wake.set()
 
     async def _run(self) -> None:
         try:
             while True:
-                try:
-                    await asyncio.wait_for(self._flush_signal.wait(), timeout=self.FLUSH_INTERVAL_S)
-                except asyncio.TimeoutError:
-                    pass
+                # Park at zero CPU until there is data to flush (or close()).
+                # This is the key change from a fixed-interval ticker: an idle
+                # or orphaned buffer blocks here instead of waking every
+                # FLUSH_INTERVAL_S forever — the latter leaked CPU when a buffer
+                # outlived its stream without close() running (one spinning task
+                # per such stream).
+                await self._wake.wait()
+                self._wake.clear()
+                # First delta / size threshold / close flush immediately;
+                # otherwise coalesce for up to FLUSH_INTERVAL_S so consecutive
+                # deltas batch into a single publish.
+                if not self._flush_now.is_set() and not self._closed:
+                    try:
+                        await asyncio.wait_for(self._flush_now.wait(), timeout=self.FLUSH_INTERVAL_S)
+                    except asyncio.TimeoutError:
+                        pass
                 async with self._lock:
-                    self._flush_signal.clear()
+                    self._flush_now.clear()
                     drained = self._drain_locked()
+                    # Data that arrived during the flush keeps the ticker running.
+                    if self._buf:
+                        self._wake.set()
                 for u in drained:
                     try:
                         await self._on_flush(u)
@@ -215,12 +240,17 @@ class CoalescingBuffer:
         # producing the duplicate-tail symptom seen on the UI stream.
         self._closed = True
         if self._task is not None:
-            self._flush_signal.set()
+            # Wake the parked ticker so it sees _closed and exits after its
+            # next drain.
+            self._wake.set()
+            self._flush_now.set()
             try:
                 await self._task
             except asyncio.CancelledError:
-                # Propagate if our caller is being cancelled; the task itself
-                # swallows CancelledError so this only fires on outer cancel.
+                # Our caller is being cancelled. Force-cancel the ticker so it
+                # can never be orphaned into a parked/looping task, then
+                # propagate the cancellation.
+                self._task.cancel()
                 raise
             self._task = None
         async with self._lock:

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -215,9 +215,9 @@ class CoalescingBuffer:
                 async with self._lock:
                     self._flush_now.clear()
                     drained = self._drain_locked()
-                    # Data that arrived during the flush keeps the ticker running.
-                    if self._buf:
-                        self._wake.set()
+                # Deltas that arrive after this drain (e.g. during the _on_flush
+                # awaits below) re-arm the ticker via add()'s empty->non-empty
+                # _wake.set(), so the loop re-runs to flush them.
                 for u in drained:
                     try:
                         await self._on_flush(u)
@@ -450,14 +450,16 @@ class StreamingTaskMessageContext:
         if not self.task_message:
             raise ValueError("Context not properly initialized - no task message")
 
-        if self._is_closed:
-            return self.task_message  # Already done
-
-        # Drain any buffered deltas before announcing DONE so consumers see the
-        # full sequence in order.
+        # Always reap the buffer ticker first, even if the context was already
+        # marked done by a Full/Done update on another path. close() is the last
+        # line of defense against an orphaned, forever-polling ticker, so it must
+        # never be short-circuited before stopping it.
         if self._buffer is not None:
             await self._buffer.close()
             self._buffer = None
+
+        if self._is_closed:
+            return self.task_message  # Already done (buffer reaped above)
 
         # Send the DONE event
         done_event = StreamTaskMessageDone(
@@ -522,6 +524,15 @@ class StreamingTaskMessageContext:
             await self.close()
             return update
         elif isinstance(update, StreamTaskMessageFull):
+            # A full message supersedes any buffered deltas and ends the stream.
+            # Close the coalescing buffer (stopping its ticker) BEFORE marking
+            # the context done — otherwise __aexit__'s close() early-returns on
+            # _is_closed and the ticker is never stopped, polling forever and
+            # leaking CPU (mirrors the StreamTaskMessageDone branch, which closes
+            # via self.close()).
+            if self._buffer is not None:
+                await self._buffer.close()
+                self._buffer = None
             await self._agentex_client.messages.update(
                 task_id=self.task_id,
                 message_id=update.parent_task_message.id,  # type: ignore[union-attr]

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -216,17 +216,21 @@ class CoalescingBuffer:
                         await self._on_flush(u)
                     except Exception as e:
                         logger.exception(f"CoalescingBuffer flush failed: {e}")
-                # Check _closed *after* draining so close() gets a final flush
-                # pass and each item is published exactly once.
+                # Check _closed *after* draining so close() always gets a final
+                # in-loop flush pass. Exiting here (instead of being cancelled
+                # mid-flush) guarantees each in-flight item is published exactly
+                # once — close()'s final drain then only picks up items added
+                # after the last lock release.
                 if self._closed:
                     return
         except asyncio.CancelledError:
             pass
 
     async def close(self) -> None:
-        # Let the ticker exit after its next drain rather than cancelling
-        # mid-flush, which could re-publish a delta whose Redis write already
-        # completed (the duplicate-tail symptom seen on the UI stream).
+        # Signal the ticker to stop and let it exit naturally after its next
+        # drain. Cancelling mid-flush would risk re-publishing a delta whose
+        # Redis write already completed but whose await had not yet returned,
+        # producing the duplicate-tail symptom seen on the UI stream.
         self._closed = True
         if self._task is not None:
             self._wake.set()

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -235,12 +235,12 @@ class CoalescingBuffer:
         if self._task is not None:
             self._wake.set()
             self._flush_now.set()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                # Outer cancel: force-cancel the ticker so it isn't orphaned.
-                self._task.cancel()
-                raise
+            # Shield the ticker: if close() is cancelled, awaiting the task bare
+            # would propagate the cancel into the ticker mid-flush, and _run
+            # swallows CancelledError — silently dropping an already-drained
+            # batch. Shielded, the ticker finishes its in-flight flush and exits
+            # on _closed; the cancel still propagates to our caller.
+            await asyncio.shield(self._task)
             self._task = None
         async with self._lock:
             drained = self._drain_locked()
@@ -434,8 +434,14 @@ class StreamingTaskMessageContext:
 
         return self
 
-    async def close(self) -> TaskMessage:
-        """Close the streaming context."""
+    async def close(self, done_event: StreamTaskMessageDone | None = None) -> TaskMessage:
+        """Close the streaming context.
+
+        ``done_event`` is the caller-provided terminal update when close is
+        driven by a streamed ``StreamTaskMessageDone`` — published as-is so its
+        ``index``/``parent_task_message`` survive. An implicit close (``__aexit__``)
+        passes nothing and a terminal Done is synthesized.
+        """
         if not self.task_message:
             raise ValueError("Context not properly initialized - no task message")
 
@@ -448,12 +454,10 @@ class StreamingTaskMessageContext:
         if self._is_closed:
             return self.task_message  # Already done (buffer reaped above)
 
-        # Send the DONE event
-        done_event = StreamTaskMessageDone(
-            parent_task_message=self.task_message,
-            type="done",
+        # Send the DONE event (the caller's, if provided, so its metadata survives).
+        await self._streaming_service.stream_update(
+            done_event or StreamTaskMessageDone(parent_task_message=self.task_message, type="done")
         )
-        await self._streaming_service.stream_update(done_event)
 
         # Update the task message with the final content
         has_deltas = (
@@ -505,19 +509,18 @@ class StreamingTaskMessageContext:
                 await self._buffer.add(update)
                 return update
 
-        # Terminal Done/Full updates must drain and stop the buffer BEFORE the
-        # terminal event reaches consumers, so leftover deltas land in order
-        # (deltas -> terminal) instead of trailing it as a stale duplicate tail.
-        # This also stops the ticker so it isn't orphaned past __aexit__'s close().
-        if isinstance(update, (StreamTaskMessageDone, StreamTaskMessageFull)) and self._buffer is not None:
+        if isinstance(update, StreamTaskMessageDone):
+            # close() drains the buffer first, then publishes this exact Done
+            # once (preserving its index/parent), persists, and marks closed.
+            await self.close(done_event=update)
+            return update
+
+        # Full publishes below, so drain and stop the buffer first → leftover
+        # deltas land in order (deltas -> Full) instead of trailing the terminal
+        # Full as a stale duplicate tail. Also stops the ticker.
+        if isinstance(update, StreamTaskMessageFull) and self._buffer is not None:
             await self._buffer.close()
             self._buffer = None
-
-        if isinstance(update, StreamTaskMessageDone):
-            # close() publishes the single terminal Done, persists, and marks the
-            # context closed — don't publish here too, that would duplicate it.
-            await self.close()
-            return update
 
         result = await self._streaming_service.stream_update(update)
 

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -166,10 +166,9 @@ class CoalescingBuffer:
         self._first_flushed = False
         self._closed = False
         self._lock = asyncio.Lock()
-        # Two events so the ticker can park at zero CPU when idle:
-        #   _wake      — buffer went empty -> non-empty; the ticker should run
-        #   _flush_now — flush immediately (first delta / size threshold / close),
-        #                bypassing the coalescing window
+        # _wake lets the ticker park at zero CPU when idle (set on empty ->
+        # non-empty); _flush_now bypasses the coalescing window (first delta /
+        # size threshold / close).
         self._wake = asyncio.Event()
         self._flush_now = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
@@ -188,25 +187,20 @@ class CoalescingBuffer:
             if not self._first_flushed or self._buf_chars >= self.MAX_BUFFERED_CHARS:
                 self._first_flushed = True
                 self._flush_now.set()
-            # Wake the (possibly parked) ticker when the buffer goes from empty
-            # to non-empty; it then applies the coalescing window itself.
+            # Unpark the ticker; it applies the coalescing window itself.
             if was_empty:
                 self._wake.set()
 
     async def _run(self) -> None:
         try:
             while True:
-                # Park at zero CPU until there is data to flush (or close()).
-                # This is the key change from a fixed-interval ticker: an idle
-                # or orphaned buffer blocks here instead of waking every
-                # FLUSH_INTERVAL_S forever — the latter leaked CPU when a buffer
-                # outlived its stream without close() running (one spinning task
-                # per such stream).
+                # Park at zero CPU until there is data (or close()). A
+                # fixed-interval ticker instead leaked CPU on buffers orphaned
+                # without close() — one task spinning every FLUSH_INTERVAL_S.
                 await self._wake.wait()
                 self._wake.clear()
-                # First delta / size threshold / close flush immediately;
-                # otherwise coalesce for up to FLUSH_INTERVAL_S so consecutive
-                # deltas batch into a single publish.
+                # Coalesce for up to FLUSH_INTERVAL_S unless an immediate flush
+                # is already pending.
                 if not self._flush_now.is_set() and not self._closed:
                     try:
                         await asyncio.wait_for(self._flush_now.wait(), timeout=self.FLUSH_INTERVAL_S)
@@ -215,41 +209,32 @@ class CoalescingBuffer:
                 async with self._lock:
                     self._flush_now.clear()
                     drained = self._drain_locked()
-                # Deltas that arrive after this drain (e.g. during the _on_flush
-                # awaits below) re-arm the ticker via add()'s empty->non-empty
-                # _wake.set(), so the loop re-runs to flush them.
+                # Deltas arriving during the _on_flush awaits below re-arm the
+                # ticker via add(), so they get flushed on the next loop.
                 for u in drained:
                     try:
                         await self._on_flush(u)
                     except Exception as e:
                         logger.exception(f"CoalescingBuffer flush failed: {e}")
-                # Check _closed *after* draining so close() always gets a final
-                # in-loop flush pass. Exiting here (instead of being cancelled
-                # mid-flush) guarantees each in-flight item is published exactly
-                # once — close()'s final drain then only picks up items added
-                # after the last lock release.
+                # Check _closed *after* draining so close() gets a final flush
+                # pass and each item is published exactly once.
                 if self._closed:
                     return
         except asyncio.CancelledError:
             pass
 
     async def close(self) -> None:
-        # Signal the ticker to stop and let it exit naturally after its next
-        # drain. Cancelling mid-flush would risk re-publishing a delta whose
-        # Redis write already completed but whose await had not yet returned,
-        # producing the duplicate-tail symptom seen on the UI stream.
+        # Let the ticker exit after its next drain rather than cancelling
+        # mid-flush, which could re-publish a delta whose Redis write already
+        # completed (the duplicate-tail symptom seen on the UI stream).
         self._closed = True
         if self._task is not None:
-            # Wake the parked ticker so it sees _closed and exits after its
-            # next drain.
             self._wake.set()
             self._flush_now.set()
             try:
                 await self._task
             except asyncio.CancelledError:
-                # Our caller is being cancelled. Force-cancel the ticker so it
-                # can never be orphaned into a parked/looping task, then
-                # propagate the cancellation.
+                # Outer cancel: force-cancel the ticker so it isn't orphaned.
                 self._task.cancel()
                 raise
             self._task = None
@@ -450,10 +435,8 @@ class StreamingTaskMessageContext:
         if not self.task_message:
             raise ValueError("Context not properly initialized - no task message")
 
-        # Always reap the buffer ticker first, even if the context was already
-        # marked done by a Full/Done update on another path. close() is the last
-        # line of defense against an orphaned, forever-polling ticker, so it must
-        # never be short-circuited before stopping it.
+        # Reap the buffer ticker before the _is_closed short-circuit, so a
+        # context already marked done by another path can't orphan it.
         if self._buffer is not None:
             await self._buffer.close()
             self._buffer = None
@@ -518,13 +501,10 @@ class StreamingTaskMessageContext:
                 await self._buffer.add(update)
                 return update
 
-        # A full message supersedes the streamed deltas and ends the stream.
-        # Drain and stop the coalescing buffer BEFORE publishing the Full, so any
-        # leftover buffered deltas land on the stream in order (deltas -> Full)
-        # rather than after the terminal Full — a consumer treating Full as the
-        # final message would otherwise see those trailing deltas as a stale
-        # duplicate tail. Closing here also stops the ticker, so it can't be
-        # orphaned when __aexit__'s close() later short-circuits on _is_closed.
+        # Drain and stop the buffer BEFORE publishing the Full, so leftover
+        # deltas land in order (deltas -> Full); publishing them after the
+        # terminal Full would look like a stale duplicate tail. This also stops
+        # the ticker so it isn't orphaned past __aexit__'s close().
         if isinstance(update, StreamTaskMessageFull) and self._buffer is not None:
             await self._buffer.close()
             self._buffer = None

--- a/src/agentex/lib/core/services/adk/streaming.py
+++ b/src/agentex/lib/core/services/adk/streaming.py
@@ -505,20 +505,23 @@ class StreamingTaskMessageContext:
                 await self._buffer.add(update)
                 return update
 
-        # Drain and stop the buffer BEFORE publishing the Full, so leftover
-        # deltas land in order (deltas -> Full); publishing them after the
-        # terminal Full would look like a stale duplicate tail. This also stops
-        # the ticker so it isn't orphaned past __aexit__'s close().
-        if isinstance(update, StreamTaskMessageFull) and self._buffer is not None:
+        # Terminal Done/Full updates must drain and stop the buffer BEFORE the
+        # terminal event reaches consumers, so leftover deltas land in order
+        # (deltas -> terminal) instead of trailing it as a stale duplicate tail.
+        # This also stops the ticker so it isn't orphaned past __aexit__'s close().
+        if isinstance(update, (StreamTaskMessageDone, StreamTaskMessageFull)) and self._buffer is not None:
             await self._buffer.close()
             self._buffer = None
 
-        result = await self._streaming_service.stream_update(update)
-
         if isinstance(update, StreamTaskMessageDone):
+            # close() publishes the single terminal Done, persists, and marks the
+            # context closed — don't publish here too, that would duplicate it.
             await self.close()
             return update
-        elif isinstance(update, StreamTaskMessageFull):
+
+        result = await self._streaming_service.stream_update(update)
+
+        if isinstance(update, StreamTaskMessageFull):
             await self._agentex_client.messages.update(
                 task_id=self.task_id,
                 message_id=update.parent_task_message.id,  # type: ignore[union-attr]

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -22,7 +22,10 @@ from agentex.types.task_message_delta import (
     ToolResponseDelta,
     ReasoningSummaryDelta,
 )
-from agentex.types.task_message_update import StreamTaskMessageDelta
+from agentex.types.task_message_update import (
+    StreamTaskMessageDelta,
+    StreamTaskMessageFull,
+)
 from agentex.lib.core.services.adk.streaming import (
     CoalescingBuffer,
     StreamingTaskMessageContext,
@@ -574,3 +577,54 @@ class TestStreamingTaskMessageContextCreatedAt:
 
         kwargs = client.messages.create.call_args.kwargs
         assert kwargs["created_at"] is omit
+
+
+class TestFullMessageClosesBuffer:
+    """Regression: a StreamTaskMessageFull must stop the coalescing-buffer ticker.
+
+    A ``StreamTaskMessageFull`` ends the stream and marks the context done. If it
+    marks ``_is_closed`` without closing the buffer, ``__aexit__``'s ``close()``
+    early-returns on the ``_is_closed`` guard and the ticker is never stopped —
+    it polls every ``FLUSH_INTERVAL_S`` forever, one orphaned task per stream
+    (the OneEdge worker CPU leak). These tests pin both halves of the fix:
+    the Full branch closes the buffer, and ``close()`` reaps it even if the
+    context was already marked closed by another path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_message_stops_ticker(self) -> None:
+        ctx, _svc, tm = await _make_context("coalesced")
+        # Stream a delta so the buffer and its background ticker are live.
+        await ctx.stream_update(_text(tm, "hello"))
+        buf = ctx._buffer
+        assert buf is not None
+        task = buf._task
+        assert task is not None and not task.done()
+
+        # End-of-turn full message (OneEdge's pattern).
+        await ctx.stream_update(
+            StreamTaskMessageFull(
+                parent_task_message=tm,
+                content=TextContent(author="agent", content="final", format="markdown"),
+                type="full",
+            )
+        )
+
+        assert ctx._buffer is None, "Full message left the buffer un-closed"
+        assert task.done(), "coalescing-buffer ticker still running after Full (orphaned)"
+
+    @pytest.mark.asyncio
+    async def test_close_reaps_buffer_even_if_already_marked_closed(self) -> None:
+        # Defense-in-depth: if any path marks the context closed without closing
+        # the buffer, close() must still stop the ticker rather than short-circuit.
+        ctx, _svc, tm = await _make_context("coalesced")
+        await ctx.stream_update(_text(tm, "hi"))
+        buf = ctx._buffer
+        assert buf is not None
+        task = buf._task
+        assert task is not None and not task.done()
+
+        ctx._is_closed = True  # stray "already done" mark with a live buffer
+        await ctx.close()
+
+        assert task.done(), "close() must reap the buffer even when already marked closed"

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -23,8 +23,8 @@ from agentex.types.task_message_delta import (
     ReasoningSummaryDelta,
 )
 from agentex.types.task_message_update import (
-    StreamTaskMessageDelta,
     StreamTaskMessageFull,
+    StreamTaskMessageDelta,
 )
 from agentex.lib.core.services.adk.streaming import (
     CoalescingBuffer,

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -400,6 +400,35 @@ class TestCoalescingBufferClose:
         await buf.add(_text(task_message, "after"))
         assert flushed == []
 
+    @pytest.mark.asyncio
+    async def test_cancelled_close_does_not_drop_in_flight_batch(self, task_message: TaskMessage) -> None:
+        """If close() is cancelled while the ticker is mid-flush, the already-
+        drained batch must still publish — not be lost to a force-cancel."""
+        flushed: list[StreamTaskMessageDelta] = []
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+
+        async def on_flush(u: StreamTaskMessageDelta) -> None:
+            entered.set()
+            await gate.wait()  # block mid-flush, before the item is recorded
+            flushed.append(u)
+
+        buf = CoalescingBuffer(on_flush=on_flush)
+        buf.start()
+        await buf.add(_text(task_message, "hi"))  # first delta → immediate flush
+        await entered.wait()  # ticker is now blocked inside on_flush
+
+        close_task = asyncio.create_task(buf.close())
+        await asyncio.sleep(0)  # let close() reach `await self._task`
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+        gate.set()  # release the in-flight flush
+        assert buf._task is not None
+        await buf._task  # ticker finishes the batch and exits on _closed
+        assert len(flushed) == 1, "in-flight batch was dropped on cancelled close()"
+
 
 class TestCoalescingBufferCloseDuringFlush:
     @pytest.mark.asyncio
@@ -625,20 +654,24 @@ class TestFullMessageClosesBuffer:
     @pytest.mark.asyncio
     async def test_done_is_single_terminal_publish_no_trailing_deltas(self) -> None:
         # Same guarantee as Full: buffered deltas publish BEFORE the terminal
-        # Done, and Done is published exactly once (not duplicated by close()).
+        # Done, Done is published exactly once (not duplicated by close()), and
+        # the caller's Done is published as-is so its metadata (index) survives.
         ctx, svc, tm = await _make_context("coalesced")
         # "alpha" flushes immediately; "beta" stays buffered in the window.
         await ctx.stream_update(_text(tm, "alpha"))
         await ctx.stream_update(_text(tm, "beta"))
 
-        await ctx.stream_update(StreamTaskMessageDone(parent_task_message=tm, type="done"))
+        done = StreamTaskMessageDone(parent_task_message=tm, type="done", index=7)
+        await ctx.stream_update(done)
 
         published = [c.args[0] for c in svc.stream_update.await_args_list]
         dones = [u for u in published if isinstance(u, StreamTaskMessageDone)]
         assert len(dones) == 1, f"Done must publish exactly once, saw {len(dones)}"
-        assert isinstance(published[-1], StreamTaskMessageDone), (
-            f"Done must be the terminal publish; saw trailing {type(published[-1]).__name__}"
+        assert published[-1] is done, (
+            f"the caller's Done must be the terminal publish (metadata preserved); "
+            f"saw trailing {type(published[-1]).__name__}"
         )
+        assert dones[0].index == 7, "caller's Done index must be preserved, not synthesized away"
         assert any(isinstance(u, StreamTaskMessageDelta) for u in published[:-1]), (
             "expected the buffered deltas to be published before the Done"
         )

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -614,6 +614,35 @@ class TestFullMessageClosesBuffer:
         assert task.done(), "coalescing-buffer ticker still running after Full (orphaned)"
 
     @pytest.mark.asyncio
+    async def test_full_is_terminal_publish_no_trailing_deltas(self) -> None:
+        # Leftover buffered deltas must be drained BEFORE the Full hits the
+        # stream (deltas -> Full), never after it — a consumer treating Full as
+        # the final message would see a trailing delta as a stale duplicate tail.
+        ctx, svc, tm = await _make_context("coalesced")
+        # First delta flushes immediately; the second stays in the coalescing
+        # window, so it is still buffered when the Full arrives.
+        await ctx.stream_update(_text(tm, "alpha"))
+        await ctx.stream_update(_text(tm, "beta"))
+
+        full = StreamTaskMessageFull(
+            parent_task_message=tm,
+            content=TextContent(author="agent", content="alphabeta", format="markdown"),
+            type="full",
+        )
+        await ctx.stream_update(full)
+
+        # Every publish (delta flushes + the Full) goes through the service mock.
+        published = [c.args[0] for c in svc.stream_update.await_args_list]
+        assert published, "nothing was published"
+        assert published[-1] is full, (
+            f"Full must be the terminal publish; saw trailing "
+            f"{type(published[-1]).__name__} after it (stale duplicate tail)"
+        )
+        assert any(isinstance(u, StreamTaskMessageDelta) for u in published[:-1]), (
+            "expected the buffered deltas to be published before the Full"
+        )
+
+    @pytest.mark.asyncio
     async def test_close_reaps_buffer_even_if_already_marked_closed(self) -> None:
         # Defense-in-depth: if any path marks the context closed without closing
         # the buffer, close() must still stop the ticker rather than short-circuit.

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -23,6 +23,7 @@ from agentex.types.task_message_delta import (
     ReasoningSummaryDelta,
 )
 from agentex.types.task_message_update import (
+    StreamTaskMessageDone,
     StreamTaskMessageFull,
     StreamTaskMessageDelta,
 )
@@ -619,6 +620,27 @@ class TestFullMessageClosesBuffer:
         )
         assert any(isinstance(u, StreamTaskMessageDelta) for u in published[:-1]), (
             "expected the buffered deltas to be published before the Full"
+        )
+
+    @pytest.mark.asyncio
+    async def test_done_is_single_terminal_publish_no_trailing_deltas(self) -> None:
+        # Same guarantee as Full: buffered deltas publish BEFORE the terminal
+        # Done, and Done is published exactly once (not duplicated by close()).
+        ctx, svc, tm = await _make_context("coalesced")
+        # "alpha" flushes immediately; "beta" stays buffered in the window.
+        await ctx.stream_update(_text(tm, "alpha"))
+        await ctx.stream_update(_text(tm, "beta"))
+
+        await ctx.stream_update(StreamTaskMessageDone(parent_task_message=tm, type="done"))
+
+        published = [c.args[0] for c in svc.stream_update.await_args_list]
+        dones = [u for u in published if isinstance(u, StreamTaskMessageDone)]
+        assert len(dones) == 1, f"Done must publish exactly once, saw {len(dones)}"
+        assert isinstance(published[-1], StreamTaskMessageDone), (
+            f"Done must be the terminal publish; saw trailing {type(published[-1]).__name__}"
+        )
+        assert any(isinstance(u, StreamTaskMessageDelta) for u in published[:-1]), (
+            "expected the buffered deltas to be published before the Done"
         )
 
     @pytest.mark.asyncio

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -307,16 +307,12 @@ class TestCoalescingBufferTimeWindow:
 
 
 class TestCoalescingBufferIdleParks:
-    """Regression: the ticker must park (block on its wake event) when there is
-    no buffered data, instead of waking every FLUSH_INTERVAL_S. The old
-    fixed-interval ticker spun at 1/FLUSH_INTERVAL forever, so a buffer that
-    outlived its stream (orphaned, close() not run) pinned worker CPU — one
-    spinning task per such stream.
-    """
+    """The ticker must park on its wake event when idle, not poll every
+    FLUSH_INTERVAL_S — a buffer orphaned without close() otherwise pins CPU."""
 
     @staticmethod
     def _count_drains(buf: CoalescingBuffer) -> list[int]:
-        """Instrument _drain_locked to count ticker wake/drain cycles."""
+        """Instrument _drain_locked to count drain cycles."""
         n = [0]
         orig = buf._drain_locked
 
@@ -329,14 +325,11 @@ class TestCoalescingBufferIdleParks:
 
     @pytest.mark.asyncio
     async def test_idle_buffer_does_not_spin(self) -> None:
-        """With no data ever added, the ticker must not drain at all over many
-        FLUSH_INTERVAL_S windows."""
         buf = CoalescingBuffer(on_flush=AsyncMock())
         drains = self._count_drains(buf)
         buf.start()
         try:
-            # ~8 windows at FLUSH_INTERVAL_S=0.050; a polling ticker would have
-            # woken ~8 times. A parked ticker drains 0 times.
+            # ~8 FLUSH_INTERVAL_S windows; a polling ticker would drain ~8x.
             await asyncio.sleep(0.4)
             assert drains[0] == 0, f"idle ticker woke {drains[0]}x (must park at 0)"
         finally:
@@ -344,20 +337,17 @@ class TestCoalescingBufferIdleParks:
 
     @pytest.mark.asyncio
     async def test_orphaned_buffer_parks_after_flush(self, task_message: TaskMessage) -> None:
-        """A buffer whose close() never runs (orphaned on an abnormal stream
-        exit) must still park at zero CPU once its data is drained — not spin.
-        This is the exact condition that previously leaked worker CPU."""
+        """An orphaned buffer (close() never runs) must still park once drained."""
         buf = CoalescingBuffer(on_flush=AsyncMock())
         buf.start()
         try:
-            await buf.add(_text(task_message, "hi"))  # one immediate flush
-            await asyncio.sleep(0.020)  # let it flush and park
-            drains = self._count_drains(buf)
-            # Deliberately do NOT close — simulate an orphaned buffer.
+            await buf.add(_text(task_message, "hi"))
+            await asyncio.sleep(0.020)  # let the immediate flush land and park
+            drains = self._count_drains(buf)  # count only post-flush cycles
             await asyncio.sleep(0.4)
             assert drains[0] == 0, f"orphaned ticker woke {drains[0]}x (must park at 0)"
         finally:
-            await buf.close()  # cleanup only
+            await buf.close()
 
 
 class TestCoalescingBufferClose:
@@ -580,28 +570,20 @@ class TestStreamingTaskMessageContextCreatedAt:
 
 
 class TestFullMessageClosesBuffer:
-    """Regression: a StreamTaskMessageFull must stop the coalescing-buffer ticker.
-
-    A ``StreamTaskMessageFull`` ends the stream and marks the context done. If it
-    marks ``_is_closed`` without closing the buffer, ``__aexit__``'s ``close()``
-    early-returns on the ``_is_closed`` guard and the ticker is never stopped —
-    it polls every ``FLUSH_INTERVAL_S`` forever, one orphaned task per stream
-    (the OneEdge worker CPU leak). These tests pin both halves of the fix:
-    the Full branch closes the buffer, and ``close()`` reaps it even if the
-    context was already marked closed by another path.
-    """
+    """A StreamTaskMessageFull must stop the buffer ticker. If it marks the
+    context done without closing the buffer, close()'s _is_closed short-circuit
+    leaves the ticker orphaned (the worker CPU leak)."""
 
     @pytest.mark.asyncio
     async def test_full_message_stops_ticker(self) -> None:
         ctx, _svc, tm = await _make_context("coalesced")
-        # Stream a delta so the buffer and its background ticker are live.
+        # A delta makes the buffer and its ticker live.
         await ctx.stream_update(_text(tm, "hello"))
         buf = ctx._buffer
         assert buf is not None
         task = buf._task
         assert task is not None and not task.done()
 
-        # End-of-turn full message (OneEdge's pattern).
         await ctx.stream_update(
             StreamTaskMessageFull(
                 parent_task_message=tm,
@@ -615,12 +597,10 @@ class TestFullMessageClosesBuffer:
 
     @pytest.mark.asyncio
     async def test_full_is_terminal_publish_no_trailing_deltas(self) -> None:
-        # Leftover buffered deltas must be drained BEFORE the Full hits the
-        # stream (deltas -> Full), never after it — a consumer treating Full as
-        # the final message would see a trailing delta as a stale duplicate tail.
+        # Buffered deltas must publish BEFORE the Full, never after (a trailing
+        # delta after the terminal Full reads as a stale duplicate tail).
         ctx, svc, tm = await _make_context("coalesced")
-        # First delta flushes immediately; the second stays in the coalescing
-        # window, so it is still buffered when the Full arrives.
+        # "alpha" flushes immediately; "beta" stays buffered in the window.
         await ctx.stream_update(_text(tm, "alpha"))
         await ctx.stream_update(_text(tm, "beta"))
 
@@ -631,7 +611,6 @@ class TestFullMessageClosesBuffer:
         )
         await ctx.stream_update(full)
 
-        # Every publish (delta flushes + the Full) goes through the service mock.
         published = [c.args[0] for c in svc.stream_update.await_args_list]
         assert published, "nothing was published"
         assert published[-1] is full, (
@@ -644,8 +623,7 @@ class TestFullMessageClosesBuffer:
 
     @pytest.mark.asyncio
     async def test_close_reaps_buffer_even_if_already_marked_closed(self) -> None:
-        # Defense-in-depth: if any path marks the context closed without closing
-        # the buffer, close() must still stop the ticker rather than short-circuit.
+        # close() must stop the ticker even when _is_closed is already set.
         ctx, _svc, tm = await _make_context("coalesced")
         await ctx.stream_update(_text(tm, "hi"))
         buf = ctx._buffer

--- a/tests/lib/core/services/adk/test_streaming.py
+++ b/tests/lib/core/services/adk/test_streaming.py
@@ -303,6 +303,60 @@ class TestCoalescingBufferTimeWindow:
             await buf.close()
 
 
+class TestCoalescingBufferIdleParks:
+    """Regression: the ticker must park (block on its wake event) when there is
+    no buffered data, instead of waking every FLUSH_INTERVAL_S. The old
+    fixed-interval ticker spun at 1/FLUSH_INTERVAL forever, so a buffer that
+    outlived its stream (orphaned, close() not run) pinned worker CPU — one
+    spinning task per such stream.
+    """
+
+    @staticmethod
+    def _count_drains(buf: CoalescingBuffer) -> list[int]:
+        """Instrument _drain_locked to count ticker wake/drain cycles."""
+        n = [0]
+        orig = buf._drain_locked
+
+        def counting() -> list[StreamTaskMessageDelta]:
+            n[0] += 1
+            return orig()
+
+        buf._drain_locked = counting  # type: ignore[method-assign]
+        return n
+
+    @pytest.mark.asyncio
+    async def test_idle_buffer_does_not_spin(self) -> None:
+        """With no data ever added, the ticker must not drain at all over many
+        FLUSH_INTERVAL_S windows."""
+        buf = CoalescingBuffer(on_flush=AsyncMock())
+        drains = self._count_drains(buf)
+        buf.start()
+        try:
+            # ~8 windows at FLUSH_INTERVAL_S=0.050; a polling ticker would have
+            # woken ~8 times. A parked ticker drains 0 times.
+            await asyncio.sleep(0.4)
+            assert drains[0] == 0, f"idle ticker woke {drains[0]}x (must park at 0)"
+        finally:
+            await buf.close()
+
+    @pytest.mark.asyncio
+    async def test_orphaned_buffer_parks_after_flush(self, task_message: TaskMessage) -> None:
+        """A buffer whose close() never runs (orphaned on an abnormal stream
+        exit) must still park at zero CPU once its data is drained — not spin.
+        This is the exact condition that previously leaked worker CPU."""
+        buf = CoalescingBuffer(on_flush=AsyncMock())
+        buf.start()
+        try:
+            await buf.add(_text(task_message, "hi"))  # one immediate flush
+            await asyncio.sleep(0.020)  # let it flush and park
+            drains = self._count_drains(buf)
+            # Deliberately do NOT close — simulate an orphaned buffer.
+            await asyncio.sleep(0.4)
+            assert drains[0] == 0, f"orphaned ticker woke {drains[0]}x (must park at 0)"
+        finally:
+            await buf.close()  # cleanup only
+
+
 class TestCoalescingBufferClose:
     @pytest.mark.asyncio
     async def test_close_drains_remaining_buffered_items(self, task_message: TaskMessage) -> None:


### PR DESCRIPTION
## Summary
`CoalescingBuffer` (`agentex/lib/core/services/adk/streaming.py`) runs a per-instance background ticker that **wakes every `FLUSH_INTERVAL_S` (50 ms) whether or not there is buffered data**. Because one buffer + ticker is created per streaming task-message context, any buffer that outlives its stream without a clean `close()` becomes an **orphaned task that polls at 20 Hz forever**. In a long-lived worker that handles many streaming tasks, these accumulate and **ratchet CPU up until a core is saturated**, with **no memory growth** and **no log output**, clearing only on process restart.

This PR fixes two related issues:
1. The idle/orphaned ticker spinning at 20 Hz (the CPU hog).
2. A path that **orphans the ticker even on a clean exit**: a `StreamTaskMessageFull` marked the context done without closing the buffer, so `close()` later short-circuited on `_is_closed` and never stopped the ticker.

## Symptoms
- Worker CPU climbs steadily with cumulative streamed tasks and never recovers between idle periods (e.g. ~0.04 cores fresh → ~0.55 after a load run → pinned at the CPU limit after sustained traffic). Latency degrades in lockstep as the dead tickers steal the event loop / GIL from live work.
- Memory stays flat; nothing is logged.
- A process restart resets it.

## Root cause
```python
# CoalescingBuffer._run (before)
while True:
    try:
        await asyncio.wait_for(self._flush_signal.wait(), timeout=self.FLUSH_INTERVAL_S)
    except asyncio.TimeoutError:
        pass
    async with self._lock:
        self._flush_signal.clear()
        drained = self._drain_locked()   # empty when idle
    ...
    if self._closed:
        return
```
When the buffer is empty and `_closed` is `False`, the `wait_for` times out every 50 ms, drains nothing, and loops — a permanent 20 Hz busy-loop. The loop only exits on `_closed`, which is set by `close()`. If `close()` never runs, or is interrupted by cancellation while awaiting the ticker, the ticker is **orphaned and spins indefinitely**. With N orphaned/idle buffers, the event loop spends most of its time arming/cancelling `TimerHandle`s.

Separately, `StreamingTaskMessageContext.stream_update` handled a `StreamTaskMessageFull` by setting `_is_closed = True` **without closing the buffer**. The subsequent `__aexit__ → close()` then hit its `if self._is_closed: return` guard and skipped the buffer teardown — leaving a live ticker behind on an otherwise clean stream end.

## Evidence (py-spy on an affected worker)
```
py-spy top:  GIL 69%, Active 73%
 41%  _run (asyncio/events.py)            # event loop running timer callbacks
 22%  _run (.../adk/streaming.py)         # CoalescingBuffer._run
 17%  wait_for (asyncio/tasks.py)
 11%  reschedule/__aenter__ (asyncio/timeouts.py)
  9%  __init__ (asyncio/events.py)        # TimerHandle churn

py-spy dump (event loop thread):
    wait_for (asyncio/tasks.py:506)
    _run (.../adk/streaming.py:190)       # the 50 ms wait_for
```
CPU was ~linearly proportional to the number of streamed tasks since the last restart; terminating the in-flight tasks/workflows did not release it (the leak is the worker-process asyncio tasks, independent of task/workflow state).

## Fix
**1. Park-on-idle ticker.** Replace the single `_flush_signal` + fixed-interval wait with **two events** so the ticker parks at zero CPU when idle:
- `_wake` — set by `add()` only when the buffer goes **empty → non-empty**. `_run` blocks on `await self._wake.wait()` when idle (no polling).
- `_flush_now` — set on **first delta / size threshold / close** → immediate flush, bypassing the coalescing delay.

`_run` parks on `_wake`; on wake it flushes immediately if `_flush_now` is set, otherwise coalesces for up to `FLUSH_INTERVAL_S`, drains, and exits on `_closed`. `close()` additionally **force-cancels** the ticker if `close()` itself is cancelled, so it can never be orphaned on the cancellation path.

**2. `StreamTaskMessageFull` closes the buffer.** The `Full` branch now drains and closes the buffer (stopping the ticker) **before** publishing the `Full`, and `close()` reaps the buffer **before** its `_is_closed` short-circuit. Two effects:
- The ticker is always stopped, even when a `Full` ends the stream — no orphaned task.
- Leftover buffered deltas publish **before** the terminal `Full` (`deltas → Full`), never after it. Publishing them after would look like a stale duplicate tail to a consumer treating `Full` as the final message.

**Behaviour preserved:** first-delta-immediate flush (latency-critical), the `MAX_BUFFERED_CHARS` early flush, the `FLUSH_INTERVAL_S` coalescing window for trailing partials, and the exactly-once final drain on `close()`. The only difference: an idle or orphaned buffer **parks** instead of polling, and under light streaming (buffer empties between deltas) a delta may flush slightly sooner — coalescing under sustained streaming is unchanged.

## Tests
- New `TestCoalescingBufferIdleParks`:
  - `test_idle_buffer_does_not_spin` — no data added → **0 drain cycles** over ~8 windows (was ~8).
  - `test_orphaned_buffer_parks_after_flush` — buffer flushed then **never closed** → **0 drain cycles** afterward.
- New `TestFullMessageClosesBuffer`:
  - `test_full_message_stops_ticker` — a `Full` stops the ticker (task is `done()`); buffer is reaped.
  - `test_full_is_terminal_publish_no_trailing_deltas` — buffered deltas publish before the `Full`; the `Full` is the terminal publish.
  - `test_close_reaps_buffer_even_if_already_marked_closed` — `close()` stops the ticker even when `_is_closed` is already set.
- Full streaming suite: **36 passed** (`tests/lib/core/services/adk/test_streaming.py`).

## Risk
Low. Hot-path semantics (first-flush, size/time coalescing, exactly-once close drain) are covered by the existing tests and unchanged. The change is local to `CoalescingBuffer` and `StreamingTaskMessageContext`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CPU-leak in `CoalescingBuffer` where the per-instance background ticker polled at 20 Hz even when idle, and a related code path in `StreamingTaskMessageContext` that could orphan the ticker on a clean stream end. The fix replaces the fixed-interval `_flush_signal` with a `_wake` (park-on-idle) / `_flush_now` (bypass coalescing) dual-event design, and uses `asyncio.shield` so a cancelled `close()` can no longer force-cancel the ticker mid-flush.

- **Park-on-idle ticker**: `_run` now blocks at `await self._wake.wait()` and only runs the coalescing window when `add()` signals data; orphaned/idle buffers consume zero CPU.
- **`StreamTaskMessageFull` closes the buffer**: deltas are drained and the ticker stopped *before* the terminal `Full` is published, fixing both the stale-tail ordering problem and the ticker-orphan-on-clean-exit bug.
- **`asyncio.shield` for close cancellation**: a cancelled `close()` no longer propagates cancellation into the ticker mid-flush; the ticker finishes its current batch and exits naturally on `_closed`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is local to CoalescingBuffer and StreamingTaskMessageContext, hot-path semantics (first-flush immediacy, coalescing window, exactly-once drain) are unchanged and covered by the existing suite, and the new tests directly exercise all four previously-broken scenarios.

The dual-event design correctly parks the ticker at zero CPU when idle. The asyncio.shield usage is appropriate: it protects the ticker's in-flight batch from a cancelled close() while still propagating CancelledError to the caller. The final drain after shield is safe because _closed=True prevents new additions before the ticker exits, so the buffer is empty when the ticker returns. Terminal-message ordering (deltas before Full/Done, Done published exactly once with its original metadata) is verified end-to-end by the new test suite. No data-loss, ordering, or resource-leak paths were found in the changed code.

No files require special attention — both changed files are well-scoped and thoroughly tested.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/services/adk/streaming.py | Core fix: replaces polling ticker with park-on-idle dual-event design (_wake/_flush_now), closes buffer on Full/Done, uses asyncio.shield to prevent ticker cancellation mid-flush. Logic is correct — idle/orphaned buffers park at zero CPU, deltas always precede terminal messages, and the Done metadata (index/parent) is preserved via the done_event parameter. |
| tests/lib/core/services/adk/test_streaming.py | New test classes cover all four fixed scenarios: idle-park, orphaned-park, cancelled-close data safety, Full-stops-ticker, Full-ordering (deltas before Full), Done-ordering (deltas before Done, exactly-once, index preserved), and close-reaps-buffer-when-already-marked-closed. Tests are behaviorally correct and complete. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant P as Producer (stream_update)
    participant B as CoalescingBuffer
    participant T as Ticker (_run)
    participant S as StreamingService

    Note over T: parked at _wake.wait() (zero CPU)

    P->>B: add(delta₁) [first delta]
    B->>B: _flush_now.set() + _wake.set()
    B-->>T: wakes
    T->>T: _wake.clear()
    T->>T: _flush_now.is_set() → skip coalesce window
    T->>B: _drain_locked() [acquires lock]
    T->>S: _on_flush(delta₁)

    P->>B: add(delta₂)
    Note over B: was_empty=True → _wake.set()
    T->>B: _drain_locked() [next loop]
    T->>S: _on_flush(delta₂)
    T->>T: _closed? No → back to _wake.wait() (parks)

    Note over T: idle — zero CPU, no polling

    P->>P: stream_update(StreamTaskMessageFull)
    P->>B: buffer.close()
    B->>B: "_closed=True, _wake.set(), _flush_now.set()"
    B-->>T: wakes (final pass)
    T->>B: _drain_locked() [empty]
    T->>T: "_closed=True → return"
    B->>B: asyncio.shield(task) resolves
    B->>B: final drain (empty)
    P->>S: stream_update(Full) ← after all deltas

    Note over P,S: Done path: close(done_event=update) drains buffer first, then publishes Done exactly once
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant P as Producer (stream_update)
    participant B as CoalescingBuffer
    participant T as Ticker (_run)
    participant S as StreamingService

    Note over T: parked at _wake.wait() (zero CPU)

    P->>B: add(delta₁) [first delta]
    B->>B: _flush_now.set() + _wake.set()
    B-->>T: wakes
    T->>T: _wake.clear()
    T->>T: _flush_now.is_set() → skip coalesce window
    T->>B: _drain_locked() [acquires lock]
    T->>S: _on_flush(delta₁)

    P->>B: add(delta₂)
    Note over B: was_empty=True → _wake.set()
    T->>B: _drain_locked() [next loop]
    T->>S: _on_flush(delta₂)
    T->>T: _closed? No → back to _wake.wait() (parks)

    Note over T: idle — zero CPU, no polling

    P->>P: stream_update(StreamTaskMessageFull)
    P->>B: buffer.close()
    B->>B: "_closed=True, _wake.set(), _flush_now.set()"
    B-->>T: wakes (final pass)
    T->>B: _drain_locked() [empty]
    T->>T: "_closed=True → return"
    B->>B: asyncio.shield(task) resolves
    B->>B: final drain (empty)
    P->>S: stream_update(Full) ← after all deltas

    Note over P,S: Done path: close(done_event=update) drains buffer first, then publishes Done exactly once
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/agentex/lib/core/services/adk/streaming.py`, line 514-515 ([link](https://github.com/scaleapi/scale-agentex-python/blob/3c6c2a9ffa08b25d522b510d61613cc4967aaea5/src/agentex/lib/core/services/adk/streaming.py#L514-L515)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Drain Before Done**

   This `Done` branch still publishes the terminal update before reaping the coalesced buffer. When a provider emits `StreamTaskMessageDone` while a delta is still inside the 50ms coalescing window, callers receive `Done`, then the buffered delta from `close()`, then the `Done` created by `close()`. A consumer that treats `Done` as terminal can therefore see stale trailing content and duplicate terminal events. The `Done` path needs the same pre-terminal buffer drain ordering as the `Full` path.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused pytest harness for Done before coalesced buffer drain](https://app.greptile.com/trex/artifacts/25555544-2c4f-47e5-86a6-01dc5862325b)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: verbose pytest output showing publish order and duplicate Done](https://app.greptile.com/trex/artifacts/86bcc59a-13be-48af-b642-828889fb9176)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11837766/artifacts?artifact=25555544-2c4f-47e5-86a6-01dc5862325b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/core/services/adk/streaming.py
   Line: 514-515

   Comment:
   **Drain Before Done**

   This `Done` branch still publishes the terminal update before reaping the coalesced buffer. When a provider emits `StreamTaskMessageDone` while a delta is still inside the 50ms coalescing window, callers receive `Done`, then the buffered delta from `close()`, then the `Done` created by `close()`. A consumer that treats `Done` as terminal can therefore see stale trailing content and duplicate terminal events. The `Done` path needs the same pre-terminal buffer drain ordering as the `Full` path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%0ALine%3A%20514-515%0A%0AComment%3A%0A**Drain%20Before%20Done**%0A%0AThis%20%60Done%60%20branch%20still%20publishes%20the%20terminal%20update%20before%20reaping%20the%20coalesced%20buffer.%20When%20a%20provider%20emits%20%60StreamTaskMessageDone%60%20while%20a%20delta%20is%20still%20inside%20the%2050ms%20coalescing%20window%2C%20callers%20receive%20%60Done%60%2C%20then%20the%20buffered%20delta%20from%20%60close%28%29%60%2C%20then%20the%20%60Done%60%20created%20by%20%60close%28%29%60.%20A%20consumer%20that%20treats%20%60Done%60%20as%20terminal%20can%20therefore%20see%20stale%20trailing%20content%20and%20duplicate%20terminal%20events.%20The%20%60Done%60%20path%20needs%20the%20same%20pre-terminal%20buffer%20drain%20ordering%20as%20the%20%60Full%60%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%0ALine%3A%20514-515%0A%0AComment%3A%0A**Drain%20Before%20Done**%0A%0AThis%20%60Done%60%20branch%20still%20publishes%20the%20terminal%20update%20before%20reaping%20the%20coalesced%20buffer.%20When%20a%20provider%20emits%20%60StreamTaskMessageDone%60%20while%20a%20delta%20is%20still%20inside%20the%2050ms%20coalescing%20window%2C%20callers%20receive%20%60Done%60%2C%20then%20the%20buffered%20delta%20from%20%60close%28%29%60%2C%20then%20the%20%60Done%60%20created%20by%20%60close%28%29%60.%20A%20consumer%20that%20treats%20%60Done%60%20as%20terminal%20can%20therefore%20see%20stale%20trailing%20content%20and%20duplicate%20terminal%20events.%20The%20%60Done%60%20path%20needs%20the%20same%20pre-terminal%20buffer%20drain%20ordering%20as%20the%20%60Full%60%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22endre%2Fimprove-buffer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22endre%2Fimprove-buffer%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%0ALine%3A%20514-515%0A%0AComment%3A%0A**Drain%20Before%20Done**%0A%0AThis%20%60Done%60%20branch%20still%20publishes%20the%20terminal%20update%20before%20reaping%20the%20coalesced%20buffer.%20When%20a%20provider%20emits%20%60StreamTaskMessageDone%60%20while%20a%20delta%20is%20still%20inside%20the%2050ms%20coalescing%20window%2C%20callers%20receive%20%60Done%60%2C%20then%20the%20buffered%20delta%20from%20%60close%28%29%60%2C%20then%20the%20%60Done%60%20created%20by%20%60close%28%29%60.%20A%20consumer%20that%20treats%20%60Done%60%20as%20terminal%20can%20therefore%20see%20stale%20trailing%20content%20and%20duplicate%20terminal%20events.%20The%20%60Done%60%20path%20needs%20the%20same%20pre-terminal%20buffer%20drain%20ordering%20as%20the%20%60Full%60%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `src/agentex/lib/core/services/adk/streaming.py`, line 518-519 ([link](https://github.com/scaleapi/scale-agentex-python/blob/a56d1815d0c5021df296ce97bc7b5a5c51008169/src/agentex/lib/core/services/adk/streaming.py#L518-L519)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Done can precede deltas**

   `StreamTaskMessageDone` still publishes the terminal event before `close()` drains the coalescing buffer. When a coalesced stream has already used the first immediate flush, then receives a small buffered delta followed by an explicit Done before the 50ms window expires, consumers can see `Done -> delta -> Done` or at least a delta after terminal Done. Drain and close the buffer before publishing the incoming Done, and avoid sending a second Done from `close()`.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused async pytest exercising explicit Done before coalescing window drains](https://app.greptile.com/trex/artifacts/25865de4-c043-4a82-83d5-02282e7240cf)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: verbose pytest failure output with captured published order](https://app.greptile.com/trex/artifacts/0544d820-15c2-40bc-aee0-d6598c2349dc)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11838369/artifacts?artifact=25865de4-c043-4a82-83d5-02282e7240cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/core/services/adk/streaming.py
   Line: 518-519

   Comment:
   **Done can precede deltas**

   `StreamTaskMessageDone` still publishes the terminal event before `close()` drains the coalescing buffer. When a coalesced stream has already used the first immediate flush, then receives a small buffered delta followed by an explicit Done before the 50ms window expires, consumers can see `Done -> delta -> Done` or at least a delta after terminal Done. Drain and close the buffer before publishing the incoming Done, and avoid sending a second Done from `close()`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%0ALine%3A%20518-519%0A%0AComment%3A%0A**Done%20can%20precede%20deltas**%0A%0A%60StreamTaskMessageDone%60%20still%20publishes%20the%20terminal%20event%20before%20%60close%28%29%60%20drains%20the%20coalescing%20buffer.%20When%20a%20coalesced%20stream%20has%20already%20used%20the%20first%20immediate%20flush%2C%20then%20receives%20a%20small%20buffered%20delta%20followed%20by%20an%20explicit%20Done%20before%20the%2050ms%20window%20expires%2C%20consumers%20can%20see%20%60Done%20-%3E%20delta%20-%3E%20Done%60%20or%20at%20least%20a%20delta%20after%20terminal%20Done.%20Drain%20and%20close%20the%20buffer%20before%20publishing%20the%20incoming%20Done%2C%20and%20avoid%20sending%20a%20second%20Done%20from%20%60close%28%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%0ALine%3A%20518-519%0A%0AComment%3A%0A**Done%20can%20precede%20deltas**%0A%0A%60StreamTaskMessageDone%60%20still%20publishes%20the%20terminal%20event%20before%20%60close%28%29%60%20drains%20the%20coalescing%20buffer.%20When%20a%20coalesced%20stream%20has%20already%20used%20the%20first%20immediate%20flush%2C%20then%20receives%20a%20small%20buffered%20delta%20followed%20by%20an%20explicit%20Done%20before%20the%2050ms%20window%20expires%2C%20consumers%20can%20see%20%60Done%20-%3E%20delta%20-%3E%20Done%60%20or%20at%20least%20a%20delta%20after%20terminal%20Done.%20Drain%20and%20close%20the%20buffer%20before%20publishing%20the%20incoming%20Done%2C%20and%20avoid%20sending%20a%20second%20Done%20from%20%60close%28%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22endre%2Fimprove-buffer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22endre%2Fimprove-buffer%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Fservices%2Fadk%2Fstreaming.py%0ALine%3A%20518-519%0A%0AComment%3A%0A**Done%20can%20precede%20deltas**%0A%0A%60StreamTaskMessageDone%60%20still%20publishes%20the%20terminal%20event%20before%20%60close%28%29%60%20drains%20the%20coalescing%20buffer.%20When%20a%20coalesced%20stream%20has%20already%20used%20the%20first%20immediate%20flush%2C%20then%20receives%20a%20small%20buffered%20delta%20followed%20by%20an%20explicit%20Done%20before%20the%2050ms%20window%20expires%2C%20consumers%20can%20see%20%60Done%20-%3E%20delta%20-%3E%20Done%60%20or%20at%20least%20a%20delta%20after%20terminal%20Done.%20Drain%20and%20close%20the%20buffer%20before%20publishing%20the%20incoming%20Done%2C%20and%20avoid%20sending%20a%20second%20Done%20from%20%60close%28%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(streaming): preserve Done metadata a..."](https://github.com/scaleapi/scale-agentex-python/commit/0aec588d68015b4b802aaf28a715dc8d7c611bf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38995033)</sub>

<!-- /greptile_comment -->