### PR TITLE
refactor(cli): migrate existing langgraph/pydantic-ai templates to unified surface

### DIFF
--- a/src/agentex/lib/adk/__init__.py
+++ b/src/agentex/lib/adk/__init__.py
@@ -10,9 +10,11 @@ from agentex.lib.adk._modules._langgraph_tracing import create_langgraph_tracing
 from agentex.lib.adk._modules._langgraph_async import stream_langgraph_events
 from agentex.lib.adk._modules._langgraph_messages import emit_langgraph_messages
 from agentex.lib.adk._modules._langgraph_sync import convert_langgraph_to_agentex_events
+from agentex.lib.adk._modules._langgraph_turn import LangGraphTurn
 from agentex.lib.adk._modules._pydantic_ai_async import stream_pydantic_ai_events
 from agentex.lib.adk._modules._pydantic_ai_sync import convert_pydantic_ai_to_agentex_events
 from agentex.lib.adk._modules._pydantic_ai_tracing import create_pydantic_ai_tracing_handler
+from agentex.lib.adk._modules._pydantic_ai_turn import PydanticAITurn
 from agentex.lib.adk._modules._claude_code_sync import convert_claude_code_to_agentex_events
 from agentex.lib.adk._modules._claude_code_turn import (
     ClaudeCodeTurn,
@@ -70,10 +72,12 @@ __all__ = [
     "stream_langgraph_events",
     "emit_langgraph_messages",
     "convert_langgraph_to_agentex_events",
+    "LangGraphTurn",
     # Pydantic AI
     "stream_pydantic_ai_events",
     "convert_pydantic_ai_to_agentex_events",
     "create_pydantic_ai_tracing_handler",
+    "PydanticAITurn",
     # Claude Code
     "convert_claude_code_to_agentex_events",
     "ClaudeCodeTurn",

--- a/src/agentex/lib/cli/templates/default-langgraph/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/project/acp.py.j2
@@ -15,13 +15,14 @@ if _litellm_key:
     os.environ["OPENAI_API_KEY"] = _litellm_key
 
 import agentex.lib.adk as adk
-from agentex.lib.adk import create_langgraph_tracing_handler, stream_langgraph_events
+from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.protocol.acp import SendEventParams, CancelTaskParams, CreateTaskParams
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.lib.adk import LangGraphTurn
 
 from project.graph import create_graph
 
@@ -67,24 +68,23 @@ async def handle_task_event_send(params: SendEventParams):
         input={"message": user_message},
         data={"__span_type__": "AGENT_WORKFLOW"},
     ) as turn_span:
-        callback = create_langgraph_tracing_handler(
+        stream = graph.astream(
+            {"messages": [{"role": "user", "content": user_message}]},
+            config={"configurable": {"thread_id": task_id}},
+            stream_mode=["messages", "updates"],
+        )
+
+        turn = LangGraphTurn(stream, model=None)
+        emitter = UnifiedEmitter(
+            task_id=task_id,
             trace_id=task_id,
             parent_span_id=turn_span.id if turn_span else None,
         )
 
-        stream = graph.astream(
-            {"messages": [{"role": "user", "content": user_message}]},
-            config={
-                "configurable": {"thread_id": task_id},
-                "callbacks": [callback],
-            },
-            stream_mode=["messages", "updates"],
-        )
-
-        final_output = await stream_langgraph_events(stream, task_id)
+        result = await emitter.auto_send_turn(turn)
 
         if turn_span:
-            turn_span.output = {"final_output": final_output}
+            turn_span.output = {"final_output": result.final_text}
 
 
 @acp.on_task_create

--- a/src/agentex/lib/cli/templates/default-pydantic-ai/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-pydantic-ai/project/acp.py.j2
@@ -19,21 +19,19 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from project.agent import create_agent
+from project.agent import MODEL_NAME, create_agent
 from pydantic_ai.run import AgentRunResultEvent
 from pydantic_ai.messages import ModelMessagesTypeAdapter
 
 import agentex.lib.adk as adk
-from agentex.lib.adk import (
-    stream_pydantic_ai_events,
-    create_pydantic_ai_tracing_handler,
-)
 from agentex.protocol.acp import SendEventParams, CancelTaskParams, CreateTaskParams
+from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.utils.model_utils import BaseModel
 from agentex.lib.sdk.fastacp.fastacp import FastACP
+from agentex.lib.adk import PydanticAITurn
 from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
 
 logger = make_logger(__name__)
@@ -125,15 +123,17 @@ async def handle_task_event_send(params: SendEventParams):
         input={"message": user_message},
         data={"__span_type__": "AGENT_WORKFLOW"},
     ) as turn_span:
-        tracing_handler = create_pydantic_ai_tracing_handler(
+        # Construct the UnifiedEmitter from the ACP context so tracing is
+        # automatic and messages are auto-sent to the task stream (Redis).
+        emitter = UnifiedEmitter(
+            task_id=task_id,
             trace_id=task_id,
             parent_span_id=turn_span.id if turn_span else None,
-            task_id=task_id,
         )
 
         # Wrap the pydantic-ai event stream so we can capture the final
         # AgentRunResultEvent (which carries the full message list for the
-        # next turn) without changing the streaming-helper's signature.
+        # next turn) before forwarding events to the emitter.
         captured_messages: list[Any] = []
 
         async def tee_messages(upstream) -> AsyncIterator[Any]:
@@ -143,9 +143,8 @@ async def handle_task_event_send(params: SendEventParams):
                 yield event
 
         async with agent.run_stream_events(user_message, message_history=previous_messages) as stream:
-            final_output = await stream_pydantic_ai_events(
-                tee_messages(stream), task_id, tracing_handler=tracing_handler
-            )
+            turn = PydanticAITurn(tee_messages(stream), model=MODEL_NAME)
+            result = await emitter.auto_send_turn(turn)
 
         # Save the updated message history so the next turn picks up here.
         if captured_messages:
@@ -158,7 +157,7 @@ async def handle_task_event_send(params: SendEventParams):
             )
 
         if turn_span:
-            turn_span.output = {"final_output": final_output}
+            turn_span.output = {"final_output": result.final_text}
 
 
 @acp.on_task_cancel

--- a/src/agentex/lib/cli/templates/sync-langgraph/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/project/acp.py.j2
@@ -8,12 +8,13 @@ tokens and tool calls from the LangGraph graph to the Agentex frontend.
 from typing import AsyncGenerator
 
 import agentex.lib.adk as adk
-from agentex.lib.adk import create_langgraph_tracing_handler, convert_langgraph_to_agentex_events
+from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.protocol.acp import SendMessageParams
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.lib.adk import LangGraphTurn
 from agentex.types.task_message_content import TaskMessageContent
 from agentex.types.task_message_delta import TextDelta
 from agentex.types.task_message_update import TaskMessageUpdate
@@ -72,22 +73,21 @@ async def handle_message_send(
         input={"message": user_message},
         data={"__span_type__": "AGENT_WORKFLOW"},
     ) as turn_span:
-        callback = create_langgraph_tracing_handler(
+        stream = graph.astream(
+            {"messages": [{"role": "user", "content": user_message}]},
+            config={"configurable": {"thread_id": thread_id}},
+            stream_mode=["messages", "updates"],
+        )
+
+        turn = LangGraphTurn(stream, model=None)
+        emitter = UnifiedEmitter(
+            task_id=thread_id,
             trace_id=thread_id,
             parent_span_id=turn_span.id if turn_span else None,
         )
 
-        stream = graph.astream(
-            {"messages": [{"role": "user", "content": user_message}]},
-            config={
-                "configurable": {"thread_id": thread_id},
-                "callbacks": [callback],
-            },
-            stream_mode=["messages", "updates"],
-        )
-
         final_text = ""
-        async for event in convert_langgraph_to_agentex_events(stream):
+        async for event in emitter.yield_turn(turn):
             # Accumulate text deltas for span output
             delta = getattr(event, "delta", None)
             if isinstance(delta, TextDelta) and delta.text_delta:

--- a/src/agentex/lib/cli/templates/sync-pydantic-ai/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-pydantic-ai/project/acp.py.j2
@@ -15,19 +15,17 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from project.agent import create_agent
+from project.agent import MODEL_NAME, create_agent
 
 import agentex.lib.adk as adk
-from agentex.lib.adk import (
-    create_pydantic_ai_tracing_handler,
-    convert_pydantic_ai_to_agentex_events,
-)
 from agentex.protocol.acp import SendMessageParams
+from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.types.task_message_update import TaskMessageUpdate
 from agentex.types.task_message_content import TaskMessageContent
+from agentex.lib.adk import PydanticAITurn
 from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
 
 logger = make_logger(__name__)
@@ -73,7 +71,7 @@ async def handle_message_send(
     logger.info(f"Processing message for task {task_id}")
 
     # Open a per-message turn span. Tool calls below nest underneath this
-    # span via the tracing handler's parent_span_id wiring.
+    # span via the emitter's parent_span_id wiring.
     async with adk.tracing.span(
         trace_id=task_id,
         task_id=task_id,
@@ -81,13 +79,14 @@ async def handle_message_send(
         input={"message": user_message},
         data={"__span_type__": "AGENT_WORKFLOW"},
     ) as turn_span:
-        tracing_handler = create_pydantic_ai_tracing_handler(
+        # Construct the UnifiedEmitter from the ACP/streaming context so tracing
+        # is automatic: tool spans nest under this turn's span.
+        emitter = UnifiedEmitter(
+            task_id=task_id,
             trace_id=task_id,
             parent_span_id=turn_span.id if turn_span else None,
-            task_id=task_id,
         )
         async with agent.run_stream_events(user_message) as stream:
-            async for event in convert_pydantic_ai_to_agentex_events(
-                stream, tracing_handler=tracing_handler
-            ):
-                yield event
+            turn = PydanticAITurn(stream, model=MODEL_NAME)
+            async for ev in emitter.yield_turn(turn):
+                yield ev

--- a/src/agentex/lib/cli/templates/temporal-pydantic-ai/project/agent.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-pydantic-ai/project/agent.py.j2
@@ -11,9 +11,9 @@ moves into recorded activities.
 
 Streaming back to Agentex happens via ``event_stream_handler``, which
 receives Pydantic AI ``AgentStreamEvent``s from inside the model activity
-and forwards them to Redis using the ``stream_pydantic_ai_events`` helper.
-The ``task_id`` and tracing parent span ID are threaded into the handler
-via ``deps``.
+and forwards them through the unified harness surface
+(``UnifiedEmitter.auto_send_turn`` + ``PydanticAITurn``). The ``task_id`` and
+tracing parent span ID are threaded into the handler via ``deps``.
 """
 
 from __future__ import annotations
@@ -27,10 +27,8 @@ from project.tools import get_weather
 from pydantic_ai.messages import AgentStreamEvent
 from pydantic_ai.durable_exec.temporal import TemporalAgent
 
-from agentex.lib.adk import (
-    stream_pydantic_ai_events,
-    create_pydantic_ai_tracing_handler,
-)
+from agentex.lib.core.harness import UnifiedEmitter
+from agentex.lib.adk import PydanticAITurn
 
 # Swap this for any Pydantic AI-supported model identifier
 # (e.g. "anthropic:claude-3-5-sonnet-latest", "openai:gpt-4o").
@@ -92,17 +90,18 @@ async def event_handler(
     activity (not the workflow), it can freely make non-deterministic Redis
     writes — including the tracing HTTP calls that record per-tool-call
     spans under the workflow's per-turn span (when ``parent_span_id`` is set).
+
+    The UnifiedEmitter is constructed from ``deps`` (task_id + parent_span_id),
+    so tool spans nest under the workflow's per-turn span and messages auto-send
+    to the task stream.
     """
-    tracing_handler = create_pydantic_ai_tracing_handler(
+    emitter = UnifiedEmitter(
+        task_id=run_context.deps.task_id,
         trace_id=run_context.deps.task_id,
         parent_span_id=run_context.deps.parent_span_id,
-        task_id=run_context.deps.task_id,
     )
-    await stream_pydantic_ai_events(
-        events,
-        run_context.deps.task_id,
-        tracing_handler=tracing_handler,
-    )
+    turn = PydanticAITurn(events, model=MODEL_NAME)
+    await emitter.auto_send_turn(turn)
 
 
 # Construct the durable agent at module load time so that the


### PR DESCRIPTION
## Summary

Third slice of #425. Migrates the existing `agentex init` templates onto the unified harness surface, matching the tutorial migration in #428.

- `default-langgraph`, `default-pydantic-ai`, `sync-langgraph`, `sync-pydantic-ai`, `temporal-pydantic-ai`: scaffolded `acp.py` / `agent.py` now use the unified surface.
- No new template dirs here (those land in the template PRs).

## Test plan
- [x] `pytest tests/lib/cli/ -k "init or template"` — 19 passed (all templates render to valid Python)

## Notes
Stacked on #428 (base = `declan-scale/tutorials-unified-surface`). Retarget to `next` after #428 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is the third slice of the unified harness surface migration, updating the five existing `agentex init` scaffolding templates (`default-langgraph`, `default-pydantic-ai`, `sync-langgraph`, `sync-pydantic-ai`, `temporal-pydantic-ai`) to use `UnifiedEmitter` + the new `*Turn` classes instead of the old `stream_*_events` helpers and LangChain callback tracing handlers.

- `LangGraphTurn` and `PydanticAITurn` are promoted to the public `agentex.lib.adk` facade (`__all__`), ensuring generated user project files import only from the stable public API.
- All five templates have their direct `create_*_tracing_handler`/`stream_*_events`/`convert_*_to_agentex_events` calls replaced by `LangGraphTurn`/`PydanticAITurn` + `emitter.yield_turn` or `emitter.auto_send_turn`, matching the pattern established in the tutorials PR (#428).

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all five templates correctly adopt the unified harness surface with no new functional regressions introduced.

The changes are mechanical migrations: old helpers replaced with Turn + UnifiedEmitter, public exports promoted for the two new Turn classes, and import paths cleaned up. The core delivery logic (auto_send_turn, yield_turn, SpanDeriver/SpanTracer) is unchanged and already reviewed in the harness PR. MODEL_NAME imports are valid in both pydantic-ai agent templates, and the tee_messages capture pattern in default-pydantic-ai is preserved correctly.

temporal-pydantic-ai/project/agent.py.j2 carries a pre-existing open question about per-activity SpanTracer lifecycle under TemporalAgent (flagged in a prior review round); no new issues introduced here.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/adk/__init__.py | Promotes LangGraphTurn and PydanticAITurn into the public __all__ so user-facing templates import from the stable surface rather than private _modules subpaths. |
| src/agentex/lib/cli/templates/default-langgraph/project/acp.py.j2 | Replaces create_langgraph_tracing_handler callback + stream_langgraph_events with LangGraphTurn(model=None) + UnifiedEmitter.auto_send_turn; turn_span.output updated to use result.final_text. |
| src/agentex/lib/cli/templates/default-pydantic-ai/project/acp.py.j2 | Replaces create_pydantic_ai_tracing_handler + stream_pydantic_ai_events with PydanticAITurn(model=MODEL_NAME) + UnifiedEmitter.auto_send_turn; tee_messages pattern preserved for capturing message history; MODEL_NAME correctly imported from project.agent. |
| src/agentex/lib/cli/templates/sync-langgraph/project/acp.py.j2 | Replaces create_langgraph_tracing_handler + convert_langgraph_to_agentex_events with LangGraphTurn(model=None) + emitter.yield_turn; final_text accumulation logic unchanged. |
| src/agentex/lib/cli/templates/sync-pydantic-ai/project/acp.py.j2 | Replaces create_pydantic_ai_tracing_handler + convert_pydantic_ai_to_agentex_events with PydanticAITurn(model=MODEL_NAME) + emitter.yield_turn inside existing run_stream_events context manager. |
| src/agentex/lib/cli/templates/temporal-pydantic-ai/project/agent.py.j2 | Replaces create_pydantic_ai_tracing_handler + stream_pydantic_ai_events in event_handler with PydanticAITurn + UnifiedEmitter.auto_send_turn; a fresh SpanTracer is constructed per event_handler invocation (in-memory span state not shared across Temporal activity calls). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant ACP as acp.py (template)
    participant UE as UnifiedEmitter
    participant Turn as LangGraphTurn / PydanticAITurn
    participant SD as SpanDeriver
    participant ST as SpanTracer
    participant Str as adk.streaming (Redis)

    Note over ACP,Str: async (default-*) templates — auto_send_turn path
    ACP->>UE: UnifiedEmitter(task_id, trace_id, parent_span_id)
    UE->>ST: SpanTracer(trace_id, parent_span_id)
    ACP->>Turn: "LangGraphTurn(stream, model=None) / PydanticAITurn(stream, model=MODEL_NAME)"
    ACP->>UE: auto_send_turn(turn)
    UE->>SD: SpanDeriver()
    loop for each StreamTaskMessage event
        Turn-->>UE: event
        UE->>SD: observe(event)
        SD-->>UE: SpanSignals (OpenSpan / CloseSpan)
        UE->>ST: handle(signal) → start_span / end_span
        UE->>Str: streaming_task_message_context / stream_update
    end
    UE->>SD: flush() → close unclosed spans
    UE-->>ACP: TurnResult(final_text, usage)

    Note over ACP,Str: sync (sync-*) templates — yield_turn path
    ACP->>UE: UnifiedEmitter(task_id, trace_id, parent_span_id)
    ACP->>Turn: LangGraphTurn / PydanticAITurn
    ACP->>UE: yield_turn(turn)
    loop for each event
        Turn-->>UE: event
        UE->>SD: observe(event) → SpanSignals
        UE->>ST: handle(signal)
        UE-->>ACP: yield event
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant ACP as acp.py (template)
    participant UE as UnifiedEmitter
    participant Turn as LangGraphTurn / PydanticAITurn
    participant SD as SpanDeriver
    participant ST as SpanTracer
    participant Str as adk.streaming (Redis)

    Note over ACP,Str: async (default-*) templates — auto_send_turn path
    ACP->>UE: UnifiedEmitter(task_id, trace_id, parent_span_id)
    UE->>ST: SpanTracer(trace_id, parent_span_id)
    ACP->>Turn: "LangGraphTurn(stream, model=None) / PydanticAITurn(stream, model=MODEL_NAME)"
    ACP->>UE: auto_send_turn(turn)
    UE->>SD: SpanDeriver()
    loop for each StreamTaskMessage event
        Turn-->>UE: event
        UE->>SD: observe(event)
        SD-->>UE: SpanSignals (OpenSpan / CloseSpan)
        UE->>ST: handle(signal) → start_span / end_span
        UE->>Str: streaming_task_message_context / stream_update
    end
    UE->>SD: flush() → close unclosed spans
    UE-->>ACP: TurnResult(final_text, usage)

    Note over ACP,Str: sync (sync-*) templates — yield_turn path
    ACP->>UE: UnifiedEmitter(task_id, trace_id, parent_span_id)
    ACP->>Turn: LangGraphTurn / PydanticAITurn
    ACP->>UE: yield_turn(turn)
    loop for each event
        Turn-->>UE: event
        UE->>SD: observe(event) → SpanSignals
        UE->>ST: handle(signal)
        UE-->>ACP: yield event
    end
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["refactor(cli): migrate existing langgrap..."](https://github.com/scaleapi/scale-agentex-python/commit/758d5f8d47bd124120894599a317da80a38140a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39296100)</sub>

<!-- /greptile_comment -->