### PR TITLE
feat(cli): add default-openai-agents init template (async base)

### DIFF
--- a/src/agentex/lib/cli/commands/init.py
+++ b/src/agentex/lib/cli/commands/init.py
@@ -29,6 +29,7 @@ class TemplateType(str, Enum):
     DEFAULT = "default"
     DEFAULT_LANGGRAPH = "default-langgraph"
     DEFAULT_PYDANTIC_AI = "default-pydantic-ai"
+    DEFAULT_OPENAI_AGENTS = "default-openai-agents"
     SYNC = "sync"
     SYNC_OPENAI_AGENTS = "sync-openai-agents"
     SYNC_OPENAI_AGENTS_LOCAL_SANDBOX = "sync-openai-agents-local-sandbox"
@@ -69,6 +70,7 @@ def create_project_structure(
         TemplateType.DEFAULT: ["acp.py"],
         TemplateType.DEFAULT_LANGGRAPH: ["acp.py", "graph.py", "tools.py"],
         TemplateType.DEFAULT_PYDANTIC_AI: ["acp.py", "agent.py", "tools.py"],
+        TemplateType.DEFAULT_OPENAI_AGENTS: ["acp.py"],
         TemplateType.SYNC: ["acp.py"],
         TemplateType.SYNC_OPENAI_AGENTS: ["acp.py"],
         TemplateType.SYNC_OPENAI_AGENTS_LOCAL_SANDBOX: ["acp.py", "agent.py", "tools.py"],
@@ -184,6 +186,7 @@ def init():
             "Which Async template would you like to use?",
             choices=[
                 {"name": "Basic Async ACP", "value": TemplateType.DEFAULT},
+                {"name": "Async ACP + OpenAI Agents SDK", "value": TemplateType.DEFAULT_OPENAI_AGENTS},
                 {"name": "Async ACP + LangGraph", "value": TemplateType.DEFAULT_LANGGRAPH},
                 {"name": "Async ACP + Pydantic AI", "value": TemplateType.DEFAULT_PYDANTIC_AI},
             ],

--- a/src/agentex/lib/cli/templates/default-openai-agents/.dockerignore.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/.dockerignore.j2
@@ -1,0 +1,43 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Environments
+.env**
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Git
+.git
+.gitignore
+
+# Misc
+.DS_Store 

--- a/src/agentex/lib/cli/templates/default-openai-agents/.env.example.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/.env.example.j2
@@ -1,0 +1,13 @@
+# {{ agent_name }} - Environment Variables
+# Copy this file to .env and fill in the values
+
+# API key for your LLM provider
+LITELLM_API_KEY=
+
+# LLM base URL (optional - override to use a different provider)
+# OPENAI_BASE_URL=
+
+# SGP Configuration (optional - for tracing)
+# SGP_API_KEY=
+# SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/default-openai-agents/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/Dockerfile-uv.j2
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.3
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    htop \
+    vim \
+    curl \
+    tar \
+    python3-dev \
+    postgresql-client \
+    build-essential \
+    libpq-dev \
+    gcc \
+    cmake \
+    netcat-openbsd \
+    nodejs \
+    npm \ 
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/**
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_HTTP_TIMEOUT=1000
+
+WORKDIR /app/{{ project_path_from_build_root }}
+
+# Copy dependency files for layer caching
+COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+
+# Install dependencies (without project itself, for layer caching)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-install-project --no-dev
+
+# Copy the project code
+COPY {{ project_path_from_build_root }}/project ./project
+
+# Install the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
+ENV PYTHONPATH=/app
+
+# Run the agent using uvicorn
+CMD ["uvicorn", "project.acp:acp", "--host", "0.0.0.0", "--port", "8000"] 

--- a/src/agentex/lib/cli/templates/default-openai-agents/Dockerfile.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/Dockerfile.j2
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.3
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    htop \
+    vim \
+    curl \
+    tar \
+    python3-dev \
+    postgresql-client \
+    build-essential \
+    libpq-dev \
+    gcc \
+    cmake \
+    netcat-openbsd \
+    nodejs \
+    npm \ 
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN uv pip install --system --upgrade pip setuptools wheel
+
+ENV UV_HTTP_TIMEOUT=1000
+
+# Copy just the requirements file to optimize caching
+COPY {{ project_path_from_build_root }}/requirements.txt /app/{{ project_path_from_build_root }}/requirements.txt
+
+WORKDIR /app/{{ project_path_from_build_root }}
+
+# Install the required Python packages
+RUN uv pip install --system -r requirements.txt
+
+# Copy the project code
+COPY {{ project_path_from_build_root }}/project /app/{{ project_path_from_build_root }}/project
+
+
+# Set environment variables
+ENV PYTHONPATH=/app
+
+# Run the agent using uvicorn
+CMD ["uvicorn", "project.acp:acp", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/agentex/lib/cli/templates/default-openai-agents/README.md.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/README.md.j2
@@ -1,0 +1,69 @@
+# {{ agent_name }} - AgentEx Async OpenAI Agents SDK Agent
+
+This template builds an **asynchronous** (non-Temporal) agent built on the
+**OpenAI Agents SDK**, delivered through the unified harness surface on AgentEx:
+- Defines an OpenAI Agents SDK `Agent` (with an example weather tool) inline in
+  `acp.py`
+- Wraps the SDK run in an `OpenAITurn`
+- Delivers canonical `StreamTaskMessage*` events via `UnifiedEmitter.auto_send_turn`
+  (the async Redis push path), so the UI receives output in real time
+- Tracing integration to SGP / AgentEx
+
+## Prerequisites
+
+- An `OPENAI_API_KEY` in your environment (or a `LITELLM_API_KEY`, which is
+  copied to `OPENAI_API_KEY` for LiteLLM-proxy compatibility)
+
+## Running the Agent
+
+```bash
+agentex agents run --manifest manifest.yaml
+```
+
+## Project Structure
+
+```
+{{ project_name }}/
+├── project/
+│   ├── __init__.py
+│   └── acp.py          # ACP server, agent + tool definitions, event handlers
+├── Dockerfile
+├── manifest.yaml
+├── dev.ipynb
+{% if use_uv %}
+└── pyproject.toml
+{% else %}
+└── requirements.txt
+{% endif %}
+```
+
+## Key Concepts
+
+### Async ACP with the harness
+The async ACP model streams events over Redis instead of an HTTP response. The
+`@acp.on_task_event_send` handler runs the OpenAI Agents SDK and pushes the
+harness events to the task stream.
+
+### The unified harness surface
+`OpenAITurn` + `UnifiedEmitter` are the unified harness surface. The turn
+normalizes the SDK's streamed run into canonical AgentEx events; the emitter
+traces and delivers them.
+
+## Development
+
+### 1. Add Your Own Tools
+Define new `@function_tool` functions in `project/acp.py` and add them to the
+agent's `tools=[...]` list in `create_agent()`.
+
+### 2. Customize the Agent
+Edit `MODEL_NAME` and `INSTRUCTIONS` in `project/acp.py` to change the model or
+system prompt.
+
+### 3. Configure Credentials
+Set your credentials via `manifest.yaml`, an exported environment variable, or a
+`.env` file in the project directory.
+
+### 4. Run Locally
+```bash
+export ENVIRONMENT=development && agentex agents run --manifest manifest.yaml
+```

--- a/src/agentex/lib/cli/templates/default-openai-agents/dev.ipynb.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/dev.ipynb.j2
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36834357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agentex import Agentex\n",
+    "\n",
+    "client = Agentex(base_url=\"http://localhost:5003\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1c309d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AGENT_NAME = \"{{ agent_name }}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f6e6ef0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # (Optional) Create a new task. If you don't create a new task, each message will be sent to a new task. The server will create the task for you.\n",
+    "\n",
+    "# import uuid\n",
+    "\n",
+    "# TASK_ID = str(uuid.uuid4())[:8]\n",
+    "\n",
+    "# rpc_response = client.agents.rpc_by_name(\n",
+    "#     agent_name=AGENT_NAME,\n",
+    "#     method=\"task/create\",\n",
+    "#     params={\n",
+    "#         \"name\": f\"{TASK_ID}-task\",\n",
+    "#         \"params\": {}\n",
+    "#     }\n",
+    "# )\n",
+    "\n",
+    "# task = rpc_response.result\n",
+    "# print(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b03b0d37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test non streaming response\n",
+    "from agentex.types import TextContent\n",
+    "\n",
+    "# The response is expected to be a list of TaskMessage objects, which is a union of the following types:\n",
+    "# - TextContent: A message with just text content   \n",
+    "# - DataContent: A message with JSON-serializable data content\n",
+    "# - ToolRequestContent: A message with a tool request, which contains a JSON-serializable request to call a tool\n",
+    "# - ToolResponseContent: A message with a tool response, which contains response object from a tool call in its content\n",
+    "\n",
+    "# When processing the message/send response, if you are expecting more than TextContent, such as DataContent, ToolRequestContent, or ToolResponseContent, you can process them as well\n",
+    "\n",
+    "rpc_response = client.agents.send_message(\n",
+    "    agent_name=AGENT_NAME,\n",
+    "    params={\n",
+    "        \"content\": {\"type\": \"text\", \"author\": \"user\", \"content\": \"Hello what can you do?\"},\n",
+    "        \"stream\": False\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "if not rpc_response or not rpc_response.result:\n",
+    "    raise ValueError(\"No result in response\")\n",
+    "\n",
+    "# Extract and print just the text content from the response\n",
+    "for task_message in rpc_response.result:\n",
+    "    content = task_message.content\n",
+    "    if isinstance(content, TextContent):\n",
+    "        text = content.content\n",
+    "        print(text)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79688331",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test streaming response\n",
+    "from agentex.types.task_message_update import StreamTaskMessageDelta, StreamTaskMessageFull\n",
+    "from agentex.types.text_delta import TextDelta\n",
+    "\n",
+    "\n",
+    "# The result object of message/send will be a TaskMessageUpdate which is a union of the following types:\n",
+    "# - StreamTaskMessageStart: \n",
+    "#   - An indicator that a streaming message was started, doesn't contain any useful content\n",
+    "# - StreamTaskMessageDelta: \n",
+    "#   - A delta of a streaming message, contains the text delta to aggregate\n",
+    "# - StreamTaskMessageDone: \n",
+    "#   - An indicator that a streaming message was done, doesn't contain any useful content\n",
+    "# - StreamTaskMessageFull: \n",
+    "#   - A non-streaming message, there is nothing to aggregate, since this contains the full message, not deltas\n",
+    "\n",
+    "# Whenn processing StreamTaskMessageDelta, if you are expecting more than TextDeltas, such as DataDelta, ToolRequestDelta, or ToolResponseDelta, you can process them as well\n",
+    "# Whenn processing StreamTaskMessageFull, if you are expecting more than TextContent, such as DataContent, ToolRequestContent, or ToolResponseContent, you can process them as well\n",
+    "\n",
+    "for agent_rpc_response_chunk in client.agents.send_message_stream(\n",
+    "    agent_name=AGENT_NAME,\n",
+    "    params={\n",
+    "        \"content\": {\"type\": \"text\", \"author\": \"user\", \"content\": \"Hello what can you do?\"},\n",
+    "        \"stream\": True\n",
+    "    }\n",
+    "):\n",
+    "    # We know that the result of the message/send when stream is set to True will be a TaskMessageUpdate\n",
+    "    task_message_update = agent_rpc_response_chunk.result\n",
+    "    # Print oly the text deltas as they arrive or any full messages\n",
+    "    if isinstance(task_message_update, StreamTaskMessageDelta):\n",
+    "        delta = task_message_update.delta\n",
+    "        if isinstance(delta, TextDelta):\n",
+    "            print(delta.text_delta, end=\"\", flush=True)\n",
+    "        else:\n",
+    "            print(f\"Found non-text {type(task_message_update)} object in streaming message.\")\n",
+    "    elif isinstance(task_message_update, StreamTaskMessageFull):\n",
+    "        content = task_message_update.content\n",
+    "        if isinstance(content, TextContent):\n",
+    "            print(content.content)\n",
+    "        else:\n",
+    "            print(f\"Found non-text {type(task_message_update)} object in full message.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5e7e042",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/agentex/lib/cli/templates/default-openai-agents/environments.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/environments.yaml.j2
@@ -1,0 +1,53 @@
+# Agent Environment Configuration
+# ------------------------------
+# This file defines environment-specific settings for your agent.
+# This DIFFERS from the manifest.yaml file in that it is used to program things that are ONLY per environment.
+
+# ********** EXAMPLE **********
+# schema_version: "v1" # This is used to validate the file structure and is not used by the agentex CLI
+# environments:
+#   dev:
+#     auth:
+#       principal:
+#         user_id: "1234567890"
+#         user_name: "John Doe"
+#         user_email: "john.doe@example.com"
+#         user_role: "admin"
+#       user_permissions: "read, write, delete"
+#     helm_overrides: # This is used to override the global helm values.yaml file in the agentex-agent helm charts
+#       replicas: 3
+#       resources:
+#         requests:
+#           cpu: "1000m"
+#           memory: "2Gi"
+#         limits:
+#           cpu: "2000m"
+#           memory: "4Gi"
+#       env:
+#         - name: LOG_LEVEL
+#           value: "DEBUG"
+#         - name: ENVIRONMENT
+#           value: "staging"
+#     kubernetes: 
+#       # OPTIONAL - Otherwise it will be derived from separately. However, this can be used to override the derived
+#       #   namespace and deploy it with in the same namespace that already exists for a separate agent.
+#       namespace: "team-{{agent_name}}"
+# ********** END EXAMPLE **********
+
+schema_version: "v1" # This is used to validate the file structure and is not used by the agentex CLI
+environments:
+  dev:
+    auth:
+      principal:
+        user_id: # TODO: Fill in
+        account_id: # TODO: Fill in
+    helm_overrides:
+      replicaCount: 2
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+        limits:
+          cpu: "1000m"
+          memory: "2Gi"
+

--- a/src/agentex/lib/cli/templates/default-openai-agents/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/manifest.yaml.j2
@@ -1,0 +1,115 @@
+# Agent Manifest Configuration
+# ---------------------------
+# This file defines how your agent should be built and deployed.
+
+# Build Configuration
+# ------------------
+# The build config defines what gets packaged into your agent's Docker image.
+# This same configuration is used whether building locally or remotely.
+#
+# When building:
+# 1. All files from include_paths are collected into a build context
+# 2. The context is filtered by dockerignore rules
+# 3. The Dockerfile uses this context to build your agent's image
+# 4. The image is pushed to a registry and used to run your agent
+build:
+  context:
+    # Root directory for the build context
+    root: ../  # Keep this as the default root
+
+    # Paths to include in the Docker build context
+    # Must include:
+    # - Your agent's directory (your custom agent code)
+    # These paths are collected and sent to the Docker daemon for building
+    include_paths:
+      - {{ project_path_from_build_root }}
+
+    # Path to your agent's Dockerfile
+    # This defines how your agent's image is built from the context
+    # Relative to the root directory
+    dockerfile: {{ project_path_from_build_root }}/Dockerfile
+
+    # Path to your agent's .dockerignore
+    # Filters unnecessary files from the build context
+    # Helps keep build context small and builds fast
+    dockerignore: {{ project_path_from_build_root }}/.dockerignore
+
+
+# Local Development Configuration
+# -----------------------------
+# Only used when running the agent locally
+local_development:
+  agent:
+    port: 8000  # Port where your local ACP server is running
+    host_address: host.docker.internal  # Host address for Docker networking (host.docker.internal for Docker, localhost for direct) 
+
+  # File paths for local development (relative to this manifest.yaml)
+  paths:
+    # Path to ACP server file
+    # Examples:
+    #   project/acp.py          (standard)
+    #   src/server.py           (custom structure)
+    #   ../shared/acp.py        (shared across projects)
+    #   /absolute/path/acp.py   (absolute path)
+    acp: project/acp.py
+
+
+# Agent Configuration
+# -----------------
+agent:
+  acp_type: async
+  # Unique name for your agent
+  # Used for task routing and monitoring
+  name: {{ agent_name }}
+
+  # Description of what your agent does
+  # Helps with documentation and discovery
+  description: {{ description }}
+
+  # Temporal workflow configuration
+  # Set enabled: true to use Temporal workflows for long-running tasks
+  temporal:
+    enabled: false
+
+  # Optional: Credentials mapping
+  # Maps Kubernetes secrets to environment variables
+  # Common credentials include:
+  credentials: [] # Update with your credentials
+  #   - env_var_name: LITELLM_API_KEY
+  #     secret_name: litellm-api-key
+  #     secret_key: api-key
+
+  # Optional: Set Environment variables for running your agent locally as well 
+  # as for deployment later on
+  env: {} # Update with your environment variables
+  #   LITELLM_API_KEY: "<YOUR_LITELLM_API_KEY_HERE>"
+  #   OPENAI_BASE_URL: "<YOUR_OPENAI_BASE_URL_HERE>"
+  #   OPENAI_ORG_ID: "<YOUR_OPENAI_ORG_ID_HERE>"
+
+
+# Deployment Configuration
+# -----------------------
+# Configuration for deploying your agent to Kubernetes clusters
+deployment:
+  # Container image configuration
+  image:
+    repository: "" # Update with your container registry
+    tag: "latest"  # Default tag, should be versioned in production
+  
+  imagePullSecrets: [] # Update with your image pull secret names
+    # - name: my-registry-secret
+
+  # Global deployment settings that apply to all clusters
+  # These can be overridden in cluster-specific environments (environments.yaml)
+  global:
+    # Default replica count
+    replicaCount: 1
+    
+    # Default resource requirements
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "1000m"
+        memory: "2Gi" 

--- a/src/agentex/lib/cli/templates/default-openai-agents/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/project/acp.py.j2
@@ -1,0 +1,133 @@
+"""ACP handler for {{ agent_name }} — an async OpenAI Agents SDK agent.
+
+Uses the async ACP model with Redis streaming instead of HTTP yields. The
+OpenAI Agents SDK run is wrapped in an ``OpenAITurn`` and pushed to the task
+stream via ``UnifiedEmitter.auto_send_turn`` — the async delivery path of the
+unified harness surface. ``auto_send_turn`` returns a ``TurnResult`` carrying
+the accumulated final text and normalized usage.
+
+The agent and its tools are defined inline below so this template stays a
+single, self-contained ``acp.py``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from agents import Agent, Runner, function_tool, set_tracing_disabled
+
+from agentex.lib import adk
+from agentex.lib.types.acp import SendEventParams, CancelTaskParams, CreateTaskParams
+from agentex.lib.types.fastacp import AsyncACPConfig
+from agentex.lib.types.tracing import SGPTracingProcessorConfig
+from agentex.lib.utils.logging import make_logger
+from agentex.lib.sdk.fastacp.fastacp import FastACP
+from agentex.lib.core.harness.emitter import UnifiedEmitter
+from agentex.lib.adk import OpenAITurn
+from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
+
+# Disable the openai-agents SDK's native tracer so it doesn't ship traces to
+# api.openai.com using OPENAI_API_KEY (which may be a LiteLLM proxy key).
+# SGP tracing below still runs via the Agentex tracing manager.
+set_tracing_disabled(True)
+
+logger = make_logger(__name__)
+
+# LiteLLM proxy auth: copy LITELLM_API_KEY to OPENAI_API_KEY for OpenAI client compatibility.
+_litellm_key = os.environ.get("LITELLM_API_KEY")
+if _litellm_key and not os.environ.get("OPENAI_API_KEY"):
+    os.environ["OPENAI_API_KEY"] = _litellm_key
+
+_sgp_api_key = os.environ.get("SGP_API_KEY", "")
+_sgp_account_id = os.environ.get("SGP_ACCOUNT_ID", "")
+if _sgp_api_key and _sgp_account_id:
+    add_tracing_processor_config(
+        SGPTracingProcessorConfig(
+            sgp_api_key=_sgp_api_key,
+            sgp_account_id=_sgp_account_id,
+            sgp_base_url=os.environ.get("SGP_CLIENT_BASE_URL", ""),
+        )
+    )
+
+acp = FastACP.create(
+    acp_type="async",
+    config=AsyncACPConfig(type="base"),
+)
+
+MODEL_NAME = "gpt-4o"
+INSTRUCTIONS = """You are a helpful AI assistant with access to tools.
+
+Current date and time: {timestamp}
+
+Guidelines:
+- Be concise and helpful
+- Use the weather tool when the user asks about the weather
+- Always report the real tool output back to the user
+"""
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return f"The weather in {city} is sunny and 72°F"
+
+
+def create_agent() -> Agent:
+    """Build and return the OpenAI Agents SDK agent with the weather tool."""
+    return Agent(
+        name="{{ agent_name }}",
+        model=MODEL_NAME,
+        instructions=INSTRUCTIONS.format(timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S")),
+        tools=[get_weather],
+    )
+
+
+def get_agent() -> Agent:
+    """Build a fresh agent per request so the timestamp in the instructions stays current."""
+    return create_agent()
+
+
+@acp.on_task_create
+async def handle_task_create(params: CreateTaskParams):
+    logger.info(f"Task created: {params.task.id}")
+
+
+@acp.on_task_event_send
+async def handle_task_event_send(params: SendEventParams):
+    """Handle each user message: run the agent and auto-send its turn."""
+    agent = get_agent()
+    task_id = params.task.id
+    user_message = params.event.content.content
+
+    logger.info(f"Processing message for task {task_id}")
+
+    # Echo the user's message into the task history.
+    await adk.messages.create(task_id=task_id, content=params.event.content)
+
+    async with adk.tracing.span(
+        trace_id=task_id,
+        task_id=task_id,
+        name="message",
+        input={"message": user_message},
+        data={"__span_type__": "AGENT_WORKFLOW"},
+    ) as turn_span:
+        result = Runner.run_streamed(starting_agent=agent, input=user_message)
+        turn = OpenAITurn(result=result, model=MODEL_NAME)
+        emitter = UnifiedEmitter(
+            task_id=task_id,
+            trace_id=task_id,
+            parent_span_id=turn_span.id if turn_span else None,
+        )
+        turn_result = await emitter.auto_send_turn(turn)
+        if turn_span:
+            turn_span.output = {"final_output": turn_result.final_text}
+
+
+@acp.on_task_cancel
+async def handle_task_canceled(params: CancelTaskParams):
+    logger.info(f"Task canceled: {params.task.id}")

--- a/src/agentex/lib/cli/templates/default-openai-agents/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/project/acp.py.j2
@@ -13,6 +13,7 @@ single, self-contained ``acp.py``.
 from __future__ import annotations
 
 import os
+from typing import List
 from datetime import datetime
 
 from dotenv import load_dotenv
@@ -26,6 +27,7 @@ from agentex.lib.types.acp import SendEventParams, CancelTaskParams, CreateTaskP
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.lib.utils.model_utils import BaseModel
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.lib.core.harness.emitter import UnifiedEmitter
 from agentex.lib.adk import OpenAITurn
@@ -92,6 +94,13 @@ def get_agent() -> Agent:
     return create_agent()
 
 
+class StateModel(BaseModel):
+    """Per-task conversation state persisted between turns."""
+
+    input_list: List[dict]
+    turn_number: int
+
+
 @acp.on_task_create
 async def handle_task_create(params: CreateTaskParams):
     logger.info(f"Task created: {params.task.id}")
@@ -102,12 +111,25 @@ async def handle_task_event_send(params: SendEventParams):
     """Handle each user message: run the agent and auto-send its turn."""
     agent = get_agent()
     task_id = params.task.id
+    agent_id = params.agent.id
     user_message = params.event.content.content
 
     logger.info(f"Processing message for task {task_id}")
 
     # Echo the user's message into the task history.
     await adk.messages.create(task_id=task_id, content=params.event.content)
+
+    # Load (or create) the persisted conversation history for this task so the
+    # agent can see prior turns, then append the new user message.
+    task_state = await adk.state.get_by_task_and_agent(task_id=task_id, agent_id=agent_id)
+    if task_state is None:
+        state = StateModel(input_list=[], turn_number=0)
+        task_state = await adk.state.create(task_id=task_id, agent_id=agent_id, state=state)
+    else:
+        state = StateModel.model_validate(task_state.state)
+
+    state.turn_number += 1
+    state.input_list.append({"role": "user", "content": user_message})
 
     async with adk.tracing.span(
         trace_id=task_id,
@@ -116,7 +138,7 @@ async def handle_task_event_send(params: SendEventParams):
         input={"message": user_message},
         data={"__span_type__": "AGENT_WORKFLOW"},
     ) as turn_span:
-        result = Runner.run_streamed(starting_agent=agent, input=user_message)
+        result = Runner.run_streamed(starting_agent=agent, input=state.input_list)
         turn = OpenAITurn(result=result, model=MODEL_NAME)
         emitter = UnifiedEmitter(
             task_id=task_id,
@@ -124,6 +146,17 @@ async def handle_task_event_send(params: SendEventParams):
             parent_span_id=turn_span.id if turn_span else None,
         )
         turn_result = await emitter.auto_send_turn(turn)
+
+        # Persist the full conversation history (user + assistant + tool calls)
+        # so the next turn resumes with complete context.
+        state.input_list = result.to_input_list()
+        await adk.state.update(
+            state_id=task_state.id,
+            task_id=task_id,
+            agent_id=agent_id,
+            state=state,
+        )
+
         if turn_span:
             turn_span.output = {"final_output": turn_result.final_text}
 

--- a/src/agentex/lib/cli/templates/default-openai-agents/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/pyproject.toml.j2
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ project_name }}"
+version = "0.1.0"
+description = "{{ description }}"
+requires-python = ">=3.12"
+dependencies = [
+    "agentex-sdk",
+    "scale-gp",
+    "openai-agents",
+    "python-dotenv>=1.0,<2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "black",
+    "isort",
+    "flake8",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["project"]
+
+[tool.black]
+line-length = 88
+target-version = ['py312']
+
+[tool.isort]
+profile = "black"
+line_length = 88

--- a/src/agentex/lib/cli/templates/default-openai-agents/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/requirements.txt.j2
@@ -1,0 +1,11 @@
+# Install agentex-sdk from local path
+agentex-sdk
+
+# Scale GenAI Platform Python SDK
+scale-gp
+
+# OpenAI Agents SDK
+openai-agents
+
+# Loads .env files for local development
+python-dotenv>=1.0,<2


### PR DESCRIPTION
## Summary

Eighth slice of #425. Adds the missing async-base OpenAI Agents SDK init template.

- New `default-openai-agents` template (all 11 scaffold files).
- Wires `DEFAULT_OPENAI_AGENTS` into `init.py` (enum, project-files map, async prompt).
- Scaffolded `acp.py` imports `OpenAITurn` from the `agentex.lib.adk` facade (added in #432), matching every other Turn-based template.

## Test plan
- [x] `pytest tests/lib/cli/ -k "init or template"` — 20 passed (template renders to valid Python)

## Notes
Stacked on #433. Retarget to `next` after the chain merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `default-openai-agents` async template (11 scaffold files) and wires it into the CLI init command as the eighth slice of the template-expansion stack. Compared to the previous review round, several issues have been resolved: SGP tracing is now correctly gated on `if _sgp_api_key and _sgp_account_id`, the agent is rebuilt per-request so `datetime.now()` in the instructions stays current, both Dockerfiles correctly use the `nodejs` apt package, and the notebook streaming cell consistently references `task_message_update`.

- **`init.py`**: `DEFAULT_OPENAI_AGENTS` is cleanly added to the enum, project-files map, and async template prompt choices.
- **`project/acp.py.j2`**: Async handler runs the OpenAI Agents SDK via `OpenAITurn` + `UnifiedEmitter.auto_send_turn`, persists conversation history in `StateModel`, and streams output over Redis. `StateModel.turn_number` is tracked but never read.
- **`Dockerfile.j2` / `Dockerfile-uv.j2`**: Pip and uv build variants; the uv variant's dependency on a pre-existing `uv.lock` is a known open item from the prior review.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The new template is additive and gated behind a CLI prompt — no existing paths are modified. The fixes applied in this revision address the regressions identified earlier.

The changes are entirely new scaffold files plus clean enum/map wiring in init.py. The only newly identified issue in this pass is a dead turn_number field that accumulates unused state but does not affect correctness. No fresh correctness regressions were introduced in this revision.

The dev.ipynb.j2 notebook and Dockerfile-uv.j2 have the most outstanding open items from earlier review rounds.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/cli/commands/init.py | Adds DEFAULT_OPENAI_AGENTS enum value, project-files map entry, and async prompt choice — straightforward wiring, no issues. |
| src/agentex/lib/cli/templates/default-openai-agents/project/acp.py.j2 | Core async ACP template; SGP guard, datetime freshness, and per-request agent creation are now correct. StateModel.turn_number is incremented but never read. Several structural issues are tracked in earlier review threads. |
| src/agentex/lib/cli/templates/default-openai-agents/Dockerfile-uv.j2 | uv-based Dockerfile; copies uv.lock but no uv.lock.j2 template is generated — tracked in a previous review thread. |
| src/agentex/lib/cli/templates/default-openai-agents/dev.ipynb.j2 | Notebook uses sync message/send helpers against an async-only event/send agent — API mismatch tracked in a previous review thread. Variable references (task_message_update) are now consistent. |
| src/agentex/lib/cli/templates/default-openai-agents/manifest.yaml.j2 | Credentials and env entries are empty/commented — missing required runtime secrets tracked in a previous review thread. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant FastACP as FastACP (async)
    participant Handler as handle_task_event_send
    participant ADK as adk.state / adk.messages
    participant Runner as OpenAI Agents Runner
    participant Emitter as UnifiedEmitter
    participant Redis

    Client->>FastACP: event/send (SendEventParams)
    FastACP->>Handler: dispatch
    Handler->>ADK: messages.create(user content)
    Handler->>ADK: state.get_by_task_and_agent()
    alt state is None
        Handler->>ADK: state.create(StateModel)
    end
    Handler->>Handler: append user turn to input_list
    Handler->>Runner: "Runner.run_streamed(input=input_list)"
    Handler->>Emitter: auto_send_turn(OpenAITurn)
    Emitter->>Runner: iterate streamed events
    Emitter->>Redis: "push StreamTaskMessage* events"
    Emitter-->>Handler: TurnResult
    Handler->>ADK: state.update(result.to_input_list())
    FastACP-->>Client: 202 processing
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant FastACP as FastACP (async)
    participant Handler as handle_task_event_send
    participant ADK as adk.state / adk.messages
    participant Runner as OpenAI Agents Runner
    participant Emitter as UnifiedEmitter
    participant Redis

    Client->>FastACP: event/send (SendEventParams)
    FastACP->>Handler: dispatch
    Handler->>ADK: messages.create(user content)
    Handler->>ADK: state.get_by_task_and_agent()
    alt state is None
        Handler->>ADK: state.create(StateModel)
    end
    Handler->>Handler: append user turn to input_list
    Handler->>Runner: "Runner.run_streamed(input=input_list)"
    Handler->>Emitter: auto_send_turn(OpenAITurn)
    Emitter->>Runner: iterate streamed events
    Emitter->>Redis: "push StreamTaskMessage* events"
    Emitter-->>Handler: TurnResult
    Handler->>ADK: state.update(result.to_input_list())
    FastACP-->>Client: 202 processing
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **default-openai-agents init does not render the full promised scaffold artifact set**

   - **Bug**
     - On head, `TemplateType.DEFAULT_OPENAI_AGENTS` is selectable and the async prompt label is present, but executing `create_project_structure(..., TemplateType.DEFAULT_OPENAI_AGENTS, use_uv=True)` generated only `.dockerignore`, `.env.example`, `Dockerfile`, `README.md`, `dev.ipynb`, `environments.yaml`, `manifest.yaml`, `project/__init__.py`, `project/acp.py`, and `pyproject.toml`. The validation expected the changed template artifact set to include both `Dockerfile-uv` and `requirements.txt` as scaffold outputs; those were missing, and an extra `project/__init__.py` was generated relative to the requested exact scaffold assertion.
   - **Cause**
     - `src/agentex/lib/cli/commands/init.py` conditionally maps package-management templates: with `use_uv=True`, `Dockerfile-uv.j2` is rendered to `Dockerfile` and only `pyproject.toml` is emitted; `requirements.txt.j2` and a distinct `Dockerfile-uv` file are not emitted. The common project directory creation also touches `project/__init__.py`, so the output cannot match the requested exact 11-file scaffold set.
   - **Fix**
     - Align the scaffold contract and implementation. If the intended contract is to render all root template artifacts, update `create_project_structure` to emit `Dockerfile-uv`, `Dockerfile`, `pyproject.toml`, and `requirements.txt` for `DEFAULT_OPENAI_AGENTS` as required, and decide whether `project/__init__.py` should be part of the documented expected set. If package-manager-specific output is intended instead, update the PR contract/tests to expect the conditional file set.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (12): Last reviewed commit: ["fix(cli): persist conversation history i..."](https://github.com/scaleapi/scale-agentex-python/commit/9861b8b34a0383549964e5f64f640eb89bc70cbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39298555)</sub>

<!-- /greptile_comment -->