### PR TITLE
feat(cli): add claude-code init templates (sync / async / temporal)

### DIFF
--- a/src/agentex/lib/cli/commands/init.py
+++ b/src/agentex/lib/cli/commands/init.py
@@ -26,15 +26,18 @@ class TemplateType(str, Enum):
     TEMPORAL_OPENAI_AGENTS = "temporal-openai-agents"
     TEMPORAL_PYDANTIC_AI = "temporal-pydantic-ai"
     TEMPORAL_LANGGRAPH = "temporal-langgraph"
+    TEMPORAL_CLAUDE_CODE = "temporal-claude-code"
     DEFAULT = "default"
     DEFAULT_LANGGRAPH = "default-langgraph"
     DEFAULT_PYDANTIC_AI = "default-pydantic-ai"
     DEFAULT_OPENAI_AGENTS = "default-openai-agents"
+    DEFAULT_CLAUDE_CODE = "default-claude-code"
     SYNC = "sync"
     SYNC_OPENAI_AGENTS = "sync-openai-agents"
     SYNC_OPENAI_AGENTS_LOCAL_SANDBOX = "sync-openai-agents-local-sandbox"
     SYNC_LANGGRAPH = "sync-langgraph"
     SYNC_PYDANTIC_AI = "sync-pydantic-ai"
+    SYNC_CLAUDE_CODE = "sync-claude-code"
 
 
 def render_template(
@@ -67,15 +70,18 @@ def create_project_structure(
         TemplateType.TEMPORAL_OPENAI_AGENTS: ["acp.py", "workflow.py", "run_worker.py", "activities.py"],
         TemplateType.TEMPORAL_PYDANTIC_AI: ["acp.py", "workflow.py", "run_worker.py", "agent.py", "tools.py"],
         TemplateType.TEMPORAL_LANGGRAPH: ["acp.py", "workflow.py", "run_worker.py", "graph.py", "tools.py"],
+        TemplateType.TEMPORAL_CLAUDE_CODE: ["acp.py", "workflow.py", "run_worker.py", "activities.py"],
         TemplateType.DEFAULT: ["acp.py"],
         TemplateType.DEFAULT_LANGGRAPH: ["acp.py", "graph.py", "tools.py"],
         TemplateType.DEFAULT_PYDANTIC_AI: ["acp.py", "agent.py", "tools.py"],
         TemplateType.DEFAULT_OPENAI_AGENTS: ["acp.py"],
+        TemplateType.DEFAULT_CLAUDE_CODE: ["acp.py"],
         TemplateType.SYNC: ["acp.py"],
         TemplateType.SYNC_OPENAI_AGENTS: ["acp.py"],
         TemplateType.SYNC_OPENAI_AGENTS_LOCAL_SANDBOX: ["acp.py", "agent.py", "tools.py"],
         TemplateType.SYNC_LANGGRAPH: ["acp.py", "graph.py", "tools.py"],
         TemplateType.SYNC_PYDANTIC_AI: ["acp.py", "agent.py", "tools.py"],
+        TemplateType.SYNC_CLAUDE_CODE: ["acp.py"],
     }[template_type]
 
     # Create project/code files
@@ -189,6 +195,7 @@ def init():
                 {"name": "Async ACP + OpenAI Agents SDK", "value": TemplateType.DEFAULT_OPENAI_AGENTS},
                 {"name": "Async ACP + LangGraph", "value": TemplateType.DEFAULT_LANGGRAPH},
                 {"name": "Async ACP + Pydantic AI", "value": TemplateType.DEFAULT_PYDANTIC_AI},
+                {"name": "Async ACP + Claude Code", "value": TemplateType.DEFAULT_CLAUDE_CODE},
             ],
         ).ask()
         if not template_type:
@@ -201,6 +208,7 @@ def init():
                 {"name": "Temporal + OpenAI Agents SDK (Recommended)", "value": TemplateType.TEMPORAL_OPENAI_AGENTS},
                 {"name": "Temporal + Pydantic AI", "value": TemplateType.TEMPORAL_PYDANTIC_AI},
                 {"name": "Temporal + LangGraph", "value": TemplateType.TEMPORAL_LANGGRAPH},
+                {"name": "Temporal + Claude Code", "value": TemplateType.TEMPORAL_CLAUDE_CODE},
             ],
         ).ask()
         if not template_type:
@@ -214,6 +222,7 @@ def init():
                 {"name": "Sync ACP + OpenAI Agents SDK + Local Sandbox", "value": TemplateType.SYNC_OPENAI_AGENTS_LOCAL_SANDBOX},
                 {"name": "Sync ACP + LangGraph", "value": TemplateType.SYNC_LANGGRAPH},
                 {"name": "Sync ACP + Pydantic AI", "value": TemplateType.SYNC_PYDANTIC_AI},
+                {"name": "Sync ACP + Claude Code", "value": TemplateType.SYNC_CLAUDE_CODE},
             ],
         ).ask()
         if not template_type:

--- a/src/agentex/lib/cli/templates/default-claude-code/.dockerignore.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/.dockerignore.j2
@@ -1,0 +1,43 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Environments
+.env**
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Git
+.git
+.gitignore
+
+# Misc
+.DS_Store 

--- a/src/agentex/lib/cli/templates/default-claude-code/.env.example.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/.env.example.j2
@@ -1,0 +1,13 @@
+# {{ agent_name }} - Environment Variables
+# Copy this file to .env and fill in the values
+
+# API key for your LLM provider
+LITELLM_API_KEY=
+
+# LLM base URL (optional - override to use a different provider)
+# OPENAI_BASE_URL=
+
+# SGP Configuration (optional - for tracing)
+# SGP_API_KEY=
+# SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/default-claude-code/.env.example.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/.env.example.j2
@@ -1,8 +1,8 @@
 # {{ agent_name }} - Environment Variables
 # Copy this file to .env and fill in the values
 
-# API key for your LLM provider
-LITELLM_API_KEY=
+# API key for the Claude Code CLI (the `claude` subprocess this agent spawns)
+ANTHROPIC_API_KEY=
 
 # LLM base URL (optional - override to use a different provider)
 # OPENAI_BASE_URL=

--- a/src/agentex/lib/cli/templates/default-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/Dockerfile-uv.j2
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/**
 
+# Install the Claude Code CLI: the agent shells out to `claude` on every turn,
+# so the binary must be present in the runtime image.
+RUN npm install -g @anthropic-ai/claude-code
+
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 ENV UV_HTTP_TIMEOUT=1000

--- a/src/agentex/lib/cli/templates/default-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/Dockerfile-uv.j2
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.3
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    htop \
+    vim \
+    curl \
+    tar \
+    python3-dev \
+    postgresql-client \
+    build-essential \
+    libpq-dev \
+    gcc \
+    cmake \
+    netcat-openbsd \
+    nodejs \
+    npm \ 
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/**
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_HTTP_TIMEOUT=1000
+
+WORKDIR /app/{{ project_path_from_build_root }}
+
+# Copy dependency files for layer caching
+COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+
+# Install dependencies (without project itself, for layer caching)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-install-project --no-dev
+
+# Copy the project code
+COPY {{ project_path_from_build_root }}/project ./project
+
+# Install the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
+ENV PYTHONPATH=/app
+
+# Run the agent using uvicorn
+CMD ["uvicorn", "project.acp:acp", "--host", "0.0.0.0", "--port", "8000"] 

--- a/src/agentex/lib/cli/templates/default-claude-code/Dockerfile.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/Dockerfile.j2
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1.3
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    htop \
+    vim \
+    curl \
+    tar \
+    python3-dev \
+    postgresql-client \
+    build-essential \
+    libpq-dev \
+    gcc \
+    cmake \
+    netcat-openbsd \
+    nodejs \
+    npm \ 
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN uv pip install --system --upgrade pip setuptools wheel
+
+ENV UV_HTTP_TIMEOUT=1000
+
+# Copy just the requirements file to optimize caching
+COPY {{ project_path_from_build_root }}/requirements.txt /app/{{ project_path_from_build_root }}/requirements.txt
+
+WORKDIR /app/{{ project_path_from_build_root }}
+
+# Install the required Python packages
+RUN uv pip install --system -r requirements.txt
+
+# Copy the project code
+COPY {{ project_path_from_build_root }}/project /app/{{ project_path_from_build_root }}/project
+
+# Set environment variables
+ENV PYTHONPATH=/app
+
+# Run the agent using uvicorn
+CMD ["uvicorn", "project.acp:acp", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/agentex/lib/cli/templates/default-claude-code/Dockerfile.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/Dockerfile.j2
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Install the Claude Code CLI: the agent shells out to `claude` on every turn,
+# so the binary must be present in the runtime image.
+RUN npm install -g @anthropic-ai/claude-code
+
 RUN uv pip install --system --upgrade pip setuptools wheel
 
 ENV UV_HTTP_TIMEOUT=1000

--- a/src/agentex/lib/cli/templates/default-claude-code/README.md.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/README.md.j2
@@ -1,0 +1,64 @@
+# {{ agent_name }} - AgentEx Async Claude Code Agent
+
+This template builds an **asynchronous** (non-Temporal) agent that drives the
+**Claude Code CLI** through the unified harness surface on AgentEx:
+- Spawns `claude -p --output-format stream-json --verbose` as a local subprocess
+- Wraps the CLI's stdout stream in a `ClaudeCodeTurn`
+- Delivers canonical `StreamTaskMessage*` events via `UnifiedEmitter.auto_send_turn`
+  (the async Redis push path), so the UI receives output in real time
+- Tracing integration to SGP / AgentEx
+
+## Prerequisites
+
+- The `claude` CLI installed and on your `PATH`
+- An `ANTHROPIC_API_KEY` (or equivalent credential) in your environment
+
+## Running the Agent
+
+```bash
+agentex agents run --manifest manifest.yaml
+```
+
+## Project Structure
+
+```
+{{ project_name }}/
+├── project/
+│   ├── __init__.py
+│   └── acp.py          # ACP server, subprocess spawn, and event handlers
+├── Dockerfile
+├── manifest.yaml
+├── dev.ipynb
+{% if use_uv %}
+└── pyproject.toml
+{% else %}
+└── requirements.txt
+{% endif %}
+```
+
+## Key Concepts
+
+### Async ACP with the harness
+The async ACP model streams events over Redis instead of an HTTP response. The
+`@acp.on_task_event_send` handler spawns the Claude Code CLI and pushes the
+harness events to the task stream.
+
+### The unified harness surface
+`ClaudeCodeTurn` + `UnifiedEmitter` are the unified harness surface. The turn
+normalizes CLI output into canonical AgentEx events; the emitter traces and
+delivers them.
+
+## Development
+
+### 1. Customize the subprocess
+Edit `_spawn_claude` in `project/acp.py` to change the CLI flags, working
+directory, or how the prompt is delivered.
+
+### 2. Configure Credentials
+Set your credentials via `manifest.yaml`, an exported environment variable, or a
+`.env` file in the project directory.
+
+### 3. Run Locally
+```bash
+export ENVIRONMENT=development && agentex agents run --manifest manifest.yaml
+```

--- a/src/agentex/lib/cli/templates/default-claude-code/dev.ipynb.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/dev.ipynb.j2
@@ -1,0 +1,126 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36834357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agentex import Agentex\n",
+    "\n",
+    "client = Agentex(base_url=\"http://localhost:5003\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1c309d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AGENT_NAME = \"{{ agent_name }}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f6e6ef0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (REQUIRED) Create a new task. For Async agents, you must create a task for messages to be associated with.\n",
+    "import uuid\n",
+    "\n",
+    "rpc_response = client.agents.create_task(\n",
+    "    agent_name=AGENT_NAME,\n",
+    "    params={\n",
+    "        \"name\": f\"{str(uuid.uuid4())[:8]}-task\",\n",
+    "        \"params\": {}\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "task = rpc_response.result\n",
+    "print(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b03b0d37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Send an event to the agent\n",
+    "\n",
+    "# The response is expected to be a list of TaskMessage objects, which is a union of the following types:\n",
+    "# - TextContent: A message with just text content   \n",
+    "# - DataContent: A message with JSON-serializable data content\n",
+    "# - ToolRequestContent: A message with a tool request, which contains a JSON-serializable request to call a tool\n",
+    "# - ToolResponseContent: A message with a tool response, which contains response object from a tool call in its content\n",
+    "\n",
+    "# When processing the message/send response, if you are expecting more than TextContent, such as DataContent, ToolRequestContent, or ToolResponseContent, you can process them as well\n",
+    "\n",
+    "rpc_response = client.agents.send_event(\n",
+    "    agent_name=AGENT_NAME,\n",
+    "    params={\n",
+    "        \"content\": {\"type\": \"text\", \"author\": \"user\", \"content\": \"Hello what can you do?\"},\n",
+    "        \"task_id\": task.id,\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "event = rpc_response.result\n",
+    "print(event)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6927cc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subscribe to the async task messages produced by the agent\n",
+    "from agentex.lib.utils.dev_tools import subscribe_to_async_task_messages\n",
+    "\n",
+    "task_messages = subscribe_to_async_task_messages(\n",
+    "    client=client,\n",
+    "    task=task, \n",
+    "    only_after_timestamp=event.created_at, \n",
+    "    print_messages=True,\n",
+    "    rich_print=True,\n",
+    "    timeout=5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4864e354",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/agentex/lib/cli/templates/default-claude-code/environments.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/environments.yaml.j2
@@ -1,0 +1,57 @@
+# Agent Environment Configuration
+# ------------------------------
+# This file defines environment-specific settings for your agent.
+# This DIFFERS from the manifest.yaml file in that it is used to program things that are ONLY per environment.
+
+# ********** EXAMPLE **********
+# schema_version: "v1" # This is used to validate the file structure and is not used by the agentex CLI
+# environments:
+#   dev:
+#     auth:
+#       principal:
+#         user_id: "1234567890"
+#         user_name: "John Doe"
+#         user_email: "john.doe@example.com"
+#         user_role: "admin"
+#       user_permissions: "read, write, delete"
+#     helm_overrides: # This is used to override the global helm values.yaml file in the agentex-agent helm charts
+#       replicas: 3
+#       resources:
+#         requests:
+#           cpu: "1000m"
+#           memory: "2Gi"
+#         limits:
+#           cpu: "2000m"
+#           memory: "4Gi"
+#       env:
+#         - name: LOG_LEVEL
+#           value: "DEBUG"
+#         - name: ENVIRONMENT
+#           value: "staging"
+#
+#     kubernetes: 
+#       # OPTIONAL - Otherwise it will be derived from separately. However, this can be used to override the derived
+#       #   namespace and deploy it with in the same namespace that already exists for a separate agent.
+#       namespace: "team-{{agent_name}}"
+# ********** END EXAMPLE **********
+
+schema_version: "v1" # This is used to validate the file structure and is not used by the agentex CLI
+environments:
+  dev:
+    auth:
+      principal:
+        user_id: # TODO: Fill in
+        account_id: # TODO: Fill in
+    helm_overrides:
+      replicaCount: 2
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+        limits:
+          cpu: "1000m"
+          memory: "2Gi"
+      temporal:
+        enabled: false
+          
+

--- a/src/agentex/lib/cli/templates/default-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/manifest.yaml.j2
@@ -1,0 +1,120 @@
+# Agent Manifest Configuration
+# ---------------------------
+# This file defines how your agent should be built and deployed.
+
+# Build Configuration
+# ------------------
+# The build config defines what gets packaged into your agent's Docker image.
+# This same configuration is used whether building locally or remotely.
+#
+# When building:
+# 1. All files from include_paths are collected into a build context
+# 2. The context is filtered by dockerignore rules
+# 3. The Dockerfile uses this context to build your agent's image
+# 4. The image is pushed to a registry and used to run your agent
+build:
+  context:
+    # Root directory for the build context
+    root: ../  # Keep this as the default root
+
+    # Paths to include in the Docker build context
+    # Must include:
+    # - Your agent's directory (your custom agent code)
+    # These paths are collected and sent to the Docker daemon for building
+    include_paths:
+      - {{ project_path_from_build_root }}
+
+    # Path to your agent's Dockerfile
+    # This defines how your agent's image is built from the context
+    # Relative to the root directory
+    dockerfile: {{ project_path_from_build_root }}/Dockerfile
+
+    # Path to your agent's .dockerignore
+    # Filters unnecessary files from the build context
+    # Helps keep build context small and builds fast
+    dockerignore: {{ project_path_from_build_root }}/.dockerignore
+
+
+# Local Development Configuration
+# -----------------------------
+# Only used when running the agent locally
+local_development:
+  agent:
+    port: 8000  # Port where your local ACP server is running
+    host_address: host.docker.internal  # Host address for Docker networking (host.docker.internal for Docker, localhost for direct) 
+
+  # File paths for local development (relative to this manifest.yaml)
+  paths:
+    # Path to ACP server file
+    # Examples:
+    #   project/acp.py          (standard)
+    #   src/server.py           (custom structure)
+    #   ../shared/acp.py        (shared across projects)
+    #   /absolute/path/acp.py   (absolute path)
+    acp: project/acp.py
+
+
+# Agent Configuration
+# -----------------
+agent:
+  acp_type: async
+  
+  # Unique name for your agent
+  # Used for task routing and monitoring
+  name: {{ agent_name }}
+
+  # Description of what your agent does
+  # Helps with documentation and discovery
+  description: {{ description }}
+
+  # Temporal workflow configuration
+  # Set enabled: true to use Temporal workflows for long-running tasks
+  temporal:
+    enabled: false
+
+  # Optional: Credentials mapping
+  # Maps Kubernetes secrets to environment variables
+  # Common credentials include:
+  credentials:
+    - env_var_name: LITELLM_API_KEY
+      secret_name: litellm-api-key
+      secret_key: api-key
+    - env_var_name: SGP_API_KEY
+      secret_name: sgp-api-key
+      secret_key: api-key
+    - env_var_name: REDIS_URL
+      secret_name: redis-url-secret
+      secret_key: url
+
+  # Optional: Set Environment variables for running your agent locally as well
+  # as for deployment later on
+  env:
+    LITELLM_API_KEY: ""  # Set your LLM API key
+  #   OPENAI_BASE_URL: "<YOUR_OPENAI_BASE_URL_HERE>"
+
+# Deployment Configuration
+# -----------------------
+# Configuration for deploying your agent to Kubernetes clusters
+deployment:
+  # Container image configuration
+  image:
+    repository: "" # Update with your container registry
+    tag: "latest"  # Default tag, should be versioned in production
+
+  imagePullSecrets: [] # Update with your image pull secret names
+    # - name: my-registry-secret
+
+  # Global deployment settings that apply to all clusters
+  # These can be overridden in cluster-specific environments (environments.yaml)
+  global:
+    # Default replica count
+    replicaCount: 1
+    
+    # Default resource requirements
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "1000m"
+        memory: "2Gi" 

--- a/src/agentex/lib/cli/templates/default-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/manifest.yaml.j2
@@ -89,9 +89,11 @@ agent:
       secret_key: url
 
   # Optional: Set Environment variables for running your agent locally as well
-  # as for deployment later on
-  env:
-    ANTHROPIC_API_KEY: ""  # Required by the Claude Code CLI
+  # as for deployment later on. ANTHROPIC_API_KEY is supplied via the credential
+  # mapping above (deploy) or your local .env (load_dotenv). Do NOT set it to an
+  # empty string here — that would shadow the real key at runtime.
+  env: {}
+  #   ANTHROPIC_API_KEY: "<your-key>"  # uncomment only to hardcode for local runs
 
 # Deployment Configuration
 # -----------------------

--- a/src/agentex/lib/cli/templates/default-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/manifest.yaml.j2
@@ -76,8 +76,10 @@ agent:
   # Maps Kubernetes secrets to environment variables
   # Common credentials include:
   credentials:
-    - env_var_name: LITELLM_API_KEY
-      secret_name: litellm-api-key
+    # The Claude Code CLI authenticates with ANTHROPIC_API_KEY (LITELLM_API_KEY
+    # is not read by the `claude` subprocess this agent spawns).
+    - env_var_name: ANTHROPIC_API_KEY
+      secret_name: anthropic-api-key
       secret_key: api-key
     - env_var_name: SGP_API_KEY
       secret_name: sgp-api-key
@@ -89,8 +91,7 @@ agent:
   # Optional: Set Environment variables for running your agent locally as well
   # as for deployment later on
   env:
-    LITELLM_API_KEY: ""  # Set your LLM API key
-  #   OPENAI_BASE_URL: "<YOUR_OPENAI_BASE_URL_HERE>"
+    ANTHROPIC_API_KEY: ""  # Required by the Claude Code CLI
 
 # Deployment Configuration
 # -----------------------

--- a/src/agentex/lib/cli/templates/default-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/project/acp.py.j2
@@ -66,6 +66,7 @@ async def _spawn_claude(prompt: str) -> AsyncIterator[str]:
     assert proc.stdin is not None
 
     proc.stdin.write(prompt.encode())
+    await proc.stdin.drain()
     proc.stdin.close()
 
     # Drain stderr concurrently. With --verbose, Claude Code can write enough to

--- a/src/agentex/lib/cli/templates/default-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/project/acp.py.j2
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import asyncio
 from typing import AsyncIterator
+from collections import deque
 
 from dotenv import load_dotenv
 
@@ -70,11 +71,17 @@ async def _spawn_claude(prompt: str) -> AsyncIterator[str]:
     # Drain stderr concurrently. With --verbose, Claude Code can write enough to
     # stderr to fill the OS pipe buffer; if we only read stdout, the CLI blocks
     # on its stderr write while we block reading stdout — a deadlock. A
-    # background task keeps stderr flowing so stdout never stalls.
+    # background task keeps stderr flowing so stdout never stalls. We keep a
+    # bounded tail so a non-zero exit can be surfaced with context instead of
+    # silently completing the turn.
+    stderr_tail: deque[str] = deque(maxlen=20)
+
     async def _drain_stderr() -> None:
         assert proc.stderr is not None
-        async for _ in proc.stderr:
-            pass
+        async for raw in proc.stderr:
+            text = raw.decode("utf-8", errors="replace").rstrip()
+            if text:
+                stderr_tail.append(text)
 
     stderr_task = asyncio.create_task(_drain_stderr())
 
@@ -92,6 +99,13 @@ async def _spawn_claude(prompt: str) -> AsyncIterator[str]:
             yield buffer.strip()
 
         await proc.wait()
+        if proc.returncode:
+            # The CLI failed (missing binary/auth, bad command). Raise so the
+            # turn surfaces as failed instead of completing with no output.
+            tail = "\n".join(stderr_tail)
+            raise RuntimeError(
+                f"claude CLI exited with status {proc.returncode}:\n{tail}"
+            )
     finally:
         # Release the subprocess and stderr drain task even if the consumer
         # abandons the generator early (task cancellation / client disconnect):

--- a/src/agentex/lib/cli/templates/default-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/project/acp.py.j2
@@ -1,0 +1,147 @@
+"""ACP handler for {{ agent_name }} — an async Claude Code agent.
+
+Spawns ``claude -p --output-format stream-json --verbose`` as a LOCAL
+asyncio subprocess (no Scale sandbox — that is a production concern). Stdout
+lines are fed into ``ClaudeCodeTurn``. Events are delivered via
+``UnifiedEmitter.auto_send_turn``, the async Redis push path.
+
+Live runs require the ``claude`` CLI to be installed and an
+ANTHROPIC_API_KEY (or equivalent credential) in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import asyncio
+from typing import AsyncIterator
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import agentex.lib.adk as adk
+from agentex.lib.adk import ClaudeCodeTurn
+from agentex.lib.types.acp import SendEventParams, CancelTaskParams, CreateTaskParams
+from agentex.lib.core.harness import UnifiedEmitter
+from agentex.lib.types.fastacp import AsyncACPConfig
+from agentex.lib.types.tracing import SGPTracingProcessorConfig
+from agentex.lib.utils.logging import make_logger
+from agentex.lib.sdk.fastacp.fastacp import FastACP
+from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
+
+logger = make_logger(__name__)
+
+add_tracing_processor_config(
+    SGPTracingProcessorConfig(
+        sgp_api_key=os.environ.get("SGP_API_KEY", ""),
+        sgp_account_id=os.environ.get("SGP_ACCOUNT_ID", ""),
+        sgp_base_url=os.environ.get("SGP_CLIENT_BASE_URL", ""),
+    )
+)
+
+acp = FastACP.create(
+    acp_type="async",
+    config=AsyncACPConfig(type="base"),
+)
+
+
+async def _spawn_claude(prompt: str) -> AsyncIterator[str]:
+    """Spawn ``claude -p --output-format stream-json`` locally and yield stdout lines.
+
+    Injectable seam: tests can monkeypatch this with a fake async iterator of
+    pre-recorded lines so no real CLI invocation is needed offline.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    assert proc.stdin is not None
+
+    proc.stdin.write(prompt.encode())
+    proc.stdin.close()
+
+    # Drain stderr concurrently. With --verbose, Claude Code can write enough to
+    # stderr to fill the OS pipe buffer; if we only read stdout, the CLI blocks
+    # on its stderr write while we block reading stdout — a deadlock. A
+    # background task keeps stderr flowing so stdout never stalls.
+    async def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        async for _ in proc.stderr:
+            pass
+
+    stderr_task = asyncio.create_task(_drain_stderr())
+
+    try:
+        buffer = ""
+        async for chunk in proc.stdout:
+            buffer += chunk.decode("utf-8", errors="replace")
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.strip()
+                if line:
+                    yield line
+
+        if buffer.strip():
+            yield buffer.strip()
+
+        await proc.wait()
+    finally:
+        # Release the subprocess and stderr drain task even if the consumer
+        # abandons the generator early (task cancellation / client disconnect):
+        # cancel the drain task and terminate+reap the process if it is still
+        # running, so neither is leaked.
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            pass
+        if proc.returncode is None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+
+
+@acp.on_task_create
+async def handle_task_create(params: CreateTaskParams):
+    logger.info("Task created: %s", params.task.id)
+
+
+@acp.on_task_event_send
+async def handle_task_event_send(params: SendEventParams):
+    """Handle a user message: spawn Claude Code locally and push events to the task stream."""
+    task_id = params.task.id
+    prompt = params.event.content.content
+    logger.info("Processing message for task %s", task_id)
+
+    await adk.messages.create(task_id=task_id, content=params.event.content)
+
+    async with adk.tracing.span(
+        trace_id=task_id,
+        task_id=task_id,
+        name="message",
+        input={"message": prompt},
+        data={"__span_type__": "AGENT_WORKFLOW"},
+    ) as turn_span:
+        emitter = UnifiedEmitter(
+            task_id=task_id,
+            trace_id=task_id,
+            parent_span_id=turn_span.id if turn_span else None,
+        )
+        turn = ClaudeCodeTurn(_spawn_claude(prompt))
+        result = await emitter.auto_send_turn(turn)
+        if turn_span:
+            turn_span.output = {"final_text": result.final_text}
+
+
+@acp.on_task_cancel
+async def handle_task_canceled(params: CancelTaskParams):
+    logger.info("Task canceled: %s", params.task.id)

--- a/src/agentex/lib/cli/templates/default-claude-code/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/pyproject.toml.j2
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ project_name }}"
+version = "0.1.0"
+description = "{{ description }}"
+requires-python = ">=3.12"
+dependencies = [
+    "agentex-sdk",
+    "scale-gp",
+    "python-dotenv>=1.0,<2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "black",
+    "isort",
+    "flake8",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["project"]
+
+[tool.black]
+line-length = 88
+target-version = ['py312']
+
+[tool.isort]
+profile = "black"
+line_length = 88

--- a/src/agentex/lib/cli/templates/default-claude-code/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/requirements.txt.j2
@@ -1,0 +1,8 @@
+# Install agentex-sdk from local path
+agentex-sdk
+
+# Scale GenAI Platform Python SDK
+scale-gp
+
+# Loads .env files for local development
+python-dotenv>=1.0,<2

--- a/src/agentex/lib/cli/templates/sync-claude-code/.dockerignore.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/.dockerignore.j2
@@ -1,0 +1,43 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Environments
+.env**
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Git
+.git
+.gitignore
+
+# Misc
+.DS_Store 

--- a/src/agentex/lib/cli/templates/sync-claude-code/.env.example.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/.env.example.j2
@@ -1,0 +1,13 @@
+# {{ agent_name }} - Environment Variables
+# Copy this file to .env and fill in the values
+
+# API key for your LLM provider
+LITELLM_API_KEY=
+
+# LLM base URL (optional - override to use a different provider)
+# OPENAI_BASE_URL=
+
+# SGP Configuration (optional - for tracing)
+# SGP_API_KEY=
+# SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/sync-claude-code/.env.example.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/.env.example.j2
@@ -1,8 +1,8 @@
 # {{ agent_name }} - Environment Variables
 # Copy this file to .env and fill in the values
 
-# API key for your LLM provider
-LITELLM_API_KEY=
+# API key for the Claude Code CLI (the `claude` subprocess this agent spawns)
+ANTHROPIC_API_KEY=
 
 # LLM base URL (optional - override to use a different provider)
 # OPENAI_BASE_URL=

--- a/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile-uv.j2
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/**
 
+# Install the Claude Code CLI: the agent shells out to `claude` on every turn,
+# so the binary must be present in the runtime image.
+RUN npm install -g @anthropic-ai/claude-code
+
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 ENV UV_HTTP_TIMEOUT=1000

--- a/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile-uv.j2
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.3
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    htop \
+    vim \
+    curl \
+    tar \
+    python3-dev \
+    postgresql-client \
+    build-essential \
+    libpq-dev \
+    gcc \
+    cmake \
+    netcat-openbsd \
+    nodejs \
+    npm \ 
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/**
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_HTTP_TIMEOUT=1000
+
+WORKDIR /app/{{ project_path_from_build_root }}
+
+# Copy dependency files for layer caching
+COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+
+# Install dependencies (without project itself, for layer caching)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-install-project --no-dev
+
+# Copy the project code
+COPY {{ project_path_from_build_root }}/project ./project
+
+# Install the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
+ENV PYTHONPATH=/app
+
+# Run the agent using uvicorn
+CMD ["uvicorn", "project.acp:acp", "--host", "0.0.0.0", "--port", "8000"] 

--- a/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile.j2
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Install the Claude Code CLI: the agent shells out to `claude` on every turn,
+# so the binary must be present in the runtime image.
+RUN npm install -g @anthropic-ai/claude-code
+
 RUN uv pip install --system --upgrade pip setuptools wheel
 
 ENV UV_HTTP_TIMEOUT=1000

--- a/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile.j2
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.3
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    htop \
+    vim \
+    curl \
+    tar \
+    python3-dev \
+    postgresql-client \
+    build-essential \
+    libpq-dev \
+    gcc \
+    cmake \
+    netcat-openbsd \
+    nodejs \
+    npm \ 
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN uv pip install --system --upgrade pip setuptools wheel
+
+ENV UV_HTTP_TIMEOUT=1000
+
+# Copy just the requirements file to optimize caching
+COPY {{ project_path_from_build_root }}/requirements.txt /app/{{ project_path_from_build_root }}/requirements.txt
+
+WORKDIR /app/{{ project_path_from_build_root }}
+
+# Install the required Python packages
+RUN uv pip install --system -r requirements.txt
+
+# Copy the project code
+COPY {{ project_path_from_build_root }}/project /app/{{ project_path_from_build_root }}/project
+
+
+# Set environment variables
+ENV PYTHONPATH=/app
+
+# Run the agent using uvicorn
+CMD ["uvicorn", "project.acp:acp", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/agentex/lib/cli/templates/sync-claude-code/README.md.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/README.md.j2
@@ -1,0 +1,64 @@
+# {{ agent_name }} - AgentEx Sync Claude Code Agent
+
+This template builds a **synchronous** agent that drives the **Claude Code CLI**
+through the unified harness surface on AgentEx:
+- Spawns `claude -p --output-format stream-json --verbose` as a local subprocess
+- Wraps the CLI's stdout stream in a `ClaudeCodeTurn`
+- Delivers canonical `StreamTaskMessage*` events via `UnifiedEmitter.yield_turn`
+  (the sync HTTP yield path)
+- Tracing integration to SGP / AgentEx
+
+## Prerequisites
+
+- The `claude` CLI installed and on your `PATH`
+- An `ANTHROPIC_API_KEY` (or equivalent credential) in your environment
+
+## Running the Agent
+
+```bash
+agentex agents run --manifest manifest.yaml
+```
+
+## Project Structure
+
+```
+{{ project_name }}/
+├── project/
+│   ├── __init__.py
+│   └── acp.py          # ACP server, subprocess spawn, and message handler
+├── Dockerfile
+├── manifest.yaml
+├── dev.ipynb
+{% if use_uv %}
+└── pyproject.toml
+{% else %}
+└── requirements.txt
+{% endif %}
+```
+
+## Key Concepts
+
+### Sync ACP with the harness
+The sync ACP model uses HTTP request/response. The `@acp.on_message_send`
+handler spawns the Claude Code CLI and yields the harness events back to the
+client as they arrive.
+
+### The unified harness surface
+`ClaudeCodeTurn` + `UnifiedEmitter` are the unified harness surface. The turn
+normalizes CLI output into canonical AgentEx events; the emitter traces and
+delivers them.
+
+## Development
+
+### 1. Customize the subprocess
+Edit `_spawn_claude` in `project/acp.py` to change the CLI flags, working
+directory, or how the prompt is delivered.
+
+### 2. Configure Credentials
+Set your credentials via `manifest.yaml`, an exported environment variable, or a
+`.env` file in the project directory.
+
+### 3. Run Locally
+```bash
+export ENVIRONMENT=development && agentex agents run --manifest manifest.yaml
+```

--- a/src/agentex/lib/cli/templates/sync-claude-code/dev.ipynb.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/dev.ipynb.j2
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36834357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agentex import Agentex\n",
+    "\n",
+    "client = Agentex(base_url=\"http://localhost:5003\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1c309d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AGENT_NAME = \"{{ agent_name }}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f6e6ef0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # (Optional) Create a new task. If you don't create a new task, each message will be sent to a new task. The server will create the task for you.\n",
+    "\n",
+    "# import uuid\n",
+    "\n",
+    "# TASK_ID = str(uuid.uuid4())[:8]\n",
+    "\n",
+    "# rpc_response = client.agents.rpc_by_name(\n",
+    "#     agent_name=AGENT_NAME,\n",
+    "#     method=\"task/create\",\n",
+    "#     params={\n",
+    "#         \"name\": f\"{TASK_ID}-task\",\n",
+    "#         \"params\": {}\n",
+    "#     }\n",
+    "# )\n",
+    "\n",
+    "# task = rpc_response.result\n",
+    "# print(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b03b0d37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test non streaming response\n",
+    "from agentex.types import TextContent\n",
+    "\n",
+    "# The response is expected to be a list of TaskMessage objects, which is a union of the following types:\n",
+    "# - TextContent: A message with just text content   \n",
+    "# - DataContent: A message with JSON-serializable data content\n",
+    "# - ToolRequestContent: A message with a tool request, which contains a JSON-serializable request to call a tool\n",
+    "# - ToolResponseContent: A message with a tool response, which contains response object from a tool call in its content\n",
+    "\n",
+    "# When processing the message/send response, if you are expecting more than TextContent, such as DataContent, ToolRequestContent, or ToolResponseContent, you can process them as well\n",
+    "\n",
+    "rpc_response = client.agents.send_message(\n",
+    "    agent_name=AGENT_NAME,\n",
+    "    params={\n",
+    "        \"content\": {\"type\": \"text\", \"author\": \"user\", \"content\": \"Hello what can you do?\"},\n",
+    "        \"stream\": False\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "if not rpc_response or not rpc_response.result:\n",
+    "    raise ValueError(\"No result in response\")\n",
+    "\n",
+    "# Extract and print just the text content from the response\n",
+    "for task_message in rpc_response.result:\n",
+    "    content = task_message.content\n",
+    "    if isinstance(content, TextContent):\n",
+    "        text = content.content\n",
+    "        print(text)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79688331",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test streaming response\n",
+    "from agentex.types.task_message_update import StreamTaskMessageDelta, StreamTaskMessageFull\n",
+    "from agentex.types.text_delta import TextDelta\n",
+    "\n",
+    "\n",
+    "# The result object of message/send will be a TaskMessageUpdate which is a union of the following types:\n",
+    "# - StreamTaskMessageStart: \n",
+    "#   - An indicator that a streaming message was started, doesn't contain any useful content\n",
+    "# - StreamTaskMessageDelta: \n",
+    "#   - A delta of a streaming message, contains the text delta to aggregate\n",
+    "# - StreamTaskMessageDone: \n",
+    "#   - An indicator that a streaming message was done, doesn't contain any useful content\n",
+    "# - StreamTaskMessageFull: \n",
+    "#   - A non-streaming message, there is nothing to aggregate, since this contains the full message, not deltas\n",
+    "\n",
+    "# Whenn processing StreamTaskMessageDelta, if you are expecting more than TextDeltas, such as DataDelta, ToolRequestDelta, or ToolResponseDelta, you can process them as well\n",
+    "# Whenn processing StreamTaskMessageFull, if you are expecting more than TextContent, such as DataContent, ToolRequestContent, or ToolResponseContent, you can process them as well\n",
+    "\n",
+    "for agent_rpc_response_chunk in client.agents.send_message_stream(\n",
+    "    agent_name=AGENT_NAME,\n",
+    "    params={\n",
+    "        \"content\": {\"type\": \"text\", \"author\": \"user\", \"content\": \"Hello what can you do?\"},\n",
+    "        \"stream\": True\n",
+    "    }\n",
+    "):\n",
+    "    # We know that the result of the message/send when stream is set to True will be a TaskMessageUpdate\n",
+    "    task_message_update = agent_rpc_response_chunk.result\n",
+    "    # Print oly the text deltas as they arrive or any full messages\n",
+    "    if isinstance(task_message_update, StreamTaskMessageDelta):\n",
+    "        delta = task_message_update.delta\n",
+    "        if isinstance(delta, TextDelta):\n",
+    "            print(delta.text_delta, end=\"\", flush=True)\n",
+    "        else:\n",
+    "            print(f\"Found non-text {type(task_message_update)} object in streaming message.\")\n",
+    "    elif isinstance(task_message_update, StreamTaskMessageFull):\n",
+    "        content = task_message_update.content\n",
+    "        if isinstance(content, TextContent):\n",
+    "            print(content.content)\n",
+    "        else:\n",
+    "            print(f\"Found non-text {type(task_message_update)} object in full message.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5e7e042",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/agentex/lib/cli/templates/sync-claude-code/environments.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/environments.yaml.j2
@@ -1,0 +1,53 @@
+# Agent Environment Configuration
+# ------------------------------
+# This file defines environment-specific settings for your agent.
+# This DIFFERS from the manifest.yaml file in that it is used to program things that are ONLY per environment.
+
+# ********** EXAMPLE **********
+# schema_version: "v1" # This is used to validate the file structure and is not used by the agentex CLI
+# environments:
+#   dev:
+#     auth:
+#       principal:
+#         user_id: "1234567890"
+#         user_name: "John Doe"
+#         user_email: "john.doe@example.com"
+#         user_role: "admin"
+#       user_permissions: "read, write, delete"
+#     helm_overrides: # This is used to override the global helm values.yaml file in the agentex-agent helm charts
+#       replicas: 3
+#       resources:
+#         requests:
+#           cpu: "1000m"
+#           memory: "2Gi"
+#         limits:
+#           cpu: "2000m"
+#           memory: "4Gi"
+#       env:
+#         - name: LOG_LEVEL
+#           value: "DEBUG"
+#         - name: ENVIRONMENT
+#           value: "staging"
+#     kubernetes: 
+#       # OPTIONAL - Otherwise it will be derived from separately. However, this can be used to override the derived
+#       #   namespace and deploy it with in the same namespace that already exists for a separate agent.
+#       namespace: "team-{{agent_name}}"
+# ********** END EXAMPLE **********
+
+schema_version: "v1" # This is used to validate the file structure and is not used by the agentex CLI
+environments:
+  dev:
+    auth:
+      principal:
+        user_id: # TODO: Fill in
+        account_id: # TODO: Fill in
+    helm_overrides:
+      replicaCount: 2
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+        limits:
+          cpu: "1000m"
+          memory: "2Gi"
+

--- a/src/agentex/lib/cli/templates/sync-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/manifest.yaml.j2
@@ -75,8 +75,10 @@ agent:
   # Maps Kubernetes secrets to environment variables
   # Common credentials include:
   credentials:
-    - env_var_name: LITELLM_API_KEY
-      secret_name: litellm-api-key
+    # The Claude Code CLI authenticates with ANTHROPIC_API_KEY (LITELLM_API_KEY
+    # is not read by the `claude` subprocess this agent spawns).
+    - env_var_name: ANTHROPIC_API_KEY
+      secret_name: anthropic-api-key
       secret_key: api-key
     - env_var_name: SGP_API_KEY
       secret_name: sgp-api-key
@@ -85,8 +87,7 @@ agent:
   # Optional: Set Environment variables for running your agent locally as well
   # as for deployment later on
   env:
-    LITELLM_API_KEY: ""  # Set your LLM API key
-  #   OPENAI_BASE_URL: "<YOUR_OPENAI_BASE_URL_HERE>"
+    ANTHROPIC_API_KEY: ""  # Required by the Claude Code CLI
 
 
 # Deployment Configuration

--- a/src/agentex/lib/cli/templates/sync-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/manifest.yaml.j2
@@ -85,9 +85,11 @@ agent:
       secret_key: api-key
 
   # Optional: Set Environment variables for running your agent locally as well
-  # as for deployment later on
-  env:
-    ANTHROPIC_API_KEY: ""  # Required by the Claude Code CLI
+  # as for deployment later on. ANTHROPIC_API_KEY is supplied via the credential
+  # mapping above (deploy) or your local .env (load_dotenv). Do NOT set it to an
+  # empty string here — that would shadow the real key at runtime.
+  env: {}
+  #   ANTHROPIC_API_KEY: "<your-key>"  # uncomment only to hardcode for local runs
 
 
 # Deployment Configuration

--- a/src/agentex/lib/cli/templates/sync-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/manifest.yaml.j2
@@ -1,0 +1,117 @@
+# Agent Manifest Configuration
+# ---------------------------
+# This file defines how your agent should be built and deployed.
+
+# Build Configuration
+# ------------------
+# The build config defines what gets packaged into your agent's Docker image.
+# This same configuration is used whether building locally or remotely.
+#
+# When building:
+# 1. All files from include_paths are collected into a build context
+# 2. The context is filtered by dockerignore rules
+# 3. The Dockerfile uses this context to build your agent's image
+# 4. The image is pushed to a registry and used to run your agent
+build:
+  context:
+    # Root directory for the build context
+    root: ../  # Keep this as the default root
+
+    # Paths to include in the Docker build context
+    # Must include:
+    # - Your agent's directory (your custom agent code)
+    # These paths are collected and sent to the Docker daemon for building
+    include_paths:
+      - {{ project_path_from_build_root }}
+
+    # Path to your agent's Dockerfile
+    # This defines how your agent's image is built from the context
+    # Relative to the root directory
+    dockerfile: {{ project_path_from_build_root }}/Dockerfile
+
+    # Path to your agent's .dockerignore
+    # Filters unnecessary files from the build context
+    # Helps keep build context small and builds fast
+    dockerignore: {{ project_path_from_build_root }}/.dockerignore
+
+
+# Local Development Configuration
+# -----------------------------
+# Only used when running the agent locally
+local_development:
+  agent:
+    port: 8000  # Port where your local ACP server is running
+    host_address: host.docker.internal  # Host address for Docker networking (host.docker.internal for Docker, localhost for direct) 
+
+  # File paths for local development (relative to this manifest.yaml)
+  paths:
+    # Path to ACP server file
+    # Examples:
+    #   project/acp.py          (standard)
+    #   src/server.py           (custom structure)
+    #   ../shared/acp.py        (shared across projects)
+    #   /absolute/path/acp.py   (absolute path)
+    acp: project/acp.py
+
+
+# Agent Configuration
+# -----------------
+agent:
+  acp_type: sync
+  # Unique name for your agent
+  # Used for task routing and monitoring
+  name: {{ agent_name }}
+
+  # Description of what your agent does
+  # Helps with documentation and discovery
+  description: {{ description }}
+
+  # Temporal workflow configuration
+  # Set enabled: true to use Temporal workflows for long-running tasks
+  temporal:
+    enabled: false
+
+  # Optional: Credentials mapping
+  # Maps Kubernetes secrets to environment variables
+  # Common credentials include:
+  credentials:
+    - env_var_name: LITELLM_API_KEY
+      secret_name: litellm-api-key
+      secret_key: api-key
+    - env_var_name: SGP_API_KEY
+      secret_name: sgp-api-key
+      secret_key: api-key
+
+  # Optional: Set Environment variables for running your agent locally as well
+  # as for deployment later on
+  env:
+    LITELLM_API_KEY: ""  # Set your LLM API key
+  #   OPENAI_BASE_URL: "<YOUR_OPENAI_BASE_URL_HERE>"
+
+
+# Deployment Configuration
+# -----------------------
+# Configuration for deploying your agent to Kubernetes clusters
+deployment:
+  # Container image configuration
+  image:
+    repository: "" # Update with your container registry
+    tag: "latest"  # Default tag, should be versioned in production
+  
+  imagePullSecrets: [] # Update with your image pull secret names
+    # - name: my-registry-secret
+
+  # Global deployment settings that apply to all clusters
+  # These can be overridden in cluster-specific environments (environments.yaml)
+  global:
+    # Default replica count
+    replicaCount: 1
+    
+    # Default resource requirements
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "1000m"
+        memory: "2Gi" 

--- a/src/agentex/lib/cli/templates/sync-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/project/acp.py.j2
@@ -65,6 +65,7 @@ async def _spawn_claude(prompt: str) -> AsyncIterator[str]:
     assert proc.stdin is not None
 
     proc.stdin.write(prompt.encode())
+    await proc.stdin.drain()
     proc.stdin.close()
 
     # Drain stderr concurrently. With --verbose, Claude Code can write enough to

--- a/src/agentex/lib/cli/templates/sync-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/project/acp.py.j2
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import asyncio
 from typing import AsyncIterator, AsyncGenerator
+from collections import deque
 
 from dotenv import load_dotenv
 
@@ -69,11 +70,17 @@ async def _spawn_claude(prompt: str) -> AsyncIterator[str]:
     # Drain stderr concurrently. With --verbose, Claude Code can write enough to
     # stderr to fill the OS pipe buffer; if we only read stdout, the CLI blocks
     # on its stderr write while we block reading stdout — a deadlock. A
-    # background task keeps stderr flowing so stdout never stalls.
+    # background task keeps stderr flowing so stdout never stalls. We keep a
+    # bounded tail so a non-zero exit can be surfaced with context instead of
+    # silently completing the turn.
+    stderr_tail: deque[str] = deque(maxlen=20)
+
     async def _drain_stderr() -> None:
         assert proc.stderr is not None
-        async for _ in proc.stderr:
-            pass
+        async for raw in proc.stderr:
+            text = raw.decode("utf-8", errors="replace").rstrip()
+            if text:
+                stderr_tail.append(text)
 
     stderr_task = asyncio.create_task(_drain_stderr())
 
@@ -91,6 +98,13 @@ async def _spawn_claude(prompt: str) -> AsyncIterator[str]:
             yield buffer.strip()
 
         await proc.wait()
+        if proc.returncode:
+            # The CLI failed (missing binary/auth, bad command). Raise so the
+            # turn surfaces as failed instead of completing with no output.
+            tail = "\n".join(stderr_tail)
+            raise RuntimeError(
+                f"claude CLI exited with status {proc.returncode}:\n{tail}"
+            )
     finally:
         # Release the subprocess and stderr drain task even if the consumer
         # abandons the generator early (task cancellation / client disconnect):

--- a/src/agentex/lib/cli/templates/sync-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/project/acp.py.j2
@@ -1,0 +1,135 @@
+"""ACP handler for {{ agent_name }} — a sync Claude Code agent.
+
+Spawns ``claude -p --output-format stream-json --verbose`` as a LOCAL
+asyncio subprocess (no Scale sandbox — that is a production concern). Stdout
+lines are fed into ``ClaudeCodeTurn``, which wraps
+``convert_claude_code_to_agentex_events``. Events are delivered via
+``UnifiedEmitter.yield_turn``, the sync HTTP yield path.
+
+Live runs require the ``claude`` CLI to be installed and an
+ANTHROPIC_API_KEY (or equivalent credential) to be in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import asyncio
+from typing import AsyncIterator, AsyncGenerator
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import agentex.lib.adk as adk
+from agentex.lib.adk import ClaudeCodeTurn
+from agentex.lib.types.acp import SendMessageParams
+from agentex.lib.core.harness import UnifiedEmitter
+from agentex.lib.types.tracing import SGPTracingProcessorConfig
+from agentex.lib.utils.logging import make_logger
+from agentex.lib.sdk.fastacp.fastacp import FastACP
+from agentex.types.task_message_update import TaskMessageUpdate
+from agentex.types.task_message_content import TaskMessageContent
+from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
+
+logger = make_logger(__name__)
+
+add_tracing_processor_config(
+    SGPTracingProcessorConfig(
+        sgp_api_key=os.environ.get("SGP_API_KEY", ""),
+        sgp_account_id=os.environ.get("SGP_ACCOUNT_ID", ""),
+        sgp_base_url=os.environ.get("SGP_CLIENT_BASE_URL", ""),
+    )
+)
+
+acp = FastACP.create(acp_type="sync")
+
+
+async def _spawn_claude(prompt: str) -> AsyncIterator[str]:
+    """Spawn ``claude -p --output-format stream-json`` locally and yield stdout lines.
+
+    This is a seam: tests can replace it with a fake async iterator of
+    pre-recorded lines so no real CLI invocation is needed offline.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    assert proc.stdin is not None
+
+    proc.stdin.write(prompt.encode())
+    proc.stdin.close()
+
+    # Drain stderr concurrently. With --verbose, Claude Code can write enough to
+    # stderr to fill the OS pipe buffer; if we only read stdout, the CLI blocks
+    # on its stderr write while we block reading stdout — a deadlock. A
+    # background task keeps stderr flowing so stdout never stalls.
+    async def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        async for _ in proc.stderr:
+            pass
+
+    stderr_task = asyncio.create_task(_drain_stderr())
+
+    try:
+        buffer = ""
+        async for chunk in proc.stdout:
+            buffer += chunk.decode("utf-8", errors="replace")
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.strip()
+                if line:
+                    yield line
+
+        if buffer.strip():
+            yield buffer.strip()
+
+        await proc.wait()
+    finally:
+        # Release the subprocess and stderr drain task even if the consumer
+        # abandons the generator early (task cancellation / client disconnect):
+        # cancel the drain task and terminate+reap the process if it is still
+        # running, so neither is leaked.
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            pass
+        if proc.returncode is None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+
+
+@acp.on_message_send
+async def handle_message_send(
+    params: SendMessageParams,
+) -> TaskMessageContent | list[TaskMessageContent] | AsyncGenerator[TaskMessageUpdate, None]:
+    """Handle an incoming message: run Claude Code locally and stream events."""
+    task_id = params.task.id
+    prompt = params.content.content
+    logger.info("Processing message for task %s", task_id)
+
+    async with adk.tracing.span(
+        trace_id=task_id,
+        task_id=task_id,
+        name="message",
+        input={"message": prompt},
+        data={"__span_type__": "AGENT_WORKFLOW"},
+    ) as turn_span:
+        emitter = UnifiedEmitter(
+            task_id=task_id,
+            trace_id=task_id,
+            parent_span_id=turn_span.id if turn_span else None,
+        )
+        turn = ClaudeCodeTurn(_spawn_claude(prompt))
+        async for event in emitter.yield_turn(turn):
+            yield event

--- a/src/agentex/lib/cli/templates/sync-claude-code/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/pyproject.toml.j2
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ project_name }}"
+version = "0.1.0"
+description = "{{ description }}"
+requires-python = ">=3.12"
+dependencies = [
+    "agentex-sdk",
+    "scale-gp",
+    "python-dotenv>=1.0,<2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "black",
+    "isort",
+    "flake8",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["project"]
+
+[tool.black]
+line-length = 88
+target-version = ['py312']
+
+[tool.isort]
+profile = "black"
+line_length = 88

--- a/src/agentex/lib/cli/templates/sync-claude-code/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/requirements.txt.j2
@@ -1,0 +1,8 @@
+# Install agentex-sdk from local path
+agentex-sdk
+
+# Scale GenAI Platform Python SDK
+scale-gp
+
+# Loads .env files for local development
+python-dotenv>=1.0,<2

--- a/src/agentex/lib/cli/templates/temporal-claude-code/.dockerignore.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/.dockerignore.j2
@@ -1,0 +1,43 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Environments
+.env**
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Git
+.git
+.gitignore
+
+# Misc
+.DS_Store 

--- a/src/agentex/lib/cli/templates/temporal-claude-code/.env.example.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/.env.example.j2
@@ -1,0 +1,13 @@
+# {{ agent_name }} - Environment Variables
+# Copy this file to .env and fill in the values
+
+# API key for your LLM provider
+LITELLM_API_KEY=
+
+# LLM base URL (optional - override to use a different provider)
+# OPENAI_BASE_URL=
+
+# SGP Configuration (optional - for tracing)
+# SGP_API_KEY=
+# SGP_ACCOUNT_ID=
+# SGP_CLIENT_BASE_URL=

--- a/src/agentex/lib/cli/templates/temporal-claude-code/.env.example.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/.env.example.j2
@@ -1,8 +1,8 @@
 # {{ agent_name }} - Environment Variables
 # Copy this file to .env and fill in the values
 
-# API key for your LLM provider
-LITELLM_API_KEY=
+# API key for the Claude Code CLI (the `claude` subprocess this agent spawns)
+ANTHROPIC_API_KEY=
 
 # LLM base URL (optional - override to use a different provider)
 # OPENAI_BASE_URL=

--- a/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile-uv.j2
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/**
 
+# Install the Claude Code CLI: the activity shells out to `claude` on every
+# turn, so the binary must be present in the runtime image.
+RUN npm install -g @anthropic-ai/claude-code
+
 # Install tctl (Temporal CLI)
 RUN ARCH="$(uname -m)" && \
     case "$ARCH" in x86_64) TCTL_ARCH=amd64 ;; aarch64|arm64) TCTL_ARCH=arm64 ;; *) TCTL_ARCH=amd64 ;; esac && \

--- a/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile-uv.j2
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.3
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    htop \
+    vim \
+    curl \
+    tar \
+    python3-dev \
+    postgresql-client \
+    build-essential \
+    libpq-dev \
+    gcc \
+    cmake \
+    netcat-openbsd \
+    nodejs \
+    npm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/**
+
+# Install tctl (Temporal CLI)
+RUN ARCH="$(uname -m)" && \
+    case "$ARCH" in x86_64) TCTL_ARCH=amd64 ;; aarch64|arm64) TCTL_ARCH=arm64 ;; *) TCTL_ARCH=amd64 ;; esac && \
+    curl -L "https://github.com/temporalio/tctl/releases/download/v1.18.1/tctl_1.18.1_linux_${TCTL_ARCH}.tar.gz" -o /tmp/tctl.tar.gz && \
+    tar -xzf /tmp/tctl.tar.gz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/tctl && \
+    rm /tmp/tctl.tar.gz
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_HTTP_TIMEOUT=1000
+
+WORKDIR /app/{{ project_path_from_build_root }}
+
+# Copy dependency files for layer caching
+COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+
+# Install dependencies (without project itself, for layer caching)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-install-project --no-dev
+
+# Copy the project code
+COPY {{ project_path_from_build_root }}/project ./project
+
+# Install the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
+
+# Run the ACP server using uvicorn
+CMD ["uvicorn", "project.acp:acp", "--host", "0.0.0.0", "--port", "8000"]
+
+# When we deploy the worker, we will replace the CMD with the following
+# CMD ["python", "-m", "run_worker"]

--- a/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile.j2
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Install the Claude Code CLI: the activity shells out to `claude` on every
+# turn, so the binary must be present in the runtime image.
+RUN npm install -g @anthropic-ai/claude-code
+
 # Install tctl (Temporal CLI)
 RUN ARCH="$(uname -m)" && \
     case "$ARCH" in x86_64) TCTL_ARCH=amd64 ;; aarch64|arm64) TCTL_ARCH=arm64 ;; *) TCTL_ARCH=amd64 ;; esac && \

--- a/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile.j2
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1.3
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    htop \
+    vim \
+    curl \
+    tar \
+    python3-dev \
+    postgresql-client \
+    build-essential \
+    libpq-dev \
+    gcc \
+    cmake \
+    netcat-openbsd \
+    nodejs \
+    npm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install tctl (Temporal CLI)
+RUN ARCH="$(uname -m)" && \
+    case "$ARCH" in x86_64) TCTL_ARCH=amd64 ;; aarch64|arm64) TCTL_ARCH=arm64 ;; *) TCTL_ARCH=amd64 ;; esac && \
+    curl -L "https://github.com/temporalio/tctl/releases/download/v1.18.1/tctl_1.18.1_linux_${TCTL_ARCH}.tar.gz" -o /tmp/tctl.tar.gz && \
+    tar -xzf /tmp/tctl.tar.gz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/tctl && \
+    rm /tmp/tctl.tar.gz
+
+RUN uv pip install --system --upgrade pip setuptools wheel
+
+ENV UV_HTTP_TIMEOUT=1000
+
+# Copy just the requirements file to optimize caching
+COPY {{ project_path_from_build_root }}/requirements.txt /app/{{ project_path_from_build_root }}/requirements.txt
+
+WORKDIR /app/{{ project_path_from_build_root }}
+
+# Install the required Python packages
+RUN uv pip install --system -r requirements.txt
+
+# Copy the project code
+COPY {{ project_path_from_build_root }}/project /app/{{ project_path_from_build_root }}/project
+
+# Run the ACP server using uvicorn
+CMD ["uvicorn", "project.acp:acp", "--host", "0.0.0.0", "--port", "8000"]
+
+# When we deploy the worker, we will replace the CMD with the following
+# CMD ["python", "-m", "run_worker"] 

--- a/src/agentex/lib/cli/templates/temporal-claude-code/README.md.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/README.md.j2
@@ -1,0 +1,73 @@
+# {{ agent_name }} — AgentEx Temporal + Claude Code
+
+This template builds a **Temporal-durable** agent that drives the **Claude Code
+CLI** through the unified harness surface on AgentEx:
+- A Temporal workflow holds conversation state (the Claude Code `session_id`)
+  durably across worker crashes
+- Each turn delegates to the `run_claude_code_turn` activity, which spawns the
+  CLI (subprocess I/O is not permitted on the workflow event loop)
+- The activity wraps the CLI's stdout stream in a `ClaudeCodeTurn` and delivers
+  canonical `StreamTaskMessage*` events via `UnifiedEmitter.auto_send_turn`
+- Tracing integration to SGP / AgentEx
+
+## Prerequisites
+
+- The `claude` CLI installed and on your `PATH`
+- An `ANTHROPIC_API_KEY` (or equivalent credential) in your environment
+- A running Temporal service (provided automatically by the local dev stack)
+
+## Running the Agent
+
+```bash
+agentex agents run --manifest manifest.yaml
+```
+
+This starts both the ACP HTTP server and the Temporal worker.
+
+## Project Structure
+
+```
+{{ project_name }}/
+├── project/
+│   ├── __init__.py
+│   ├── acp.py            # Thin ACP server; FastACP auto-wires to the workflow
+│   ├── workflow.py       # Temporal workflow (durable conversation state)
+│   ├── activities.py     # run_claude_code_turn activity (CLI subprocess)
+│   └── run_worker.py     # Temporal worker entrypoint
+├── Dockerfile
+├── manifest.yaml
+├── dev.ipynb
+{% if use_uv %}
+└── pyproject.toml
+{% else %}
+└── requirements.txt
+{% endif %}
+```
+
+## Key Concepts
+
+### Subprocess must run in an activity
+Temporal runs workflow + signal-handler bodies on a deterministic sandbox event
+loop that does not implement `subprocess_exec`. The workflow therefore delegates
+each turn to the `run_claude_code_turn` activity, which also gains Temporal's
+retry + timeout guarantees.
+
+### The unified harness surface
+`ClaudeCodeTurn` + `UnifiedEmitter` are the unified harness surface. The turn
+normalizes CLI output into canonical AgentEx events; the emitter traces and
+delivers them.
+
+## Development
+
+### 1. Customize the subprocess
+Edit `_spawn_claude` in `project/activities.py` to change the CLI flags, working
+directory, or how the prompt is delivered.
+
+### 2. Configure Credentials
+Set your credentials via `manifest.yaml`, an exported environment variable, or a
+`.env` file in the project directory.
+
+### 3. Run Locally
+```bash
+export ENVIRONMENT=development && agentex agents run --manifest manifest.yaml
+```

--- a/src/agentex/lib/cli/templates/temporal-claude-code/dev.ipynb.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/dev.ipynb.j2
@@ -1,0 +1,126 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36834357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agentex import Agentex\n",
+    "\n",
+    "client = Agentex(base_url=\"http://localhost:5003\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1c309d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AGENT_NAME = \"{{ agent_name }}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f6e6ef0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (REQUIRED) Create a new task. For Async agents, you must create a task for messages to be associated with.\n",
+    "import uuid\n",
+    "\n",
+    "rpc_response = client.agents.create_task(\n",
+    "    agent_name=AGENT_NAME,\n",
+    "    params={\n",
+    "        \"name\": f\"{str(uuid.uuid4())[:8]}-task\",\n",
+    "        \"params\": {}\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "task = rpc_response.result\n",
+    "print(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b03b0d37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Send an event to the agent\n",
+    "\n",
+    "# The response is expected to be a list of TaskMessage objects, which is a union of the following types:\n",
+    "# - TextContent: A message with just text content   \n",
+    "# - DataContent: A message with JSON-serializable data content\n",
+    "# - ToolRequestContent: A message with a tool request, which contains a JSON-serializable request to call a tool\n",
+    "# - ToolResponseContent: A message with a tool response, which contains response object from a tool call in its content\n",
+    "\n",
+    "# When processing the message/send response, if you are expecting more than TextContent, such as DataContent, ToolRequestContent, or ToolResponseContent, you can process them as well\n",
+    "\n",
+    "rpc_response = client.agents.send_event(\n",
+    "    agent_name=AGENT_NAME,\n",
+    "    params={\n",
+    "        \"content\": {\"type\": \"text\", \"author\": \"user\", \"content\": \"Hello what can you do?\"},\n",
+    "        \"task_id\": task.id,\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "event = rpc_response.result\n",
+    "print(event)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6927cc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subscribe to the async task messages produced by the agent\n",
+    "from agentex.lib.utils.dev_tools import subscribe_to_async_task_messages\n",
+    "\n",
+    "task_messages = subscribe_to_async_task_messages(\n",
+    "    client=client,\n",
+    "    task=task, \n",
+    "    only_after_timestamp=event.created_at, \n",
+    "    print_messages=True,\n",
+    "    rich_print=True,\n",
+    "    timeout=5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4864e354",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/agentex/lib/cli/templates/temporal-claude-code/environments.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/environments.yaml.j2
@@ -1,0 +1,64 @@
+# Agent Environment Configuration
+# ------------------------------
+# This file defines environment-specific settings for your agent.
+# This DIFFERS from the manifest.yaml file in that it is used to program things that are ONLY per environment.
+
+# ********** EXAMPLE **********
+# schema_version: "v1" # This is used to validate the file structure and is not used by the agentex CLI
+# environments:
+#   dev:
+#     auth:
+#       principal:
+#         user_id: "1234567890"
+#         user_name: "John Doe"
+#         user_email: "john.doe@example.com"
+#         user_role: "admin"
+#       user_permissions: "read, write, delete"
+#     helm_overrides: # This is used to override the global helm values.yaml file in the agentex-agent helm charts
+#       replicas: 3
+#       resources:
+#         requests:
+#           cpu: "1000m"
+#           memory: "2Gi"
+#         limits:
+#           cpu: "2000m"
+#           memory: "4Gi"
+#       env:
+#         - name: LOG_LEVEL
+#           value: "DEBUG"
+#         - name: ENVIRONMENT
+#           value: "staging"
+#
+#     kubernetes: 
+#       # OPTIONAL - Otherwise it will be derived from separately. However, this can be used to override the derived
+#       #   namespace and deploy it with in the same namespace that already exists for a separate agent.
+#       namespace: "team-{{agent_name}}"
+# ********** END EXAMPLE **********
+
+schema_version: "v1" # This is used to validate the file structure and is not used by the agentex CLI
+environments:
+  dev:
+    auth:
+      principal:
+        user_id: # TODO: Fill in
+        account_id: # TODO: Fill in
+    helm_overrides: 
+      # This is used to override the global helm values.yaml file in the agentex-agent helm charts
+      replicaCount: 2
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+        limits:
+          cpu: "1000m"
+          memory: "2Gi"
+      temporal-worker:
+        enabled: true
+        replicaCount: 2
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            cpu: "1000m"
+            memory: "2Gi"

--- a/src/agentex/lib/cli/templates/temporal-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/manifest.yaml.j2
@@ -100,14 +100,16 @@ agent:
     - env_var_name: REDIS_URL
       secret_name: redis-url-secret
       secret_key: url
-  #   - env_var_name: LITELLM_API_KEY
-  #     secret_name: litellm-api-key
-  #     secret_key: api-key
-  
-  # Optional: Set Environment variables for running your agent locally as well 
+    # The Claude Code CLI spawned in project/activities.py authenticates with
+    # ANTHROPIC_API_KEY; without it every turn fails with a CLI auth error.
+    - env_var_name: ANTHROPIC_API_KEY
+      secret_name: anthropic-api-key
+      secret_key: api-key
+
+  # Optional: Set Environment variables for running your agent locally as well
   # as for deployment later on
-  env: {}
-  #   LITELLM_API_KEY: "<YOUR_LITELLM_API_KEY_HERE>"
+  env:
+    ANTHROPIC_API_KEY: ""  # Required by the Claude Code CLI
   #   OPENAI_BASE_URL: "<YOUR_OPENAI_BASE_URL_HERE>"
   #   OPENAI_ORG_ID: "<YOUR_OPENAI_ORG_ID_HERE>"
 

--- a/src/agentex/lib/cli/templates/temporal-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/manifest.yaml.j2
@@ -107,11 +107,11 @@ agent:
       secret_key: api-key
 
   # Optional: Set Environment variables for running your agent locally as well
-  # as for deployment later on
-  env:
-    ANTHROPIC_API_KEY: ""  # Required by the Claude Code CLI
-  #   OPENAI_BASE_URL: "<YOUR_OPENAI_BASE_URL_HERE>"
-  #   OPENAI_ORG_ID: "<YOUR_OPENAI_ORG_ID_HERE>"
+  # as for deployment later on. ANTHROPIC_API_KEY is supplied via the credential
+  # mapping above (deploy) or your local .env (load_dotenv). Do NOT set it to an
+  # empty string here — that would shadow the real key at runtime.
+  env: {}
+  #   ANTHROPIC_API_KEY: "<your-key>"  # uncomment only to hardcode for local runs
 
 
 # Deployment Configuration

--- a/src/agentex/lib/cli/templates/temporal-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/manifest.yaml.j2
@@ -1,0 +1,140 @@
+# Agent Manifest Configuration
+# ---------------------------
+# This file defines how your agent should be built and deployed.
+
+# Build Configuration
+# ------------------
+# The build config defines what gets packaged into your agent's Docker image.
+# This same configuration is used whether building locally or remotely.
+#
+# When building:
+# 1. All files from include_paths are collected into a build context
+# 2. The context is filtered by dockerignore rules
+# 3. The Dockerfile uses this context to build your agent's image
+# 4. The image is pushed to a registry and used to run your agent
+build:
+  context:
+    # Root directory for the build context
+    root: ../  # Keep this as the default root
+
+    # Paths to include in the Docker build context
+    # Must include:
+    # - Your agent's directory (your custom agent code)
+    # These paths are collected and sent to the Docker daemon for building
+    include_paths:
+      - {{ project_path_from_build_root }}
+
+    # Path to your agent's Dockerfile
+    # This defines how your agent's image is built from the context
+    # Relative to the root directory
+    dockerfile: {{ project_path_from_build_root }}/Dockerfile
+
+    # Path to your agent's .dockerignore
+    # Filters unnecessary files from the build context
+    # Helps keep build context small and builds fast
+    dockerignore: {{ project_path_from_build_root }}/.dockerignore
+
+
+# Local Development Configuration
+# -----------------------------
+# Only used when running the agent locally
+local_development:
+  agent:
+    port: 8000  # Port where your local ACP server is running
+    host_address: host.docker.internal  # Host address for Docker networking (host.docker.internal for Docker, localhost for direct) 
+
+  # File paths for local development (relative to this manifest.yaml)
+  paths:
+    # Path to ACP server file
+    # Examples:
+    #   project/acp.py          (standard)
+    #   src/server.py           (custom structure)
+    #   ../shared/acp.py        (shared across projects)
+    #   /absolute/path/acp.py   (absolute path)
+    acp: project/acp.py
+    
+    # Path to temporal worker file
+    # Examples:
+    #   project/run_worker.py   (standard)
+    #   workers/temporal.py     (custom structure)
+    #   ../shared/worker.py     (shared across projects)
+    worker: project/run_worker.py
+
+
+# Agent Configuration
+# -----------------
+agent:
+  # Type of agent - either sync or async
+  acp_type: async
+
+  # Unique name for your agent
+  # Used for task routing and monitoring
+  name: {{ agent_name }}
+
+  # Description of what your agent does
+  # Helps with documentation and discovery
+  description: "{{ description }}"
+
+  # Temporal workflow configuration
+  # This enables your agent to run as a Temporal workflow for long-running tasks
+  temporal:
+    enabled: true
+    workflows:
+      # Name of the workflow class
+      # Must match the @workflow.defn name in your workflow.py
+      - name: {{ workflow_name }}
+
+        # Queue name for task distribution
+        # Used by Temporal to route tasks to your agent
+        # Convention: <agent_name>_task_queue
+        queue_name: {{ queue_name }}
+
+    # Optional: Health check port for temporal worker
+    # Defaults to 80 if not specified
+    # health_check_port: 80
+
+  # Optional: Credentials mapping
+  # Maps Kubernetes secrets to environment variables
+  # Common credentials include:
+  credentials:
+    - env_var_name: REDIS_URL
+      secret_name: redis-url-secret
+      secret_key: url
+  #   - env_var_name: LITELLM_API_KEY
+  #     secret_name: litellm-api-key
+  #     secret_key: api-key
+  
+  # Optional: Set Environment variables for running your agent locally as well 
+  # as for deployment later on
+  env: {}
+  #   LITELLM_API_KEY: "<YOUR_LITELLM_API_KEY_HERE>"
+  #   OPENAI_BASE_URL: "<YOUR_OPENAI_BASE_URL_HERE>"
+  #   OPENAI_ORG_ID: "<YOUR_OPENAI_ORG_ID_HERE>"
+
+
+# Deployment Configuration
+# -----------------------
+# Configuration for deploying your agent to Kubernetes clusters
+deployment:
+  # Container image configuration
+  image:
+    repository: "" # Update with your container registry
+    tag: "latest"  # Default tag, should be versioned in production
+
+  imagePullSecrets: [] # Update with your image pull secret name
+    # - name: my-registry-secret
+
+  # Global deployment settings that apply to all clusters
+  # These can be overridden in cluster-specific environments (environments.yaml)
+  global:
+    # Default replica count
+    replicaCount: 1
+    
+    # Default resource requirements
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "1000m"
+        memory: "2Gi" 

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/acp.py.j2
@@ -1,0 +1,31 @@
+"""ACP server for {{ agent_name }} — a Temporal Claude Code agent.
+
+This file is intentionally thin. When ``acp_type="async"`` is combined
+with ``TemporalACPConfig``, FastACP auto-wires:
+
+    HTTP task/create       -> @workflow.run on the workflow class
+    HTTP task/event/send   -> @workflow.signal(SignalName.RECEIVE_EVENT)
+    HTTP task/cancel       -> workflow cancellation via the Temporal client
+
+The actual agent code lives in ``project/workflow.py`` and is executed by
+the Temporal worker (``project/run_worker.py``), not by this HTTP process.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from agentex.lib.types.fastacp import TemporalACPConfig
+from agentex.lib.sdk.fastacp.fastacp import FastACP
+
+acp = FastACP.create(
+    acp_type="async",
+    config=TemporalACPConfig(
+        type="temporal",
+        temporal_address=os.getenv("TEMPORAL_ADDRESS", "localhost:7233"),
+    ),
+)

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/activities.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/activities.py.j2
@@ -78,6 +78,7 @@ async def _spawn_claude(prompt: str, session_id: str | None = None) -> AsyncIter
     assert proc.stdin is not None
 
     proc.stdin.write(prompt.encode())
+    await proc.stdin.drain()
     proc.stdin.close()
 
     # Drain stderr concurrently. With --verbose, Claude Code can write enough to

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/activities.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/activities.py.j2
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, AsyncIterator
 from datetime import datetime
+from collections import deque
 
 from temporalio import activity
 
@@ -82,11 +83,17 @@ async def _spawn_claude(prompt: str, session_id: str | None = None) -> AsyncIter
     # Drain stderr concurrently. With --verbose, Claude Code can write enough to
     # stderr to fill the OS pipe buffer; if we only read stdout, the CLI blocks
     # on its stderr write while we block reading stdout — a deadlock. A
-    # background task keeps stderr flowing so stdout never stalls.
+    # background task keeps stderr flowing so stdout never stalls. We keep a
+    # bounded tail so a non-zero exit can be surfaced with context instead of
+    # silently completing the turn.
+    stderr_tail: deque[str] = deque(maxlen=20)
+
     async def _drain_stderr() -> None:
         assert proc.stderr is not None
-        async for _ in proc.stderr:
-            pass
+        async for raw in proc.stderr:
+            text = raw.decode("utf-8", errors="replace").rstrip()
+            if text:
+                stderr_tail.append(text)
 
     stderr_task = asyncio.create_task(_drain_stderr())
 
@@ -104,6 +111,14 @@ async def _spawn_claude(prompt: str, session_id: str | None = None) -> AsyncIter
             yield buffer.strip()
 
         await proc.wait()
+        if proc.returncode:
+            # The CLI failed (missing binary/auth, bad command). Raise so the
+            # activity (and turn) surfaces as failed instead of completing with
+            # no output. Temporal will apply the activity's retry policy.
+            tail = "\n".join(stderr_tail)
+            raise RuntimeError(
+                f"claude CLI exited with status {proc.returncode}:\n{tail}"
+            )
     finally:
         # Release the subprocess and stderr drain task even if the consumer
         # abandons the generator early (task cancellation / client disconnect):

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/activities.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/activities.py.j2
@@ -1,0 +1,139 @@
+"""Temporal activity for {{ agent_name }} — Claude Code harness.
+
+Subprocess spawning (and any other I/O) must run inside a Temporal *activity*,
+not in workflow code. Temporal runs workflow + signal-handler bodies on a
+deterministic sandbox event loop that does not implement ``subprocess_exec``
+(or threads / sockets), so spawning the CLI directly in the signal handler
+raises ``NotImplementedError``. This activity runs the Claude Code CLI, drives
+the ``ClaudeCodeTurn`` through ``UnifiedEmitter.auto_send_turn`` (the async
+Redis push path), and returns the turn result to the workflow.
+
+The ``_spawn_claude`` async generator is an injectable seam: offline tests
+can provide a fake that yields pre-recorded stdout lines so no real CLI runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+from datetime import datetime
+
+from temporalio import activity
+
+from agentex.lib.adk import ClaudeCodeTurn
+from agentex.lib.core.harness import UnifiedEmitter
+from agentex.lib.utils.logging import make_logger
+from agentex.lib.utils.model_utils import BaseModel
+
+logger = make_logger(__name__)
+
+RUN_CLAUDE_CODE_TURN_ACTIVITY = "run_claude_code_turn"
+
+
+class RunClaudeCodeTurnParams(BaseModel):
+    """Arguments for one Claude Code turn run inside an activity."""
+
+    task_id: str
+    prompt: str
+    trace_id: str | None = None
+    parent_span_id: str | None = None
+    session_id: str | None = None
+    created_at: datetime | None = None
+
+
+class RunClaudeCodeTurnResult(BaseModel):
+    """Result returned from the activity to the workflow."""
+
+    final_text: str
+    session_id: str | None = None
+
+
+async def _spawn_claude(prompt: str, session_id: str | None = None) -> AsyncIterator[str]:
+    """Spawn ``claude -p --output-format stream-json`` locally and yield stdout lines.
+
+    Pass ``session_id`` to resume a previous Claude Code session (multi-turn
+    memory via ``-r <session_id>``).
+
+    Injectable seam: tests can monkeypatch this with a fake async iterator so no
+    real CLI invocation is needed offline.
+    """
+    cmd = [
+        "claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+    ]
+    if session_id:
+        cmd.extend(["-r", session_id])
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    assert proc.stdin is not None
+
+    proc.stdin.write(prompt.encode())
+    proc.stdin.close()
+
+    # Drain stderr concurrently. With --verbose, Claude Code can write enough to
+    # stderr to fill the OS pipe buffer; if we only read stdout, the CLI blocks
+    # on its stderr write while we block reading stdout — a deadlock. A
+    # background task keeps stderr flowing so stdout never stalls.
+    async def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        async for _ in proc.stderr:
+            pass
+
+    stderr_task = asyncio.create_task(_drain_stderr())
+
+    try:
+        buffer = ""
+        async for chunk in proc.stdout:
+            buffer += chunk.decode("utf-8", errors="replace")
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.strip()
+                if line:
+                    yield line
+
+        if buffer.strip():
+            yield buffer.strip()
+
+        await proc.wait()
+    finally:
+        # Release the subprocess and stderr drain task even if the consumer
+        # abandons the generator early (task cancellation / client disconnect):
+        # cancel the drain task and terminate+reap the process if it is still
+        # running, so neither is leaked.
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            pass
+        if proc.returncode is None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+
+
+@activity.defn(name=RUN_CLAUDE_CODE_TURN_ACTIVITY)
+async def run_claude_code_turn(params: RunClaudeCodeTurnParams) -> dict[str, Any]:
+    """Run one Claude Code turn end-to-end and stream events to the task.
+
+    Runs in an activity (real asyncio loop) so subprocess I/O is permitted.
+    """
+    emitter = UnifiedEmitter(
+        task_id=params.task_id,
+        trace_id=params.trace_id,
+        parent_span_id=params.parent_span_id,
+    )
+    turn = ClaudeCodeTurn(_spawn_claude(params.prompt, session_id=params.session_id))
+    result = await emitter.auto_send_turn(turn, created_at=params.created_at)
+
+    return RunClaudeCodeTurnResult(final_text=result.final_text, session_id=turn.session_id).model_dump()

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/run_worker.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/run_worker.py.j2
@@ -1,0 +1,41 @@
+"""Temporal worker for {{ agent_name }} — Claude Code harness.
+
+Run as a separate long-lived process alongside the ACP HTTP server. The
+worker polls Temporal for workflow + activity tasks and executes them.
+
+The Claude Code CLI subprocess runs in the ``run_claude_code_turn`` activity
+(registered below alongside the built-in Agentex activities), because
+subprocess I/O is not permitted on the Temporal workflow event loop.
+"""
+
+import asyncio
+
+from project.workflow import {{ workflow_class }}
+from project.activities import run_claude_code_turn
+from agentex.lib.utils.debug import setup_debug_if_enabled
+from agentex.lib.utils.logging import make_logger
+from agentex.lib.environment_variables import EnvironmentVariables
+from agentex.lib.core.temporal.activities import get_all_activities
+from agentex.lib.core.temporal.workers.worker import AgentexWorker
+
+environment_variables = EnvironmentVariables.refresh()
+logger = make_logger(__name__)
+
+
+async def main():
+    setup_debug_if_enabled()
+
+    task_queue_name = environment_variables.WORKFLOW_TASK_QUEUE
+    if task_queue_name is None:
+        raise ValueError("WORKFLOW_TASK_QUEUE is not set")
+
+    worker = AgentexWorker(task_queue=task_queue_name)
+
+    await worker.run(
+        activities=[run_claude_code_turn, *get_all_activities()],
+        workflow={{ workflow_class }},
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/workflow.py.j2
@@ -1,0 +1,135 @@
+"""Temporal workflow for {{ agent_name }} — Claude Code harness.
+
+Holds conversation state (session_id for multi-turn resume) durably across
+crashes. Each user message triggers ``on_task_event_send``, which delegates the
+turn to the ``run_claude_code_turn`` activity. The activity spawns the Claude
+Code CLI, wraps its stdout in ``ClaudeCodeTurn``, and delivers the turn via
+``UnifiedEmitter.auto_send_turn`` (the async Redis push path).
+
+Note on subprocess inside Temporal
+------------------------------------
+Subprocess (and all other) I/O must run in a Temporal *activity*, never in
+workflow code. Temporal runs workflow + signal-handler bodies on a
+deterministic sandbox event loop that does not implement ``subprocess_exec``
+(spawning the CLI there raises ``NotImplementedError``). The activity also gets
+Temporal's retry + timeout guarantees.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+from datetime import timedelta
+
+from temporalio import workflow
+
+from agentex.lib import adk
+from agentex.lib.types.acp import SendEventParams, CreateTaskParams
+from agentex.lib.types.tracing import SGPTracingProcessorConfig
+from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
+from agentex.lib.environment_variables import EnvironmentVariables
+from agentex.lib.core.temporal.types.workflow import SignalName
+from agentex.lib.core.temporal.workflows.workflow import BaseWorkflow
+from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
+
+with workflow.unsafe.imports_passed_through():
+    from project.activities import RunClaudeCodeTurnParams, run_claude_code_turn
+
+add_tracing_processor_config(
+    SGPTracingProcessorConfig(
+        sgp_api_key=os.environ.get("SGP_API_KEY", ""),
+        sgp_account_id=os.environ.get("SGP_ACCOUNT_ID", ""),
+        sgp_base_url=os.environ.get("SGP_CLIENT_BASE_URL", ""),
+    )
+)
+
+environment_variables = EnvironmentVariables.refresh()
+
+if environment_variables.WORKFLOW_NAME is None:
+    raise ValueError("Environment variable WORKFLOW_NAME is not set")
+if environment_variables.AGENT_NAME is None:
+    raise ValueError("Environment variable AGENT_NAME is not set")
+
+logger = make_logger(__name__)
+
+
+@workflow.defn(name=environment_variables.WORKFLOW_NAME)
+class {{ workflow_class }}(BaseWorkflow):
+    """Temporal workflow that runs Claude Code locally for each user message.
+
+    Persists the Claude Code session_id across turns so the CLI can resume
+    the conversation (``-r <session_id>``). Temporal's durable state ensures
+    the session_id survives worker crashes.
+    """
+
+    def __init__(self):
+        super().__init__(display_name=environment_variables.AGENT_NAME)
+        self._complete_task = False
+        self._turn_number = 0
+        # Claude Code session_id for multi-turn resume.
+        self._session_id: str | None = None
+
+    @workflow.signal(name=SignalName.RECEIVE_EVENT)
+    async def on_task_event_send(self, params: SendEventParams) -> None:
+        """Handle a user message: spawn Claude Code and push events to the task stream."""
+        self._turn_number += 1
+        task_id = params.task.id
+        prompt = params.event.content.content
+        logger.info("Turn %d for task %s", self._turn_number, task_id)
+
+        await adk.messages.create(task_id=task_id, content=params.event.content)
+
+        async with adk.tracing.span(
+            trace_id=task_id,
+            task_id=task_id,
+            name=f"Turn {self._turn_number}",
+            input={"message": prompt},
+        ) as span:
+            # Delegate the subprocess turn to an activity: subprocess I/O is not
+            # permitted on the Temporal workflow event loop. The activity streams
+            # events to the task and returns the final text + session_id.
+            # workflow.now() gives a deterministic timestamp under replay.
+            result = await workflow.execute_activity(
+                run_claude_code_turn,
+                RunClaudeCodeTurnParams(
+                    task_id=task_id,
+                    prompt=prompt,
+                    trace_id=task_id,
+                    parent_span_id=span.id if span else None,
+                    session_id=self._session_id,
+                    created_at=workflow.now(),
+                ),
+                start_to_close_timeout=timedelta(minutes=5),
+            )
+
+            # Capture session_id to enable Claude Code resume on the next turn.
+            sid = result.get("session_id")
+            if sid:
+                self._session_id = sid
+
+            if span:
+                span.output = {"final_text": result.get("final_text")}
+
+    @workflow.run
+    async def on_task_create(self, params: CreateTaskParams) -> str:
+        logger.info("Task created: %s", params.task.id)
+
+        await adk.messages.create(
+            task_id=params.task.id,
+            content=TextContent(
+                author="agent",
+                content=(
+                    f"Task initialized with params:\n{json.dumps(params.params, indent=2)}\n"
+                    "Send me a message and I'll run it through Claude Code locally."
+                ),
+            ),
+        )
+
+        await workflow.wait_condition(lambda: self._complete_task, timeout=None)
+        return "Task completed"
+
+    @workflow.signal
+    async def complete_task_signal(self) -> None:
+        logger.info("Received complete_task signal")
+        self._complete_task = True

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/workflow.py.j2
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import json
+import asyncio
 from datetime import timedelta
 
 from temporalio import workflow
@@ -69,47 +70,55 @@ class {{ workflow_class }}(BaseWorkflow):
         self._turn_number = 0
         # Claude Code session_id for multi-turn resume.
         self._session_id: str | None = None
+        # Serialize turns: signal handlers can interleave at await points, so two
+        # quick messages could both read the same stale _session_id and run
+        # independent Claude Code sessions. The lock keeps turns sequential and
+        # preserves conversation continuity.
+        self._turn_lock = asyncio.Lock()
 
     @workflow.signal(name=SignalName.RECEIVE_EVENT)
     async def on_task_event_send(self, params: SendEventParams) -> None:
         """Handle a user message: spawn Claude Code and push events to the task stream."""
-        self._turn_number += 1
-        task_id = params.task.id
-        prompt = params.event.content.content
-        logger.info("Turn %d for task %s", self._turn_number, task_id)
+        async with self._turn_lock:
+            self._turn_number += 1
+            task_id = params.task.id
+            prompt = params.event.content.content
+            logger.info("Turn %d for task %s", self._turn_number, task_id)
 
-        await adk.messages.create(task_id=task_id, content=params.event.content)
+            await adk.messages.create(task_id=task_id, content=params.event.content)
 
-        async with adk.tracing.span(
-            trace_id=task_id,
-            task_id=task_id,
-            name=f"Turn {self._turn_number}",
-            input={"message": prompt},
-        ) as span:
-            # Delegate the subprocess turn to an activity: subprocess I/O is not
-            # permitted on the Temporal workflow event loop. The activity streams
-            # events to the task and returns the final text + session_id.
-            # workflow.now() gives a deterministic timestamp under replay.
-            result = await workflow.execute_activity(
-                run_claude_code_turn,
-                RunClaudeCodeTurnParams(
-                    task_id=task_id,
-                    prompt=prompt,
-                    trace_id=task_id,
-                    parent_span_id=span.id if span else None,
-                    session_id=self._session_id,
-                    created_at=workflow.now(),
-                ),
-                start_to_close_timeout=timedelta(minutes=5),
-            )
+            async with adk.tracing.span(
+                trace_id=task_id,
+                task_id=task_id,
+                name=f"Turn {self._turn_number}",
+                input={"message": prompt},
+            ) as span:
+                # Delegate the subprocess turn to an activity: subprocess I/O is not
+                # permitted on the Temporal workflow event loop. The activity streams
+                # events to the task and returns the final text + session_id.
+                # workflow.now() gives a deterministic timestamp under replay.
+                result = await workflow.execute_activity(
+                    run_claude_code_turn,
+                    RunClaudeCodeTurnParams(
+                        task_id=task_id,
+                        prompt=prompt,
+                        trace_id=task_id,
+                        parent_span_id=span.id if span else None,
+                        session_id=self._session_id,
+                        created_at=workflow.now(),
+                    ),
+                    # Agentic Claude Code runs (multiple tool calls, large codegen)
+                    # can take a while; tune this to your workload.
+                    start_to_close_timeout=timedelta(minutes=30),
+                )
 
-            # Capture session_id to enable Claude Code resume on the next turn.
-            sid = result.get("session_id")
-            if sid:
-                self._session_id = sid
+                # Capture session_id to enable Claude Code resume on the next turn.
+                sid = result.get("session_id")
+                if sid:
+                    self._session_id = sid
 
-            if span:
-                span.output = {"final_text": result.get("final_text")}
+                if span:
+                    span.output = {"final_text": result.get("final_text")}
 
     @workflow.run
     async def on_task_create(self, params: CreateTaskParams) -> str:

--- a/src/agentex/lib/cli/templates/temporal-claude-code/pyproject.toml.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/pyproject.toml.j2
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ project_name }}"
+version = "0.1.0"
+description = "{{ description }}"
+requires-python = ">=3.12"
+dependencies = [
+    "agentex-sdk",
+    "scale-gp",
+    "temporalio>=1.18.2",
+    "python-dotenv>=1.0,<2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "httpx",
+    "black",
+    "isort",
+    "flake8",
+    "debugpy>=1.8.15",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["project"]
+
+[tool.black]
+line-length = 88
+target-version = ['py312']
+
+[tool.isort]
+profile = "black"
+line_length = 88

--- a/src/agentex/lib/cli/templates/temporal-claude-code/requirements.txt.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/requirements.txt.j2
@@ -1,0 +1,11 @@
+# Agentex SDK
+agentex-sdk
+
+# Scale GenAI Platform Python SDK
+scale-gp
+
+# Temporal workflow engine
+temporalio>=1.18.2
+
+# Loads .env files for local development
+python-dotenv>=1.0,<2


### PR DESCRIPTION
## Summary

Ninth slice of #425. Adds the claude-code `agentex init` templates across all three tiers.

- New `default-claude-code`, `sync-claude-code`, `temporal-claude-code` template dirs.
- Wires `DEFAULT_CLAUDE_CODE`, `SYNC_CLAUDE_CODE`, `TEMPORAL_CLAUDE_CODE` into `init.py` (enum, project-files map, prompts).
- Scaffolded code imports `ClaudeCodeTurn` from the `agentex.lib.adk` facade.

## Test plan
- [x] `pytest tests/lib/cli/ -k "init or template"` — 23 passed (all render to valid Python)

## Notes
Stacked on #434. Retarget to `next` after the chain merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds Claude Code `agentex init` templates for default, sync, and Temporal project tiers.
- Wires the new Claude Code template choices into CLI init prompts and project-file generation.
- Expands ADK/harness unification and test coverage across OpenAI, Claude Code, Codex, LangGraph, and Pydantic AI integrations.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Merge should wait for fixes to the OpenAI sync stream event lifecycle and the generated Claude Code Dockerfile.

The changed areas are covered by focused checks, and the remaining concerns are localized to stream event ordering and template rendering.

src/agentex/lib/adk/_modules/_openai_sync.py and src/agentex/lib/cli/templates/default-claude-code/Dockerfile.j2
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused pytest harness against the real sync OpenAI converter with mocked OpenAI SDK events for a reasoning delta followed by an output item done, and observed that the reasoning start event at index 1 did not have a corresponding done event.
- Ran a focused pytest harness against the real \_openai\_sync.py converter with a mocked OpenAI stream containing a reasoning delta followed by a normal answer text delta, and confirmed that the reasoning and text start indices reused index 1.
- Rendered the default-claude-code Dockerfile.j2 template into a temporary project and validated that the next Dockerfile command would fail parsing due to a broken line continuation in the template.
- Checked the Claude Code scaffold process and confirmed that after scaffolding, template directories and Jinja files exist, init wiring passes, and create\_project\_structure runs for all three tiers with the generated Claude Code sources importing the facade.

<a href="https://app.greptile.com/trex/runs/12096626/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Claude Code scaffolds omit expected root files**

   - **Bug**
     - The new Claude Code templates are selectable and create projects, but the generated structures do not match the requested contract. default-claude-code and sync-claude-code generate project/acp.py plus root files such as manifest.yaml, README.md, pyproject.toml, Dockerfile, etc., but no agentex.json. temporal-claude-code generates project/acp.py, project/activities.py, project/workflow.py, and project/run_worker.py, but the expected contract requires run_worker.py at the project root and also expects agentex.json.
   - **Cause**
     - create_project_structure writes every file listed in project_files into code_dir (`project/`), so temporal run_worker.py is placed under project/run_worker.py. The root template map also renders manifest.yaml but does not render an agentex.json root file for these templates.
   - **Fix**
     - Update the Claude Code scaffold mapping/rendering so temporal-claude-code emits run_worker.py at the scaffold root when that is the intended contract, and add or map the expected agentex.json root template for the new Claude Code templates. If manifest.yaml is the intended replacement for agentex.json, update the contract/tests accordingly.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. `src/agentex/lib/adk/_modules/_openai_sync.py`, line 178-184 ([link](https://github.com/scaleapi/scale-agentex-python/blob/4f2002cb625fe695841fccb186ba7285b060a443/src/agentex/lib/adk/_modules/_openai_sync.py#L178-L184)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Reasoning never closes**

   Reasoning items are opened with `StreamTaskMessageStart`, but this completion branch skips the matching `StreamTaskMessageDone`. A reasoning stream that emits deltas and then completes leaves sync ACP clients with an unterminated reasoning message, and tracing has to mark the reasoning span incomplete during final cleanup instead of closing it normally.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused pytest harness for mocked sync OpenAI reasoning stream](https://app.greptile.com/trex/artifacts/72970ac8-e897-4801-b1c4-47c9fbe1017e)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: verbose pytest output showing missing reasoning done event](https://app.greptile.com/trex/artifacts/514cf122-5bf8-49d5-a318-144f8541148c)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12096626/artifacts?artifact=72970ac8-e897-4801-b1c4-47c9fbe1017e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/adk/_modules/_openai_sync.py
   Line: 178-184

   Comment:
   **Reasoning never closes**

   Reasoning items are opened with `StreamTaskMessageStart`, but this completion branch skips the matching `StreamTaskMessageDone`. A reasoning stream that emits deltas and then completes leaves sync ACP clients with an unterminated reasoning message, and tracing has to mark the reasoning span incomplete during final cleanup instead of closing it normally.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fadk%2F_modules%2F_openai_sync.py%0ALine%3A%20178-184%0A%0AComment%3A%0A**Reasoning%20never%20closes**%0A%0AReasoning%20items%20are%20opened%20with%20%60StreamTaskMessageStart%60%2C%20but%20this%20completion%20branch%20skips%20the%20matching%20%60StreamTaskMessageDone%60.%20A%20reasoning%20stream%20that%20emits%20deltas%20and%20then%20completes%20leaves%20sync%20ACP%20clients%20with%20an%20unterminated%20reasoning%20message%2C%20and%20tracing%20has%20to%20mark%20the%20reasoning%20span%20incomplete%20during%20final%20cleanup%20instead%20of%20closing%20it%20normally.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=435&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


3. `src/agentex/lib/adk/_modules/_openai_sync.py`, line 295-306 ([link](https://github.com/scaleapi/scale-agentex-python/blob/4f2002cb625fe695841fccb186ba7285b060a443/src/agentex/lib/adk/_modules/_openai_sync.py#L295-L306)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Text reuses reasoning index**

   After a reasoning item, the next text item can reuse the reasoning message index. The reasoning handlers increment `message_index`, but this branch only increments text indices after tool output, so a normal reasoning-then-answer stream can emit the final text `Start` with the same index as the reasoning message. Downstream consumers key open contexts by `index`, so the answer can overwrite or alias the reasoning context and mix text output into the reasoning message.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused pytest harness for reasoning then text index reuse](https://app.greptile.com/trex/artifacts/337bb49c-8b76-4249-8f72-185731757e72)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: verbose pytest output showing duplicate reasoning and text start indices](https://app.greptile.com/trex/artifacts/41dd8686-b559-4aa3-9f6b-5e7f5b0205e8)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12096626/artifacts?artifact=337bb49c-8b76-4249-8f72-185731757e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/adk/_modules/_openai_sync.py
   Line: 295-306

   Comment:
   **Text reuses reasoning index**

   After a reasoning item, the next text item can reuse the reasoning message index. The reasoning handlers increment `message_index`, but this branch only increments text indices after tool output, so a normal reasoning-then-answer stream can emit the final text `Start` with the same index as the reasoning message. Downstream consumers key open contexts by `index`, so the answer can overwrite or alias the reasoning context and mix text output into the reasoning message.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fadk%2F_modules%2F_openai_sync.py%0ALine%3A%20295-306%0A%0AComment%3A%0A**Text%20reuses%20reasoning%20index**%0A%0AAfter%20a%20reasoning%20item%2C%20the%20next%20text%20item%20can%20reuse%20the%20reasoning%20message%20index.%20The%20reasoning%20handlers%20increment%20%60message_index%60%2C%20but%20this%20branch%20only%20increments%20text%20indices%20after%20tool%20output%2C%20so%20a%20normal%20reasoning-then-answer%20stream%20can%20emit%20the%20final%20text%20%60Start%60%20with%20the%20same%20index%20as%20the%20reasoning%20message.%20Downstream%20consumers%20key%20open%20contexts%20by%20%60index%60%2C%20so%20the%20answer%20can%20overwrite%20or%20alias%20the%20reasoning%20context%20and%20mix%20text%20output%20into%20the%20reasoning%20message.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=435&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fadk%2F_modules%2F_openai_sync.py%3A178-184%0A**Reasoning%20never%20closes**%0A%0AReasoning%20items%20are%20opened%20with%20%60StreamTaskMessageStart%60%2C%20but%20this%20completion%20branch%20skips%20the%20matching%20%60StreamTaskMessageDone%60.%20A%20reasoning%20stream%20that%20emits%20deltas%20and%20then%20completes%20leaves%20sync%20ACP%20clients%20with%20an%20unterminated%20reasoning%20message%2C%20and%20tracing%20has%20to%20mark%20the%20reasoning%20span%20incomplete%20during%20final%20cleanup%20instead%20of%20closing%20it%20normally.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fadk%2F_modules%2F_openai_sync.py%3A295-306%0A**Text%20reuses%20reasoning%20index**%0A%0AAfter%20a%20reasoning%20item%2C%20the%20next%20text%20item%20can%20reuse%20the%20reasoning%20message%20index.%20The%20reasoning%20handlers%20increment%20%60message_index%60%2C%20but%20this%20branch%20only%20increments%20text%20indices%20after%20tool%20output%2C%20so%20a%20normal%20reasoning-then-answer%20stream%20can%20emit%20the%20final%20text%20%60Start%60%20with%20the%20same%20index%20as%20the%20reasoning%20message.%20Downstream%20consumers%20key%20open%20contexts%20by%20%60index%60%2C%20so%20the%20answer%20can%20overwrite%20or%20alias%20the%20reasoning%20context%20and%20mix%20text%20output%20into%20the%20reasoning%20message.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=435&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/agentex/lib/adk/_modules/_openai_sync.py:178-184
**Reasoning never closes**

Reasoning items are opened with `StreamTaskMessageStart`, but this completion branch skips the matching `StreamTaskMessageDone`. A reasoning stream that emits deltas and then completes leaves sync ACP clients with an unterminated reasoning message, and tracing has to mark the reasoning span incomplete during final cleanup instead of closing it normally.

### Issue 2 of 2
src/agentex/lib/adk/_modules/_openai_sync.py:295-306
**Text reuses reasoning index**

After a reasoning item, the next text item can reuse the reasoning message index. The reasoning handlers increment `message_index`, but this branch only increments text indices after tool output, so a normal reasoning-then-answer stream can emit the final text `Start` with the same index as the reasoning message. Downstream consumers key open contexts by `index`, so the answer can overwrite or alias the reasoning context and mix text output into the reasoning message.


`````

</details>

<sub>Reviews (16): Last reviewed commit: ["fix(cli): drain claude stdin and stop en..."](https://github.com/scaleapi/scale-agentex-python/commit/4f2002cb625fe695841fccb186ba7285b060a443) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39298978)</sub>

<!-- /greptile_comment -->