### PR TITLE
feat(tracing): skip Agentex span-start write by default (end-only ingest)

### DIFF
--- a/src/agentex/lib/core/tracing/processors/agentex_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/agentex_tracing_processor.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import weakref
 from typing import TYPE_CHECKING, Any, Dict, override
@@ -5,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, override
 from agentex import Agentex
 from agentex.types.span import Span
 from agentex.lib.types.tracing import AgentexTracingProcessorConfig
+from agentex.lib.utils.logging import make_logger
 from agentex.lib.adk.utils._modules.client import create_async_agentex_client
 from agentex.lib.core.tracing.processors.tracing_processor_interface import (
     SyncTracingProcessor,
@@ -14,28 +16,82 @@ from agentex.lib.core.tracing.processors.tracing_processor_interface import (
 if TYPE_CHECKING:
     from agentex import AsyncAgentex
 
+logger = make_logger(__name__)
+
+
+# NOTE: This is the Agentex-backend toggle (writes to the agentex `spans`
+# table via the Agentex API). It is intentionally SEPARATE from the SGP/EGP
+# processor's ``AGENTEX_TRACING_SKIP_SPAN_START`` so the two backends can be
+# controlled independently.
+_SKIP_SPAN_START_ENV = "AGENTEX_TRACING_SKIP_AGENTEX_SPAN_START"
+
+
+def _skip_span_start_enabled() -> bool:
+    """Whether to skip the Agentex span-start write and persist each span only on end.
+
+    The Agentex processor otherwise writes every span twice: a ``spans.create``
+    on start (no ``end_time``/``output`` yet) and a ``spans.update`` on end.
+    The start row is overwritten by the end write moments later, so persisting
+    it doubles the per-span HTTP/DB write volume against the Agentex control
+    plane — the load that timed out span-start activities and pressured the
+    Agentex Postgres connection pool under load.
+
+    When enabled (the default), the start write is skipped and the END write
+    becomes a single ``spans.create`` carrying the complete span — one INSERT
+    per span instead of an INSERT + UPDATE. (A plain ``spans.update`` on end
+    would 404 because the row was never created.)
+
+    Default ON. Set ``AGENTEX_TRACING_SKIP_AGENTEX_SPAN_START`` to
+    ``0``/``false``/``no``/``off`` to restore the start write — e.g. if you
+    need in-flight spans visible before they complete, or spans that never end
+    (process crash) to still be persisted.
+    """
+    raw = os.environ.get(_SKIP_SPAN_START_ENV, "1").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def _create_kwargs(span: Span) -> Dict[str, Any]:
+    """Full-span kwargs for ``spans.create`` — used on start (skip disabled) and
+    on end (skip enabled, single-INSERT path)."""
+    return {
+        "name": span.name,
+        "start_time": span.start_time,
+        "end_time": span.end_time,
+        "id": span.id,
+        "trace_id": span.trace_id,
+        "parent_id": span.parent_id,
+        "input": span.input,
+        "output": span.output,
+        "data": span.data,
+        "task_id": span.task_id,
+    }
+
 
 class AgentexSyncTracingProcessor(SyncTracingProcessor):
     def __init__(self, config: AgentexTracingProcessorConfig):  # noqa: ARG002
         self.client = Agentex()
-
-    @override
-    def on_span_start(self, span: Span) -> None:
-        self.client.spans.create(
-            name=span.name,
-            start_time=span.start_time,
-            end_time=span.end_time,
-            trace_id=span.trace_id,
-            id=span.id,
-            data=span.data,
-            input=span.input,
-            output=span.output,
-            parent_id=span.parent_id,
-            task_id=span.task_id,
+        logger.info(
+            "Agentex tracing span-start write %s (%s)",
+            "disabled — end-only ingest" if _skip_span_start_enabled() else "enabled",
+            _SKIP_SPAN_START_ENV,
         )
 
     @override
+    def on_span_start(self, span: Span) -> None:
+        # End-only ingest: by default the start write is skipped (see
+        # _skip_span_start_enabled) so each span is persisted once, on end.
+        if _skip_span_start_enabled():
+            return
+        self.client.spans.create(**_create_kwargs(span))
+
+    @override
     def on_span_end(self, span: Span) -> None:
+        # End-only ingest: the start create was skipped, so persist the complete
+        # span as a single INSERT here (a bare spans.update would 404 — no row).
+        if _skip_span_start_enabled():
+            self.client.spans.create(**_create_kwargs(span))
+            return
+
         update: Dict[str, Any] = {}
         if span.trace_id:
             update["trace_id"] = span.trace_id
@@ -82,6 +138,11 @@ class AgentexAsyncTracingProcessor(AsyncTracingProcessor):
         self._clients_by_loop: weakref.WeakKeyDictionary[
             asyncio.AbstractEventLoop, "AsyncAgentex"
         ] = weakref.WeakKeyDictionary()
+        logger.info(
+            "Agentex tracing span-start write %s (%s)",
+            "disabled — end-only ingest" if _skip_span_start_enabled() else "enabled",
+            _SKIP_SPAN_START_ENV,
+        )
 
     def _build_client(self) -> "AsyncAgentex":
         import httpx
@@ -111,21 +172,20 @@ class AgentexAsyncTracingProcessor(AsyncTracingProcessor):
     # https://linear.app/scale-epd/issue/AGX1-199/add-agentex-batch-endpoint-for-traces
     @override
     async def on_span_start(self, span: Span) -> None:
-        await self.client.spans.create(
-            name=span.name,
-            start_time=span.start_time,
-            end_time=span.end_time,
-            id=span.id,
-            trace_id=span.trace_id,
-            parent_id=span.parent_id,
-            input=span.input,
-            output=span.output,
-            data=span.data,
-            task_id=span.task_id,
-        )
+        # End-only ingest: by default the start write is skipped (see
+        # _skip_span_start_enabled) so each span is persisted once, on end.
+        if _skip_span_start_enabled():
+            return
+        await self.client.spans.create(**_create_kwargs(span))
 
     @override
     async def on_span_end(self, span: Span) -> None:
+        # End-only ingest: the start create was skipped, so persist the complete
+        # span as a single INSERT here (a bare spans.update would 404 — no row).
+        if _skip_span_start_enabled():
+            await self.client.spans.create(**_create_kwargs(span))
+            return
+
         update: Dict[str, Any] = {}
         if span.trace_id:
             update["trace_id"] = span.trace_id

--- a/src/agentex/lib/core/tracing/processors/agentex_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/agentex_tracing_processor.py
@@ -70,9 +70,15 @@ def _create_kwargs(span: Span) -> Dict[str, Any]:
 class AgentexSyncTracingProcessor(SyncTracingProcessor):
     def __init__(self, config: AgentexTracingProcessorConfig):  # noqa: ARG002
         self.client = Agentex()
+        # Capture the skip decision once at init: both halves of a span's
+        # lifecycle MUST agree, otherwise a start-skip + end-update lands on a
+        # non-existent row (404) — or the reverse double-creates. Re-reading the
+        # env per event would let a mid-span toggle (tests, config reload) split
+        # the decision. Deploy-time flag, so a single read is correct.
+        self._skip_span_start = _skip_span_start_enabled()
         logger.info(
             "Agentex tracing span-start write %s (%s)",
-            "disabled — end-only ingest" if _skip_span_start_enabled() else "enabled",
+            "disabled — end-only ingest" if self._skip_span_start else "enabled",
             _SKIP_SPAN_START_ENV,
         )
 
@@ -80,7 +86,7 @@ class AgentexSyncTracingProcessor(SyncTracingProcessor):
     def on_span_start(self, span: Span) -> None:
         # End-only ingest: by default the start write is skipped (see
         # _skip_span_start_enabled) so each span is persisted once, on end.
-        if _skip_span_start_enabled():
+        if self._skip_span_start:
             return
         self.client.spans.create(**_create_kwargs(span))
 
@@ -88,7 +94,7 @@ class AgentexSyncTracingProcessor(SyncTracingProcessor):
     def on_span_end(self, span: Span) -> None:
         # End-only ingest: the start create was skipped, so persist the complete
         # span as a single INSERT here (a bare spans.update would 404 — no row).
-        if _skip_span_start_enabled():
+        if self._skip_span_start:
             self.client.spans.create(**_create_kwargs(span))
             return
 
@@ -138,9 +144,15 @@ class AgentexAsyncTracingProcessor(AsyncTracingProcessor):
         self._clients_by_loop: weakref.WeakKeyDictionary[
             asyncio.AbstractEventLoop, "AsyncAgentex"
         ] = weakref.WeakKeyDictionary()
+        # Capture the skip decision once at init: both halves of a span's
+        # lifecycle MUST agree, otherwise a start-skip + end-update lands on a
+        # non-existent row (404) — or the reverse double-creates. Re-reading the
+        # env per event would let a mid-span toggle (tests, config reload) split
+        # the decision. Deploy-time flag, so a single read is correct.
+        self._skip_span_start = _skip_span_start_enabled()
         logger.info(
             "Agentex tracing span-start write %s (%s)",
-            "disabled — end-only ingest" if _skip_span_start_enabled() else "enabled",
+            "disabled — end-only ingest" if self._skip_span_start else "enabled",
             _SKIP_SPAN_START_ENV,
         )
 
@@ -174,7 +186,7 @@ class AgentexAsyncTracingProcessor(AsyncTracingProcessor):
     async def on_span_start(self, span: Span) -> None:
         # End-only ingest: by default the start write is skipped (see
         # _skip_span_start_enabled) so each span is persisted once, on end.
-        if _skip_span_start_enabled():
+        if self._skip_span_start:
             return
         await self.client.spans.create(**_create_kwargs(span))
 
@@ -182,7 +194,7 @@ class AgentexAsyncTracingProcessor(AsyncTracingProcessor):
     async def on_span_end(self, span: Span) -> None:
         # End-only ingest: the start create was skipped, so persist the complete
         # span as a single INSERT here (a bare spans.update would 404 — no row).
-        if _skip_span_start_enabled():
+        if self._skip_span_start:
             await self.client.spans.create(**_create_kwargs(span))
             return
 

--- a/tests/lib/core/tracing/processors/test_agentex_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_agentex_tracing_processor.py
@@ -90,6 +90,28 @@ class TestAgentexSyncSkipSpanStart:
             processor.on_span_end(span)
             client.spans.update.assert_called_once()  # end is the UPDATE
 
+    def test_skip_decision_captured_at_init_not_per_call(self, monkeypatch):
+        """The two halves of a span MUST use the same skip decision. A flag
+        toggled after construction must not split it (start-skip + end-update
+        would 404). The decision is captured once at init.
+        """
+        monkeypatch.delenv(SKIP_ENV, raising=False)  # construct with skip ON
+        with patch(f"{MODULE}.Agentex") as MockAgentex:
+            from agentex.lib.core.tracing.processors.agentex_tracing_processor import (
+                AgentexSyncTracingProcessor,
+            )
+
+            processor = AgentexSyncTracingProcessor(_make_config())
+            client = MockAgentex.return_value
+            span = _make_span()
+
+            processor.on_span_start(span)  # skipped (cached ON)
+            monkeypatch.setenv(SKIP_ENV, "0")  # toggle mid-span — must be ignored
+            processor.on_span_end(span)
+
+            client.spans.create.assert_called_once()  # still end-only INSERT
+            client.spans.update.assert_not_called()  # NOT a 404-prone UPDATE
+
 
 class TestAgentexAsyncSkipSpanStart:
     async def test_start_skipped_and_end_creates_by_default(self, monkeypatch):
@@ -135,6 +157,29 @@ class TestAgentexAsyncSkipSpanStart:
 
             await processor.on_span_end(span)
             client.spans.update.assert_awaited_once()  # end is the UPDATE
+
+    async def test_skip_decision_captured_at_init_not_per_call(self, monkeypatch):
+        """A flag toggled after construction must not split a span's lifecycle."""
+        monkeypatch.delenv(SKIP_ENV, raising=False)  # construct with skip ON
+        with patch(f"{MODULE}.create_async_agentex_client") as mock_factory:
+            client = MagicMock()
+            client.spans.create = AsyncMock()
+            client.spans.update = AsyncMock()
+            mock_factory.return_value = client
+
+            from agentex.lib.core.tracing.processors.agentex_tracing_processor import (
+                AgentexAsyncTracingProcessor,
+            )
+
+            processor = AgentexAsyncTracingProcessor(_make_config())
+            span = _make_span()
+
+            await processor.on_span_start(span)  # skipped (cached ON)
+            monkeypatch.setenv(SKIP_ENV, "0")  # toggle mid-span — must be ignored
+            await processor.on_span_end(span)
+
+            client.spans.create.assert_awaited_once()  # still end-only INSERT
+            client.spans.update.assert_not_called()  # NOT a 404-prone UPDATE
 
 
 class TestAgentexAsyncTracingProcessor:

--- a/tests/lib/core/tracing/processors/test_agentex_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_agentex_tracing_processor.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import weakref
-from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -24,9 +25,116 @@ import agentex.lib.core.tracing.processors.agentex_tracing_processor  # noqa: E4
 MODULE = "agentex.lib.core.tracing.processors.agentex_tracing_processor"
 
 
+SKIP_ENV = "AGENTEX_TRACING_SKIP_AGENTEX_SPAN_START"
+
+
 def _make_config() -> MagicMock:
     """Empty config — AgentexTracingProcessorConfig is unused by __init__."""
     return MagicMock()
+
+
+def _make_span():
+    from agentex.types.span import Span
+
+    now = datetime.now(timezone.utc)
+    return Span(
+        id="span-1",
+        trace_id="trace-1",
+        name="test-span",
+        start_time=now,
+        end_time=now,
+        input={"in": 1},
+        output={"out": 2},
+    )
+
+
+class TestAgentexSyncSkipSpanStart:
+    """The Agentex backend writes create-on-start + update-on-end by default.
+    End-only ingest (default) skips the start write and makes the END a single
+    create — verify the start is a no-op and end does an INSERT, not an UPDATE.
+    """
+
+    def test_start_skipped_and_end_creates_by_default(self, monkeypatch):
+        monkeypatch.delenv(SKIP_ENV, raising=False)  # default ON
+        with patch(f"{MODULE}.Agentex") as MockAgentex:
+            from agentex.lib.core.tracing.processors.agentex_tracing_processor import (
+                AgentexSyncTracingProcessor,
+            )
+
+            processor = AgentexSyncTracingProcessor(_make_config())
+            client = MockAgentex.return_value
+            span = _make_span()
+
+            processor.on_span_start(span)
+            client.spans.create.assert_not_called()  # start skipped
+            client.spans.update.assert_not_called()
+
+            processor.on_span_end(span)
+            client.spans.create.assert_called_once()  # single INSERT on end
+            client.spans.update.assert_not_called()  # never a 404-prone UPDATE
+
+    def test_start_creates_and_end_updates_when_skip_disabled(self, monkeypatch):
+        monkeypatch.setenv(SKIP_ENV, "0")
+        with patch(f"{MODULE}.Agentex") as MockAgentex:
+            from agentex.lib.core.tracing.processors.agentex_tracing_processor import (
+                AgentexSyncTracingProcessor,
+            )
+
+            processor = AgentexSyncTracingProcessor(_make_config())
+            client = MockAgentex.return_value
+            span = _make_span()
+
+            processor.on_span_start(span)
+            client.spans.create.assert_called_once()  # start write restored
+
+            processor.on_span_end(span)
+            client.spans.update.assert_called_once()  # end is the UPDATE
+
+
+class TestAgentexAsyncSkipSpanStart:
+    async def test_start_skipped_and_end_creates_by_default(self, monkeypatch):
+        monkeypatch.delenv(SKIP_ENV, raising=False)  # default ON
+        with patch(f"{MODULE}.create_async_agentex_client") as mock_factory:
+            client = MagicMock()
+            client.spans.create = AsyncMock()
+            client.spans.update = AsyncMock()
+            mock_factory.return_value = client
+
+            from agentex.lib.core.tracing.processors.agentex_tracing_processor import (
+                AgentexAsyncTracingProcessor,
+            )
+
+            processor = AgentexAsyncTracingProcessor(_make_config())
+            span = _make_span()
+
+            await processor.on_span_start(span)
+            client.spans.create.assert_not_called()  # start skipped
+            client.spans.update.assert_not_called()
+
+            await processor.on_span_end(span)
+            client.spans.create.assert_awaited_once()  # single INSERT on end
+            client.spans.update.assert_not_called()
+
+    async def test_start_creates_and_end_updates_when_skip_disabled(self, monkeypatch):
+        monkeypatch.setenv(SKIP_ENV, "0")
+        with patch(f"{MODULE}.create_async_agentex_client") as mock_factory:
+            client = MagicMock()
+            client.spans.create = AsyncMock()
+            client.spans.update = AsyncMock()
+            mock_factory.return_value = client
+
+            from agentex.lib.core.tracing.processors.agentex_tracing_processor import (
+                AgentexAsyncTracingProcessor,
+            )
+
+            processor = AgentexAsyncTracingProcessor(_make_config())
+            span = _make_span()
+
+            await processor.on_span_start(span)
+            client.spans.create.assert_awaited_once()  # start write restored
+
+            await processor.on_span_end(span)
+            client.spans.update.assert_awaited_once()  # end is the UPDATE
 
 
 class TestAgentexAsyncTracingProcessor:


### PR DESCRIPTION
## Summary
The Agentex tracing processor writes every span **twice** — a `spans.create` on start and a `spans.update` on end. The start row is overwritten by the end write moments later, so persisting it doubles per-span HTTP/DB write volume against the Agentex control plane. Under load this pressures the Agentex Postgres load.

This defaults the Agentex backend to **end-only ingest**: skip the start write and persist each span once, as a single `spans.create` on end.

## Key correctness detail
Unlike the SGP processor (uniform `upsert_batch`), the Agentex processor does `create` on start + **`update`** on end. Naively skipping start would make the end `update` hit a non-existent row (**404**). So when the start is skipped, `on_span_end` now does a single `spans.create` carrying the complete span — **one INSERT per span** instead of INSERT + UPDATE. Applied to both the sync and async processors.

## Scope / flag
- Gated by a **dedicated, default-ON** env var **`AGENTEX_TRACING_SKIP_AGENTEX_SPAN_START`**.
- Set to `0`/`false`/`no`/`off` to restore the start write.

## Trade-off
Same as the SGP end-only path: in-flight spans aren't visible until they complete, and spans whose process crashes before `end` won't persist. Documented in the docstring.

## Tests
- `pytest tests/lib/core/tracing/processors/test_agentex_tracing_processor.py` — 7 passed (3 existing + 4 new: default-skip and skip-disabled, sync + async).
- `pytest tests/lib/core/tracing` — 85 passed, 2 skipped.
- `ruff check` clean.

## Related
- Complements #437 (fail-open Temporal span activities) and the agent-side EGP-only export flag — together they remove the per-span Agentex HTTP load that was failing workflows under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an "end-only ingest" mode for the Agentex tracing processor, skipping the per-span `spans.create` call on start and converting the end-of-span write from `spans.update` to a single `spans.create` carrying the complete span — halving the HTTP/DB write volume against the Agentex control plane.

- **Skip flag captured at init**: both sync and async processors store `self._skip_span_start` once in `__init__`, ensuring the two halves of each span's lifecycle always agree on the mode (avoids the previously flagged 404/double-create split).
- **`_create_kwargs` helper**: extracts the full-span keyword dict shared by the start write (skip=OFF) and the end-only insert (skip=ON), removing the field-list duplication between sync and async paths.
- **Test coverage**: 4 new test cases verify default-skip, skip-disabled, and the mid-span toggle regression for both sync and async processors.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a default-ON write-reduction flag with a clear opt-out, and both the split-decision hazard and the 404 risk are properly addressed.

The init-time flag capture ensures both halves of every span always agree on the mode, the end-only path correctly switches from spans.update to spans.create, and _create_kwargs passes the same fields as the original start-path code did. Tests cover all three behavioural cases for both processors. No correctness or safety issues found in the changed code.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/processors/agentex_tracing_processor.py | Adds _skip_span_start_enabled(), _create_kwargs(), and the init-time flag capture; both processors correctly branch on self._skip_span_start to skip start writes and substitute a single end-of-span INSERT. Logic is sound and consistent across sync/async. |
| tests/lib/core/tracing/processors/test_agentex_tracing_processor.py | Adds TestAgentexSyncSkipSpanStart and TestAgentexAsyncSkipSpanStart with 3 cases each (default, skip-disabled, mid-span toggle regression). New _make_span() helper builds a realistic Span fixture. Async tests rely on project-wide asyncio_mode=auto in keeping with existing test patterns. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    INIT["__init__(config)\nself._skip_span_start = _skip_span_start_enabled()"]

    INIT --> START["on_span_start(span)"]
    INIT --> END["on_span_end(span)"]

    START --> C1{self._skip_span_start?}
    C1 -- "True (default)" --> NOOP["return (no-op)"]
    C1 -- "False" --> CREATE_START["spans.create(**_create_kwargs(span))"]

    END --> C2{self._skip_span_start?}
    C2 -- "True (default)" --> CREATE_END["spans.create(**_create_kwargs(span))\n(single INSERT — complete span)"]
    C2 -- "False" --> UPDATE_END["spans.update(span.id, **span.model_dump(...))"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    INIT["__init__(config)\nself._skip_span_start = _skip_span_start_enabled()"]

    INIT --> START["on_span_start(span)"]
    INIT --> END["on_span_end(span)"]

    START --> C1{self._skip_span_start?}
    C1 -- "True (default)" --> NOOP["return (no-op)"]
    C1 -- "False" --> CREATE_START["spans.create(**_create_kwargs(span))"]

    END --> C2{self._skip_span_start?}
    C2 -- "True (default)" --> CREATE_END["spans.create(**_create_kwargs(span))\n(single INSERT — complete span)"]
    C2 -- "False" --> UPDATE_END["spans.update(span.id, **span.model_dump(...))"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(tracing): capture skip-span-start de..."](https://github.com/scaleapi/scale-agentex-python/commit/8474cc026dfb4c104913875d44c181f2ec7d4fff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39348220)</sub>

<!-- /greptile_comment -->