### PR TITLE
fix(tests): use relative import for assert_matches_type in webhooks test

### DIFF
--- a/tests/api_resources/test_webhooks.py
+++ b/tests/api_resources/test_webhooks.py
@@ -8,8 +8,9 @@ from typing import Any, cast
 import pytest
 
 from agentex import Agentex, AsyncAgentex
-from tests.utils import assert_matches_type
 from agentex.types import WebhookCreateWebhookTriggerResponse
+
+from ..utils import assert_matches_type
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 


### PR DESCRIPTION
## Summary

`./scripts/lint` (pyright) fails on `tests/api_resources/test_webhooks.py`:

```
tests/api_resources/test_webhooks.py:11:6 - error: Import "tests.utils" could not be resolved (reportMissingImports)
```

The Stainless-generated webhooks test (added in `feat(api): add webhook endpoint`) imported `assert_matches_type` via the **absolute** path `from tests.utils import ...`. This repo's pyright config has no repo-root `extraPaths`, so absolute `tests.*` imports don't resolve — only relative imports within the `tests` package do. It was the only file in `tests/api_resources/` using the absolute form; every sibling uses `from ..utils import assert_matches_type`.

## Fix

One-line change to match the sibling convention (relative `..utils` import as its own group).

## Verification

- `uv run pyright tests/api_resources/test_webhooks.py` → **0 errors**
- `ruff check` → passes

## Note

This is a Stainless-generated file, so the generator may re-emit the absolute import on the next sync. The durable fix belongs in the Stainless config (emit the relative import); this PR unblocks lint in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates `tests/api_resources/test_webhooks.py` to import `assert_matches_type` via the package-relative `..utils` path.
- Aligns the webhooks API resource test with sibling test files so pyright can resolve the test utility import.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; this is a focused test import fix with no runtime library behavior changes.

The change is limited to one test file and matches the existing import convention used by sibling tests.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Pyright check for the relative-import scenario and observed a missing import error for tests.utils, with exit code 1.
- Updated the code to fix the relative import and re-ran the Pyright check, which now reports 0 errors, 0 warnings, and 0 informations.
- Ran Ruff checks before and after the fix; both runs reported All checks passed.

<a href="https://app.greptile.com/trex/runs/12068371/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): use relative import for asse..."](https://github.com/scaleapi/scale-agentex-python/commit/09f0c0734429e75f95d30e76357fd4a8990b8cb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39403657)</sub>

<!-- /greptile_comment -->