### PR TITLE
fix(harness): correct codex & openai reasoning stream envelopes

### DIFF
--- a/src/agentex/lib/adk/_modules/_codex_sync.py
+++ b/src/agentex/lib/adk/_modules/_codex_sync.py
@@ -48,7 +48,9 @@ Item sub-types (item.started / item.updated / item.completed)
   reasoning               -> reasoning:
                                item.started                 -> StreamTaskMessageStart(ReasoningContent)
                                item.updated                 -> (no-op; final text arrives on completed)
-                               item.completed               -> StreamTaskMessageFull(ReasoningContent)
+                               item.completed               -> StreamTaskMessageDelta(ReasoningSummaryDelta)
+                                                              + StreamTaskMessageDelta(ReasoningContentDelta)
+                                                              + StreamTaskMessageDone
   command_execution       -> tool request + response:
                                item.started                 -> StreamTaskMessageStart(ToolRequestContent)
                                                               + StreamTaskMessageDone
@@ -96,6 +98,7 @@ from agentex.types.task_message_content import TextContent
 from agentex.types.tool_request_content import ToolRequestContent
 from agentex.types.tool_response_content import ToolResponseContent
 from agentex.types.reasoning_content_delta import ReasoningContentDelta
+from agentex.types.reasoning_summary_delta import ReasoningSummaryDelta
 
 logger = make_logger(__name__)
 
@@ -366,18 +369,6 @@ class _CodexStreamProcessor:
                         ),
                     )
                 )
-                if current:
-                    out.append(
-                        StreamTaskMessageDelta(
-                            type="delta",
-                            index=idx,
-                            delta=ReasoningContentDelta(
-                                type="reasoning_content",
-                                content_index=0,
-                                content_delta=current,
-                            ),
-                        )
-                    )
 
             elif evt_type == "item.updated":
                 # Accumulate silently; final text arrives on item.completed.
@@ -389,30 +380,53 @@ class _CodexStreamProcessor:
                 if text:
                     self.reasoning_count += 1
                     summary = text.strip().split("\n", 1)[0][:300]
-                    final_content = ReasoningContent(
-                        type="reasoning",
-                        author="agent",
-                        summary=[summary],
-                        content=[text],
-                        style="static",
-                    )
-                    if idx is not None:
+                    if idx is None:
+                        # No started event was seen; open the message now.
+                        idx = self._alloc()
                         out.append(
-                            StreamTaskMessageFull(
-                                type="full",
+                            StreamTaskMessageStart(
+                                type="start",
                                 index=idx,
-                                content=final_content,
+                                content=ReasoningContent(
+                                    type="reasoning",
+                                    author="agent",
+                                    summary=[],
+                                    content=[],
+                                    style="active",
+                                ),
                             )
                         )
-                    else:
-                        # No started event was seen; emit a standalone Full.
-                        out.append(
-                            StreamTaskMessageFull(
-                                type="full",
-                                index=self._alloc(),
-                                content=final_content,
-                            )
+                    # Deliver the reasoning as deltas, then close with a Done.
+                    # Emitting a Full here instead would leave the open Start
+                    # context dangling: auto_send routes Full into its own
+                    # throwaway streaming context (ignoring the index), so the
+                    # Start context survives until end-of-turn teardown and
+                    # persists a second, near-empty reasoning message. Streaming
+                    # the content as deltas lets the open context accumulate the
+                    # final ReasoningContent and close cleanly as one message.
+                    out.append(
+                        StreamTaskMessageDelta(
+                            type="delta",
+                            index=idx,
+                            delta=ReasoningSummaryDelta(
+                                type="reasoning_summary",
+                                summary_index=0,
+                                summary_delta=summary,
+                            ),
                         )
+                    )
+                    out.append(
+                        StreamTaskMessageDelta(
+                            type="delta",
+                            index=idx,
+                            delta=ReasoningContentDelta(
+                                type="reasoning_content",
+                                content_index=0,
+                                content_delta=text,
+                            ),
+                        )
+                    )
+                    out.append(StreamTaskMessageDone(type="done", index=idx))
                 elif idx is not None:
                     # Empty reasoning block — still need to close with a Done.
                     out.append(StreamTaskMessageDone(type="done", index=idx))

--- a/src/agentex/lib/adk/providers/_modules/sync_provider.py
+++ b/src/agentex/lib/adk/providers/_modules/sync_provider.py
@@ -32,6 +32,7 @@ from openai.types.responses.response_reasoning_summary_text_done_event import Re
 from agentex import AsyncAgentex
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.core.tracing.tracer import AsyncTracer
+from agentex.types.reasoning_content import ReasoningContent
 from agentex.types.task_message_delta import TextDelta
 from agentex.types.task_message_update import (
     StreamTaskMessageDone,
@@ -560,14 +561,20 @@ async def convert_openai_to_agentex_events(stream_response):
                         item_id_to_index[item_id] = message_index
                         item_id_to_type[item_id] = "reasoning_summary"
 
-                        # Send a start event for this new reasoning summary message
+                        # Send a start event for this new reasoning summary message.
+                        # The start content must be ReasoningContent (not TextContent)
+                        # so consumers that branch on the start event's content type
+                        # render a reasoning/thinking indicator; the final persisted
+                        # content is rebuilt from the reasoning deltas regardless.
                         yield StreamTaskMessageStart(
                             type="start",
                             index=item_id_to_index[item_id],
-                            content=TextContent(
-                                type="text",
+                            content=ReasoningContent(
+                                type="reasoning",
                                 author="agent",
-                                content="",  # Start with empty content
+                                summary=[],
+                                content=[],
+                                style="active",
                             ),
                         )
 
@@ -604,14 +611,20 @@ async def convert_openai_to_agentex_events(stream_response):
                         item_id_to_index[item_id] = message_index
                         item_id_to_type[item_id] = "reasoning_content"
 
-                        # Send a start event for this new reasoning content message
+                        # Send a start event for this new reasoning content message.
+                        # The start content must be ReasoningContent (not TextContent)
+                        # so consumers that branch on the start event's content type
+                        # render a reasoning/thinking indicator; the final persisted
+                        # content is rebuilt from the reasoning deltas regardless.
                         yield StreamTaskMessageStart(
                             type="start",
                             index=item_id_to_index[item_id],
-                            content=TextContent(
-                                type="text",
+                            content=ReasoningContent(
+                                type="reasoning",
                                 author="agent",
-                                content="",  # Start with empty content
+                                summary=[],
+                                content=[],
+                                style="active",
                             ),
                         )
 

--- a/tests/lib/adk/test_codex_sync.py
+++ b/tests/lib/adk/test_codex_sync.py
@@ -35,6 +35,7 @@ from agentex.lib.adk._modules._codex_sync import (
     convert_codex_to_agentex_events,
 )
 from agentex.types.reasoning_content_delta import ReasoningContentDelta
+from agentex.types.reasoning_summary_delta import ReasoningSummaryDelta
 
 
 async def _aiter(items: list[Any]) -> AsyncIterator[Any]:
@@ -365,7 +366,15 @@ class TestToolCallStreaming:
 
 
 class TestReasoningStreaming:
-    async def test_reasoning_start_full(self) -> None:
+    async def test_reasoning_start_deltas_done(self) -> None:
+        """A reasoning block opens with a Start, streams the final text as
+        summary + content deltas, and closes with a Done.
+
+        It must NOT emit a Full at the open Start's index: auto_send routes a
+        Full into a throwaway streaming context (ignoring the index), which
+        would leave the Start context dangling and persist a duplicate, empty
+        reasoning message (AGX1 codex reasoning duplicate bug).
+        """
         events = [
             {"type": "item.started", "item": {"id": "r1", "type": "reasoning", "text": ""}},
             {
@@ -380,31 +389,34 @@ class TestReasoningStreaming:
         out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
 
         starts = [e for e in out if isinstance(e, StreamTaskMessageStart)]
-        fulls = [e for e in out if isinstance(e, StreamTaskMessageFull) and isinstance(e.content, ReasoningContent)]
+        dones = [e for e in out if isinstance(e, StreamTaskMessageDone)]
+        reasoning_fulls = [
+            e for e in out if isinstance(e, StreamTaskMessageFull) and isinstance(e.content, ReasoningContent)
+        ]
+        content_deltas = [
+            e for e in out if isinstance(e, StreamTaskMessageDelta) and isinstance(e.delta, ReasoningContentDelta)
+        ]
+        summary_deltas = [
+            e for e in out if isinstance(e, StreamTaskMessageDelta) and isinstance(e.delta, ReasoningSummaryDelta)
+        ]
 
+        # Exactly one message: Start + deltas + Done, all on the same index, no Full.
         assert len(starts) == 1
         assert isinstance(starts[0].content, ReasoningContent)
-        assert len(fulls) == 1
-        assert isinstance(fulls[0].content, ReasoningContent)
-        reasoning_content = fulls[0].content.content
-        assert reasoning_content is not None
-        assert any("thinking... done" in s for s in reasoning_content)
+        assert reasoning_fulls == []
+        assert len(content_deltas) == 1
+        assert content_deltas[0].delta.content_delta == "thinking... done"
+        assert len(summary_deltas) == 1
+        assert summary_deltas[0].delta.summary_delta == "thinking... done"
+        assert len(dones) == 1
+        idx = starts[0].index
+        assert content_deltas[0].index == idx
+        assert summary_deltas[0].index == idx
+        assert dones[0].index == idx
 
-    async def test_reasoning_initial_text_emits_delta(self) -> None:
-        events = [
-            {
-                "type": "item.started",
-                "item": {"id": "r1", "type": "reasoning", "text": "seed"},
-            },
-        ]
-        out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
-        deltas = [e for e in out if isinstance(e, StreamTaskMessageDelta)]
-        assert len(deltas) == 1
-        assert isinstance(deltas[0].delta, ReasoningContentDelta)
-        assert deltas[0].delta.content_delta == "seed"
-
-    async def test_reasoning_no_started_emits_standalone_full(self) -> None:
-        """If item.completed arrives without item.started, emit a standalone Full."""
+    async def test_reasoning_no_started_opens_and_closes_one_message(self) -> None:
+        """If item.completed arrives without item.started, the converter opens a
+        Start lazily and closes it with a Done (still one clean message, no Full)."""
         events = [
             {
                 "type": "item.completed",
@@ -412,12 +424,23 @@ class TestReasoningStreaming:
             }
         ]
         out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
-        fulls = [e for e in out if isinstance(e, StreamTaskMessageFull) and isinstance(e.content, ReasoningContent)]
-        assert len(fulls) == 1
-        assert isinstance(fulls[0].content, ReasoningContent)
-        orphan_content = fulls[0].content.content
-        assert orphan_content is not None
-        assert any("orphan thought" in s for s in orphan_content)
+
+        starts = [e for e in out if isinstance(e, StreamTaskMessageStart)]
+        dones = [e for e in out if isinstance(e, StreamTaskMessageDone)]
+        reasoning_fulls = [
+            e for e in out if isinstance(e, StreamTaskMessageFull) and isinstance(e.content, ReasoningContent)
+        ]
+        content_deltas = [
+            e for e in out if isinstance(e, StreamTaskMessageDelta) and isinstance(e.delta, ReasoningContentDelta)
+        ]
+
+        assert len(starts) == 1
+        assert isinstance(starts[0].content, ReasoningContent)
+        assert reasoning_fulls == []
+        assert len(content_deltas) == 1
+        assert content_deltas[0].delta.content_delta == "orphan thought"
+        assert len(dones) == 1
+        assert dones[0].index == starts[0].index
 
     async def test_reasoning_summary_is_first_line(self) -> None:
         events = [
@@ -428,9 +451,27 @@ class TestReasoningStreaming:
             },
         ]
         out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
-        full = next(e for e in out if isinstance(e, StreamTaskMessageFull) and isinstance(e.content, ReasoningContent))
-        assert isinstance(full.content, ReasoningContent)
-        assert full.content.summary == ["line one"]
+        summary_delta = next(
+            e for e in out if isinstance(e, StreamTaskMessageDelta) and isinstance(e.delta, ReasoningSummaryDelta)
+        )
+        assert summary_delta.delta.summary_delta == "line one"
+
+    async def test_reasoning_empty_block_closes_with_done_only(self) -> None:
+        """A reasoning block that completes with no text still closes its Start."""
+        events = [
+            {"type": "item.started", "item": {"id": "r3", "type": "reasoning", "text": ""}},
+            {"type": "item.completed", "item": {"id": "r3", "type": "reasoning", "text": ""}},
+        ]
+        out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
+
+        starts = [e for e in out if isinstance(e, StreamTaskMessageStart)]
+        dones = [e for e in out if isinstance(e, StreamTaskMessageDone)]
+        deltas = [e for e in out if isinstance(e, StreamTaskMessageDelta)]
+
+        assert len(starts) == 1
+        assert deltas == []
+        assert len(dones) == 1
+        assert dones[0].index == starts[0].index
 
 
 # ---------------------------------------------------------------------------

--- a/tests/lib/adk/test_codex_sync.py
+++ b/tests/lib/adk/test_codex_sync.py
@@ -405,9 +405,13 @@ class TestReasoningStreaming:
         assert isinstance(starts[0].content, ReasoningContent)
         assert reasoning_fulls == []
         assert len(content_deltas) == 1
-        assert content_deltas[0].delta.content_delta == "thinking... done"
+        content_delta = content_deltas[0].delta
+        assert isinstance(content_delta, ReasoningContentDelta)
+        assert content_delta.content_delta == "thinking... done"
         assert len(summary_deltas) == 1
-        assert summary_deltas[0].delta.summary_delta == "thinking... done"
+        summary_delta = summary_deltas[0].delta
+        assert isinstance(summary_delta, ReasoningSummaryDelta)
+        assert summary_delta.summary_delta == "thinking... done"
         assert len(dones) == 1
         idx = starts[0].index
         assert content_deltas[0].index == idx
@@ -438,7 +442,9 @@ class TestReasoningStreaming:
         assert isinstance(starts[0].content, ReasoningContent)
         assert reasoning_fulls == []
         assert len(content_deltas) == 1
-        assert content_deltas[0].delta.content_delta == "orphan thought"
+        content_delta = content_deltas[0].delta
+        assert isinstance(content_delta, ReasoningContentDelta)
+        assert content_delta.content_delta == "orphan thought"
         assert len(dones) == 1
         assert dones[0].index == starts[0].index
 
@@ -451,10 +457,12 @@ class TestReasoningStreaming:
             },
         ]
         out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
-        summary_delta = next(
+        summary_event = next(
             e for e in out if isinstance(e, StreamTaskMessageDelta) and isinstance(e.delta, ReasoningSummaryDelta)
         )
-        assert summary_delta.delta.summary_delta == "line one"
+        summary_delta = summary_event.delta
+        assert isinstance(summary_delta, ReasoningSummaryDelta)
+        assert summary_delta.summary_delta == "line one"
 
     async def test_reasoning_empty_block_closes_with_done_only(self) -> None:
         """A reasoning block that completes with no text still closes its Start."""


### PR DESCRIPTION
## What

Fixes two reasoning-stream issues found while reviewing the unified-harness release (#424). Both are confined to the **streaming envelope** (the live `StreamTaskMessage*` sequence); neither changes the persisted message *type*, but #1 produces a duplicate persisted message.

### 1. Codex: duplicate / orphaned reasoning message (🔴 user-visible)
`_codex_sync.py` emitted `Start(ReasoningContent, active)` then `Full(ReasoningContent, static)` at the open index, with **no `Done`**. `auto_send` handles `Full` by opening its own throwaway streaming context (it ignores `event.index`), so the original `Start` context was never closed until end-of-turn teardown — persisting a **second, near-empty reasoning message** with a later timestamp (duplicate + out-of-order).

Fix: mirror the working `_claude_code_sync.py` pattern — stream the final reasoning as `ReasoningSummaryDelta` + `ReasoningContentDelta` on the open index, then close with `Done`. The open context accumulates the final `ReasoningContent` and closes cleanly as one message. The no-`started` case opens the `Start` lazily and closes it the same way; the empty-reasoning case still closes with a bare `Done`.

### 2. OpenAI: reasoning `Start` content type regressed `ReasoningContent` → `TextContent` (🟠)
`convert_openai_to_agentex_events` opened reasoning summary/content messages with a `TextContent` `Start`. On the migrated `auto_send`/Temporal path this regressed the pre-migration behavior (which started reasoning with `ReasoningContent`), so any consumer that branches on the start event's content type to show a "thinking" indicator now sees plain text. The persisted content is rebuilt from the reasoning deltas regardless, so only the live envelope was affected.

Fix: emit `ReasoningContent(style="active")` for both reasoning `Start`s. This aligns the converter with the codex/claude_code taps, the (already-corrected) langgraph-sync converter, and what the OpenAI conformance suite already treats as canonical.

## Testing
- Rewrote the codex reasoning tests to assert the `Start` + summary/content deltas + `Done` sequence and that **no** `Full(ReasoningContent)` is emitted; added an empty-block-closes-with-Done case.
- `tests/lib/adk/test_codex_sync.py`, `tests/lib/adk/providers/test_openai_turn.py`, `tests/lib/adk/test_codex_turn.py`, `tests/lib/adk/test_claude_code_sync.py`, `tests/lib/adk/providers/`, and the full `tests/lib/core/harness/` (incl. conformance) suites pass (203 + 87 green across runs).
- `ruff format` + `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two streaming envelope bugs in the reasoning message pipeline: a Codex duplicate-message issue caused by mixing `Start`+`Full` (which leaves the open context dangling via `auto_send`'s index-ignoring behaviour), and an OpenAI regression where reasoning `Start` events were typed as `TextContent` instead of `ReasoningContent`.

- **Codex** (`_codex_sync.py`): `item.completed` now emits `ReasoningSummaryDelta` + `ReasoningContentDelta` + `Done` on the already-open index, mirroring the `_claude_code_sync.py` pattern; a lazy `Start` is opened when no `item.started` preceded it, and an empty block still closes cleanly with a bare `Done`.
- **OpenAI** (`sync_provider.py`): Both `reasoning_summary` and `reasoning_content` `Start` events now carry `ReasoningContent(style="active")` so downstream consumers that branch on the start-event type correctly render a thinking indicator.
- **Tests** (`test_codex_sync.py`): Existing reasoning tests are rewritten to assert the full `Start → deltas → Done` sequence and explicitly assert no `Full(ReasoningContent)` is emitted; a new test covers the empty-block case.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — both fixes are well-scoped to the streaming envelope layer and don't touch persisted message types; the production logic is correct.

The Codex and OpenAI changes are straightforward and well-explained. The lazy-open path in `_codex_sync.py` correctly opens a `Start`, emits both a `ReasoningSummaryDelta` and a `ReasoningContentDelta`, then closes with `Done` — but the corresponding test (`test_reasoning_no_started_opens_and_closes_one_message`) only asserts on the content delta, leaving the summary delta unverified on that path.

tests/lib/adk/test_codex_sync.py — the lazy-open reasoning test is missing the `ReasoningSummaryDelta` assertion that the normal-path test carries.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/adk/_modules/_codex_sync.py | Replaces Full(ReasoningContent) emission with Start+SummaryDelta+ContentDelta+Done sequence; adds lazy Start for no-started case and imports ReasoningSummaryDelta. |
| src/agentex/lib/adk/providers/_modules/sync_provider.py | Fixes reasoning Start events to use ReasoningContent instead of TextContent for both reasoning_summary and reasoning_content paths; imports ReasoningContent. |
| tests/lib/adk/test_codex_sync.py | Rewrites reasoning tests to assert Start+deltas+Done pattern and adds empty-block test; lazy-open path missing ReasoningSummaryDelta assertion. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Codex as Codex API
    participant Proc as _CodexStreamProcessor
    participant Consumer as auto_send / Consumer

    Note over Proc,Consumer: BEFORE (broken)
    Codex->>Proc: item.started (reasoning)
    Proc->>Consumer: "StreamTaskMessageStart(ReasoningContent, active) @ idx"
    Codex->>Proc: "item.completed (reasoning, text=...)"
    Proc->>Consumer: "StreamTaskMessageFull(ReasoningContent, static) @ idx"
    Note over Consumer: auto_send ignores idx on Full — Start @ idx stays dangling until teardown — duplicate message persisted

    Note over Proc,Consumer: AFTER (fixed)
    Codex->>Proc: item.started (reasoning)
    Proc->>Consumer: "StreamTaskMessageStart(ReasoningContent, active) @ idx"
    Codex->>Proc: "item.completed (reasoning, text=...)"
    Proc->>Consumer: "StreamTaskMessageDelta(ReasoningSummaryDelta) @ idx"
    Proc->>Consumer: "StreamTaskMessageDelta(ReasoningContentDelta) @ idx"
    Proc->>Consumer: "StreamTaskMessageDone @ idx"
    Note over Consumer: Open context accumulates deltas and closes cleanly — one message persisted

    Note over Proc,Consumer: OpenAI fix (sync_provider.py)
    Proc->>Consumer: "StreamTaskMessageStart(ReasoningContent, was TextContent) @ idx"
    Note over Consumer: Consumers see correct type for thinking-indicator branch
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Codex as Codex API
    participant Proc as _CodexStreamProcessor
    participant Consumer as auto_send / Consumer

    Note over Proc,Consumer: BEFORE (broken)
    Codex->>Proc: item.started (reasoning)
    Proc->>Consumer: "StreamTaskMessageStart(ReasoningContent, active) @ idx"
    Codex->>Proc: "item.completed (reasoning, text=...)"
    Proc->>Consumer: "StreamTaskMessageFull(ReasoningContent, static) @ idx"
    Note over Consumer: auto_send ignores idx on Full — Start @ idx stays dangling until teardown — duplicate message persisted

    Note over Proc,Consumer: AFTER (fixed)
    Codex->>Proc: item.started (reasoning)
    Proc->>Consumer: "StreamTaskMessageStart(ReasoningContent, active) @ idx"
    Codex->>Proc: "item.completed (reasoning, text=...)"
    Proc->>Consumer: "StreamTaskMessageDelta(ReasoningSummaryDelta) @ idx"
    Proc->>Consumer: "StreamTaskMessageDelta(ReasoningContentDelta) @ idx"
    Proc->>Consumer: "StreamTaskMessageDone @ idx"
    Note over Consumer: Open context accumulates deltas and closes cleanly — one message persisted

    Note over Proc,Consumer: OpenAI fix (sync_provider.py)
    Proc->>Consumer: "StreamTaskMessageStart(ReasoningContent, was TextContent) @ idx"
    Note over Consumer: Consumers see correct type for thinking-indicator branch
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Flib%2Fadk%2Ftest_codex_sync.py%3A441-449%0A**Lazy-open%20path%20missing%20%60ReasoningSummaryDelta%60%20assertion**%0A%0AThe%20production%20code%20for%20the%20%60idx%20is%20None%60%20case%20always%20emits%20a%20%60ReasoningSummaryDelta%60%20before%20the%20%60ReasoningContentDelta%60%20%28lines%20407%E2%80%93416%20of%20%60_codex_sync.py%60%29.%20This%20test%20only%20asserts%20on%20%60content_deltas%60%20and%20ignores%20%60summary_deltas%60%2C%20so%20a%20future%20regression%20that%20accidentally%20drops%20the%20summary%20delta%20on%20this%20path%20would%20go%20undetected.%20Adding%20the%20same%20%60summary_deltas%60%20assertions%20that%20%60test_reasoning_start_deltas_done%60%20carries%20would%20close%20the%20gap.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=441&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/lib/adk/test_codex_sync.py:441-449
**Lazy-open path missing `ReasoningSummaryDelta` assertion**

The production code for the `idx is None` case always emits a `ReasoningSummaryDelta` before the `ReasoningContentDelta` (lines 407–416 of `_codex_sync.py`). This test only asserts on `content_deltas` and ignores `summary_deltas`, so a future regression that accidentally drops the summary delta on this path would go undetected. Adding the same `summary_deltas` assertions that `test_reasoning_start_deltas_done` carries would close the gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): narrow reasoning delta types..."](https://github.com/scaleapi/scale-agentex-python/commit/8540bc8155edbeba1d0c6a677c08fc62dc6cbf5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39410932)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->