### PR TITLE
fix(cli): harden init templates per Greptile feedback (suite-wide)

### DIFF
--- a/src/agentex/lib/cli/templates/default-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/Dockerfile-uv.j2
@@ -31,18 +31,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/default-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/manifest.yaml.j2
@@ -65,7 +65,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/default-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-claude-code/project/acp.py.j2
@@ -27,6 +27,7 @@ from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
 
@@ -134,7 +135,11 @@ async def handle_task_create(params: CreateTaskParams):
 async def handle_task_event_send(params: SendEventParams):
     """Handle a user message: spawn Claude Code locally and push events to the task stream."""
     task_id = params.task.id
-    prompt = params.event.content.content
+    content = params.event.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+        return
+    prompt = content.content
     logger.info("Processing message for task %s", task_id)
 
     await adk.messages.create(task_id=task_id, content=params.event.content)

--- a/src/agentex/lib/cli/templates/default-codex/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default-codex/Dockerfile-uv.j2
@@ -31,18 +31,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/default-codex/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-codex/manifest.yaml.j2
@@ -65,7 +65,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/default-codex/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-codex/project/acp.py.j2
@@ -32,6 +32,7 @@ load_dotenv()
 import agentex.lib.adk as adk
 from agentex.lib.adk import CodexTurn
 from agentex.lib.types.acp import SendEventParams, CancelTaskParams, CreateTaskParams
+from agentex.types.text_content import TextContent
 from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
@@ -56,6 +57,20 @@ acp = FastACP.create(
 )
 
 MODEL = os.environ.get("CODEX_MODEL", "o4-mini")
+
+# Serialize turns per task. Two ``task/event/send`` calls for the same task can
+# otherwise both read the old ``codex_thread_id`` (or ``None``), run independent
+# codex turns, and race to overwrite the stored thread id — forking the session.
+# A per-task lock keeps turns sequential without blocking other tasks.
+_task_locks: dict[str, asyncio.Lock] = {}
+
+
+def _task_lock(task_id: str) -> asyncio.Lock:
+    lock = _task_locks.get(task_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _task_locks[task_id] = lock
+    return lock
 
 
 class ConversationState(BaseModel):
@@ -150,81 +165,93 @@ async def handle_task_event_send(params: SendEventParams):
     """Handle each user message: spawn codex, stream events, save thread ID."""
     task_id = params.task.id
     agent_id = params.agent.id
-    user_message = params.event.content.content
+
+    content = params.event.content
+    if not isinstance(content, TextContent):
+        logger.warning(
+            "Ignoring non-text event content (type=%s) for task %s",
+            getattr(content, "type", "?"),
+            task_id,
+        )
+        return
+    user_message = content.content
 
     logger.info("Processing message for task %s", task_id)
 
-    await adk.messages.create(task_id=task_id, content=params.event.content)
+    await adk.messages.create(task_id=task_id, content=content)
 
-    task_state = await adk.state.get_by_task_and_agent(task_id=task_id, agent_id=agent_id)
-    if task_state is None:
-        state = ConversationState()
-        task_state = await adk.state.create(task_id=task_id, agent_id=agent_id, state=state)
-    else:
-        state = ConversationState.model_validate(task_state.state)
+    # Serialize the read-modify-write of ``codex_thread_id`` so two concurrent
+    # turns on the same task cannot fork the codex session.
+    async with _task_lock(task_id):
+        task_state = await adk.state.get_by_task_and_agent(task_id=task_id, agent_id=agent_id)
+        if task_state is None:
+            state = ConversationState()
+            task_state = await adk.state.create(task_id=task_id, agent_id=agent_id, state=state)
+        else:
+            state = ConversationState.model_validate(task_state.state)
 
-    state.turn_number += 1
+        state.turn_number += 1
 
-    async with adk.tracing.span(
-        trace_id=task_id,
-        task_id=task_id,
-        name=f"Turn {state.turn_number}",
-        input={"message": user_message},
-        data={"__span_type__": "AGENT_WORKFLOW"},
-    ) as turn_span:
-        start_ms = int(time.monotonic() * 1000)
-
-        process = await _spawn_codex(MODEL, thread_id=state.codex_thread_id)
-
-        assert process.stdin is not None
-        process.stdin.write(user_message.encode("utf-8"))
-        await process.stdin.drain()
-        process.stdin.close()
-
-        turn = CodexTurn(
-            events=_process_stdout(process),
-            model=MODEL,
-        )
-
-        emitter = UnifiedEmitter(
-            task_id=task_id,
+        async with adk.tracing.span(
             trace_id=task_id,
-            parent_span_id=turn_span.id if turn_span else None,
-        )
-
-        # Guarantee the subprocess is reaped even if auto_send_turn raises
-        # (e.g. a Redis error); otherwise codex stays blocked writing to a full
-        # stdout pipe buffer and the OS process leaks until the server restarts.
-        try:
-            result = await emitter.auto_send_turn(turn)
-        finally:
-            if process.returncode is None:
-                process.kill()
-            await process.wait()
-
-        # Record the real wall-clock duration AFTER streaming completes; setting
-        # it before the stream ran would capture only subprocess spawn overhead.
-        turn.duration_ms = int(time.monotonic() * 1000) - start_ms
-
-        usage = turn.usage()
-
-        # Persist the codex session id (public accessor; valid post-stream) so the
-        # next turn resumes the same session.
-        if turn.session_id:
-            state.codex_thread_id = turn.session_id
-
-        await adk.state.update(
-            state_id=task_state.id,
             task_id=task_id,
-            agent_id=agent_id,
-            state=state,
-        )
+            name=f"Turn {state.turn_number}",
+            input={"message": user_message},
+            data={"__span_type__": "AGENT_WORKFLOW"},
+        ) as turn_span:
+            start_ms = int(time.monotonic() * 1000)
 
-        if turn_span:
-            turn_span.output = {
-                "final_text": result.final_text,
-                "model": usage.model,
-            }
+            process = await _spawn_codex(MODEL, thread_id=state.codex_thread_id)
+
+            assert process.stdin is not None
+            process.stdin.write(user_message.encode("utf-8"))
+            await process.stdin.drain()
+            process.stdin.close()
+
+            turn = CodexTurn(
+                events=_process_stdout(process),
+                model=MODEL,
+            )
+
+            emitter = UnifiedEmitter(
+                task_id=task_id,
+                trace_id=task_id,
+                parent_span_id=turn_span.id if turn_span else None,
+            )
+
+            # Guarantee the subprocess is reaped even if auto_send_turn raises
+            # (e.g. a Redis error); otherwise codex stays blocked writing to a full
+            # stdout pipe buffer and the OS process leaks until the server restarts.
+            try:
+                result = await emitter.auto_send_turn(turn)
+            finally:
+                if process.returncode is None:
+                    process.kill()
+                await process.wait()
+
+            # Record the real wall-clock duration AFTER streaming completes; setting
+            # it before the stream ran would capture only subprocess spawn overhead.
+            turn.duration_ms = int(time.monotonic() * 1000) - start_ms
+
+            usage = turn.usage()
+
+            # Persist the codex session id (public accessor; valid post-stream) so the
+            # next turn resumes the same session.
+            if turn.session_id:
+                state.codex_thread_id = turn.session_id
+
+            await adk.state.update(
+                state_id=task_state.id,
+                task_id=task_id,
+                agent_id=agent_id,
+                state=state,
+            )
+
+            if turn_span:
+                turn_span.output = {
+                    "final_text": result.final_text,
+                    "model": usage.model,
+                }
 
 
 @acp.on_task_cancel

--- a/src/agentex/lib/cli/templates/default-codex/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-codex/project/acp.py.j2
@@ -182,7 +182,8 @@ async def handle_task_event_send(params: SendEventParams):
 
     # Serialize the read-modify-write of ``codex_thread_id`` so two concurrent
     # turns on the same task cannot fork the codex session.
-    async with _task_lock(task_id):
+    lock = _task_lock(task_id)
+    async with lock:
         task_state = await adk.state.get_by_task_and_agent(task_id=task_id, agent_id=agent_id)
         if task_state is None:
             state = ConversationState()
@@ -253,10 +254,14 @@ async def handle_task_event_send(params: SendEventParams):
                     "model": usage.model,
                 }
 
+    # Evict the lock once this turn has released it and no other turn holds or
+    # is waiting on it, so ``_task_locks`` stays bounded without breaking the
+    # serialization guarantee. There is no await between ``_task_lock()`` and
+    # acquiring it, so an unlocked, waiter-free lock has no in-flight user.
+    if not lock.locked() and not getattr(lock, "_waiters", None):
+        _task_locks.pop(task_id, None)
+
 
 @acp.on_task_cancel
 async def handle_task_canceled(params: CancelTaskParams):
     logger.info("Task canceled: %s", params.task.id)
-    # Evict the per-task turn lock so it doesn't accumulate for the lifetime of
-    # the process (one Lock per task otherwise lives forever).
-    _task_locks.pop(params.task.id, None)

--- a/src/agentex/lib/cli/templates/default-codex/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-codex/project/acp.py.j2
@@ -178,12 +178,15 @@ async def handle_task_event_send(params: SendEventParams):
 
     logger.info("Processing message for task %s", task_id)
 
-    await adk.messages.create(task_id=task_id, content=content)
-
-    # Serialize the read-modify-write of ``codex_thread_id`` so two concurrent
-    # turns on the same task cannot fork the codex session.
+    # Serialize the whole turn (echo + the read-modify-write of
+    # ``codex_thread_id``) so two concurrent turns on the same task cannot fork
+    # the codex session or interleave their echoed messages.
     lock = _task_lock(task_id)
-    async with lock:
+    await lock.acquire()
+    try:
+        # Echo inside the lock so this turn's message stays ordered with it.
+        await adk.messages.create(task_id=task_id, content=content)
+
         task_state = await adk.state.get_by_task_and_agent(task_id=task_id, agent_id=agent_id)
         if task_state is None:
             state = ConversationState()
@@ -253,13 +256,14 @@ async def handle_task_event_send(params: SendEventParams):
                     "final_text": result.final_text,
                     "model": usage.model,
                 }
-
-    # Evict the lock once this turn has released it and no other turn holds or
-    # is waiting on it, so ``_task_locks`` stays bounded without breaking the
-    # serialization guarantee. There is no await between ``_task_lock()`` and
-    # acquiring it, so an unlocked, waiter-free lock has no in-flight user.
-    if not lock.locked() and not getattr(lock, "_waiters", None):
-        _task_locks.pop(task_id, None)
+    finally:
+        lock.release()
+        # Evict the lock once released and idle (unlocked, no waiters) so
+        # ``_task_locks`` stays bounded even if the turn raised. There is no
+        # await between ``_task_lock()`` and acquiring it, so an unlocked,
+        # waiter-free lock has no in-flight user.
+        if not lock.locked() and not getattr(lock, "_waiters", None):
+            _task_locks.pop(task_id, None)
 
 
 @acp.on_task_cancel

--- a/src/agentex/lib/cli/templates/default-codex/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-codex/project/acp.py.j2
@@ -257,3 +257,6 @@ async def handle_task_event_send(params: SendEventParams):
 @acp.on_task_cancel
 async def handle_task_canceled(params: CancelTaskParams):
     logger.info("Task canceled: %s", params.task.id)
+    # Evict the per-task turn lock so it doesn't accumulate for the lifetime of
+    # the process (one Lock per task otherwise lives forever).
+    _task_locks.pop(params.task.id, None)

--- a/src/agentex/lib/cli/templates/default-langgraph/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/default-langgraph/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/manifest.yaml.j2
@@ -65,7 +65,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/default-langgraph/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-langgraph/project/acp.py.j2
@@ -22,6 +22,7 @@ from agentex.protocol.acp import SendEventParams, CancelTaskParams, CreateTaskPa
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
 from agentex.lib.adk import LangGraphTurn
 
 from project.graph import create_graph
@@ -55,7 +56,11 @@ async def handle_task_event_send(params: SendEventParams):
     """Handle incoming events, streaming tokens and tool calls via Redis."""
     graph = await get_graph()
     task_id = params.task.id
-    user_message = params.event.content.content
+    content = params.event.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+        return
+    user_message = content.content
 
     logger.info(f"Processing message for thread {task_id}")
 

--- a/src/agentex/lib/cli/templates/default-openai-agents/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/default-openai-agents/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/manifest.yaml.j2
@@ -64,7 +64,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/default-openai-agents/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-openai-agents/project/acp.py.j2
@@ -27,6 +27,7 @@ from agentex.lib.types.acp import SendEventParams, CancelTaskParams, CreateTaskP
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
 from agentex.lib.utils.model_utils import BaseModel
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.lib.core.harness.emitter import UnifiedEmitter
@@ -112,7 +113,11 @@ async def handle_task_event_send(params: SendEventParams):
     agent = get_agent()
     task_id = params.task.id
     agent_id = params.agent.id
-    user_message = params.event.content.content
+    content = params.event.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+        return
+    user_message = content.content
 
     logger.info(f"Processing message for task {task_id}")
 

--- a/src/agentex/lib/cli/templates/default-pydantic-ai/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default-pydantic-ai/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/default-pydantic-ai/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default-pydantic-ai/manifest.yaml.j2
@@ -65,7 +65,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/default-pydantic-ai/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/default-pydantic-ai/project/acp.py.j2
@@ -29,6 +29,7 @@ from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.types.fastacp import AsyncACPConfig
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
 from agentex.lib.utils.model_utils import BaseModel
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.lib.adk import PydanticAITurn
@@ -97,7 +98,11 @@ async def handle_task_event_send(params: SendEventParams):
     agent = get_agent()
     task_id = params.task.id
     agent_id = params.agent.id
-    user_message = params.event.content.content
+    content = params.event.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+        return
+    user_message = content.content
 
     logger.info(f"Processing message for task {task_id}")
 

--- a/src/agentex/lib/cli/templates/default/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/default/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/default/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/default/manifest.yaml.j2
@@ -65,7 +65,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/Dockerfile-uv.j2
@@ -31,18 +31,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/sync-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/manifest.yaml.j2
@@ -64,7 +64,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/sync-claude-code/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-claude-code/project/acp.py.j2
@@ -27,6 +27,7 @@ from agentex.lib.types.acp import SendMessageParams
 from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.types.task_message_update import TaskMessageUpdate
 from agentex.types.task_message_content import TaskMessageContent
@@ -130,7 +131,11 @@ async def handle_message_send(
 ) -> TaskMessageContent | list[TaskMessageContent] | AsyncGenerator[TaskMessageUpdate, None]:
     """Handle an incoming message: run Claude Code locally and stream events."""
     task_id = params.task.id
-    prompt = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text message content (type=%s)", getattr(content, "type", "?"))
+        return
+    prompt = content.content
     logger.info("Processing message for task %s", task_id)
 
     async with adk.tracing.span(

--- a/src/agentex/lib/cli/templates/sync-codex/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync-codex/Dockerfile-uv.j2
@@ -31,18 +31,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/sync-codex/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-codex/manifest.yaml.j2
@@ -64,7 +64,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/sync-codex/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-codex/project/acp.py.j2
@@ -36,6 +36,7 @@ from agentex.lib.types.acp import SendMessageParams
 from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.types.task_message_update import TaskMessageUpdate
 from agentex.types.task_message_content import TaskMessageContent
@@ -125,7 +126,11 @@ async def handle_message_send(
 ) -> TaskMessageContent | list[TaskMessageContent] | AsyncGenerator[TaskMessageUpdate, None]:
     """Handle each message by running ``codex exec`` locally and streaming events."""
     task_id = params.task.id
-    user_message = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text message content (type=%s)", getattr(content, "type", "?"))
+        return
+    user_message = content.content
     logger.info("Processing message for task %s", task_id)
 
     start_ms = int(time.monotonic() * 1000)

--- a/src/agentex/lib/cli/templates/sync-langgraph/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/sync-langgraph/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/manifest.yaml.j2
@@ -64,7 +64,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/sync-langgraph/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-langgraph/project/acp.py.j2
@@ -14,6 +14,7 @@ from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.protocol.acp import SendMessageParams
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
 from agentex.lib.adk import LangGraphTurn
 from agentex.types.task_message_content import TaskMessageContent
 from agentex.types.task_message_delta import TextDelta
@@ -63,7 +64,11 @@ async def handle_message_send(
     graph = await get_graph()
 
     thread_id = params.task.id
-    user_message = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text message content (type=%s)", getattr(content, "type", "?"))
+        return
+    user_message = content.content
 
     logger.info(f"Processing message for thread {thread_id}")
 

--- a/src/agentex/lib/cli/templates/sync-openai-agents-local-sandbox/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents-local-sandbox/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/sync-openai-agents-local-sandbox/README.md.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents-local-sandbox/README.md.j2
@@ -262,7 +262,10 @@ Add sophisticated response generation:
 @acp.on_message_send
 async def handle_message_send(params: SendMessageParams):
     # Analyze input
-    user_message = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        return TextContent(author="agent", content="Sorry, I can only handle text messages right now.")
+    user_message = content.content
     
     # Generate response
     response = await generate_intelligent_response(user_message)

--- a/src/agentex/lib/cli/templates/sync-openai-agents-local-sandbox/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents-local-sandbox/manifest.yaml.j2
@@ -64,7 +64,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/sync-openai-agents-local-sandbox/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents-local-sandbox/project/acp.py.j2
@@ -63,7 +63,11 @@ async def handle_message_send(
 ) -> TaskMessageContent:
     """Handle incoming messages by running the local-sandbox agent."""
     task_id = params.task.id
-    user_message = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text message content (type=%s)", getattr(content, "type", "?"))
+        return TextContent(author="agent", content="Sorry, I can only handle text messages right now.")
+    user_message = content.content
     logger.info(f"Processing message for task {task_id}")
 
     async with adk.tracing.span(

--- a/src/agentex/lib/cli/templates/sync-openai-agents/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/sync-openai-agents/README.md.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/README.md.j2
@@ -251,7 +251,10 @@ Add sophisticated response generation:
 @acp.on_message_send
 async def handle_message_send(params: SendMessageParams):
     # Analyze input
-    user_message = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        return TextContent(author="agent", content="Sorry, I can only handle text messages right now.")
+    user_message = content.content
     
     # Generate response
     response = await generate_intelligent_response(user_message)

--- a/src/agentex/lib/cli/templates/sync-openai-agents/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/manifest.yaml.j2
@@ -64,7 +64,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-openai-agents/project/acp.py.j2
@@ -98,7 +98,12 @@ async def handle_message_send(
         )
         return
 
-    user_prompt = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text message content (type=%s)", getattr(content, "type", "?"))
+        return
+
+    user_prompt = content.content
 
     # Retrieve the task state. Each event is handled as a new turn, so we need to get the state for the current turn.
     task_state = await adk.state.get_by_task_and_agent(task_id=params.task.id, agent_id=params.agent.id)

--- a/src/agentex/lib/cli/templates/sync-pydantic-ai/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync-pydantic-ai/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/sync-pydantic-ai/README.md.j2
+++ b/src/agentex/lib/cli/templates/sync-pydantic-ai/README.md.j2
@@ -251,7 +251,10 @@ Add sophisticated response generation:
 @acp.on_message_send
 async def handle_message_send(params: SendMessageParams):
     # Analyze input
-    user_message = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        return TextContent(author="agent", content="Sorry, I can only handle text messages right now.")
+    user_message = content.content
     
     # Generate response
     response = await generate_intelligent_response(user_message)

--- a/src/agentex/lib/cli/templates/sync-pydantic-ai/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync-pydantic-ai/manifest.yaml.j2
@@ -64,7 +64,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/sync-pydantic-ai/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync-pydantic-ai/project/acp.py.j2
@@ -22,6 +22,7 @@ from agentex.protocol.acp import SendMessageParams
 from agentex.lib.core.harness import UnifiedEmitter
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
+from agentex.types.text_content import TextContent
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.types.task_message_update import TaskMessageUpdate
 from agentex.types.task_message_content import TaskMessageContent
@@ -67,7 +68,12 @@ async def handle_message_send(
     agent = get_agent()
     task_id = params.task.id
 
-    user_message = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        logger.warning("Ignoring non-text message content (type=%s)", getattr(content, "type", "?"))
+        return
+
+    user_message = content.content
     logger.info(f"Processing message for task {task_id}")
 
     # Open a per-message turn span. Tool calls below nest underneath this

--- a/src/agentex/lib/cli/templates/sync/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/sync/Dockerfile-uv.j2
@@ -27,18 +27,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/src/agentex/lib/cli/templates/sync/README.md.j2
+++ b/src/agentex/lib/cli/templates/sync/README.md.j2
@@ -251,7 +251,10 @@ Add sophisticated response generation:
 @acp.on_message_send
 async def handle_message_send(params: SendMessageParams):
     # Analyze input
-    user_message = params.content.content
+    content = params.content
+    if not isinstance(content, TextContent):
+        return TextContent(author="agent", content="Sorry, I can only handle text messages right now.")
+    user_message = content.content
     
     # Generate response
     response = await generate_intelligent_response(user_message)

--- a/src/agentex/lib/cli/templates/sync/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/sync/manifest.yaml.j2
@@ -64,7 +64,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # Set enabled: true to use Temporal workflows for long-running tasks

--- a/src/agentex/lib/cli/templates/sync/project/acp.py.j2
+++ b/src/agentex/lib/cli/templates/sync/project/acp.py.j2
@@ -20,7 +20,13 @@ async def handle_message_send(
     params: SendMessageParams
 ) -> TaskMessageContent | list[TaskMessageContent] | AsyncGenerator[TaskMessageUpdate, None]:
     """Default message handler with streaming support"""
+    content = params.content
+    if not isinstance(content, TextContent):
+        return TextContent(
+            author="agent",
+            content="Sorry, I can only handle text messages right now.",
+        )
     return TextContent(
         author="agent",
-        content=f"Hello! I've received your message. Here's a generic response, but in future tutorials we'll see how you can get me to intelligently respond to your message. This is what I heard you say: {params.content.content}",
+        content=f"Hello! I've received your message. Here's a generic response, but in future tutorials we'll see how you can get me to intelligently respond to your message. This is what I heard you say: {content.content}",
     )

--- a/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/Dockerfile-uv.j2
@@ -39,18 +39,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 

--- a/src/agentex/lib/cli/templates/temporal-claude-code/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/manifest.yaml.j2
@@ -73,7 +73,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: "{{ description }}"
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # This enables your agent to run as a Temporal workflow for long-running tasks

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/workflow.py.j2
@@ -80,12 +80,12 @@ class {{ workflow_class }}(BaseWorkflow):
     async def on_task_event_send(self, params: SendEventParams) -> None:
         """Handle a user message: spawn Claude Code and push events to the task stream."""
         async with self._turn_lock:
-            self._turn_number += 1
             task_id = params.task.id
             content = params.event.content
             if not isinstance(content, TextContent):
                 logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
                 return
+            self._turn_number += 1
             prompt = content.content
             logger.info("Turn %d for task %s", self._turn_number, task_id)
 

--- a/src/agentex/lib/cli/templates/temporal-claude-code/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-claude-code/project/workflow.py.j2
@@ -82,7 +82,11 @@ class {{ workflow_class }}(BaseWorkflow):
         async with self._turn_lock:
             self._turn_number += 1
             task_id = params.task.id
-            prompt = params.event.content.content
+            content = params.event.content
+            if not isinstance(content, TextContent):
+                logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+                return
+            prompt = content.content
             logger.info("Turn %d for task %s", self._turn_number, task_id)
 
             await adk.messages.create(task_id=task_id, content=params.event.content)

--- a/src/agentex/lib/cli/templates/temporal-codex/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/temporal-codex/Dockerfile-uv.j2
@@ -39,18 +39,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 

--- a/src/agentex/lib/cli/templates/temporal-codex/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-codex/manifest.yaml.j2
@@ -73,7 +73,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: "{{ description }}"
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # This enables your agent to run as a Temporal workflow for long-running tasks

--- a/src/agentex/lib/cli/templates/temporal-codex/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-codex/project/workflow.py.j2
@@ -88,7 +88,12 @@ class {{ workflow_class }}(BaseWorkflow):
 
             await adk.messages.create(task_id=params.task.id, content=params.event.content)
 
-            user_message = params.event.content.content
+            content = params.event.content
+            if not isinstance(content, TextContent):
+                logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+                return
+
+            user_message = content.content
 
             async with adk.tracing.span(
                 trace_id=params.task.id,

--- a/src/agentex/lib/cli/templates/temporal-codex/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-codex/project/workflow.py.j2
@@ -84,14 +84,14 @@ class {{ workflow_class }}(BaseWorkflow):
         """Handle a new user message: spawn codex, stream events via UnifiedEmitter."""
         logger.info("Received task event: %s", params.task.id)
         async with self._turn_lock:
-            self._turn_number += 1
-
-            await adk.messages.create(task_id=params.task.id, content=params.event.content)
-
             content = params.event.content
             if not isinstance(content, TextContent):
                 logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
                 return
+
+            self._turn_number += 1
+
+            await adk.messages.create(task_id=params.task.id, content=params.event.content)
 
             user_message = content.content
 

--- a/src/agentex/lib/cli/templates/temporal-langgraph/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/temporal-langgraph/Dockerfile-uv.j2
@@ -33,18 +33,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 

--- a/src/agentex/lib/cli/templates/temporal-langgraph/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-langgraph/manifest.yaml.j2
@@ -73,7 +73,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: "{{ description }}"
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # This enables your agent to run as a Temporal workflow for long-running tasks

--- a/src/agentex/lib/cli/templates/temporal-langgraph/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-langgraph/project/workflow.py.j2
@@ -94,7 +94,11 @@ class {{ workflow_class }}(BaseWorkflow):
         """Handle a new user message: echo it, then run the agent graph durably."""
         logger.info(f"Received task event for task {params.task.id}")
         self._turn_number += 1
-        user_text = params.event.content.content
+        content = params.event.content
+        if not isinstance(content, TextContent):
+            logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+            return
+        user_text = content.content
 
         # Echo the user's message so it shows up as a chat bubble.
         await adk.messages.create(task_id=params.task.id, content=params.event.content)

--- a/src/agentex/lib/cli/templates/temporal-langgraph/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-langgraph/project/workflow.py.j2
@@ -93,11 +93,11 @@ class {{ workflow_class }}(BaseWorkflow):
     async def on_task_event_send(self, params: SendEventParams) -> None:
         """Handle a new user message: echo it, then run the agent graph durably."""
         logger.info(f"Received task event for task {params.task.id}")
-        self._turn_number += 1
         content = params.event.content
         if not isinstance(content, TextContent):
             logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
             return
+        self._turn_number += 1
         user_text = content.content
 
         # Echo the user's message so it shows up as a chat bubble.

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/Dockerfile-uv.j2
@@ -33,18 +33,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/manifest.yaml.j2
@@ -73,7 +73,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # This enables your agent to run as a Temporal workflow for long-running tasks

--- a/src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-openai-agents/project/workflow.py.j2
@@ -100,6 +100,11 @@ class {{ workflow_class }}(BaseWorkflow):
     async def on_task_event_send(self, params: SendEventParams) -> None:
         logger.info(f"Received task message instruction: {params}")
 
+        content = params.event.content
+        if not isinstance(content, TextContent):
+            logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+            return
+
         # Increment turn number for tracing
         self._state.turn_number += 1
 
@@ -108,7 +113,7 @@ class {{ workflow_class }}(BaseWorkflow):
         self._parent_span_id = params.task.id
 
         # Add the user message to conversation history
-        self._state.input_list.append({"role": "user", "content": params.event.content.content})
+        self._state.input_list.append({"role": "user", "content": content.content})
 
         # Echo back the client's message to show it in the UI
         await adk.messages.create(task_id=params.task.id, content=params.event.content)

--- a/src/agentex/lib/cli/templates/temporal-pydantic-ai/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/temporal-pydantic-ai/Dockerfile-uv.j2
@@ -33,18 +33,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 

--- a/src/agentex/lib/cli/templates/temporal-pydantic-ai/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal-pydantic-ai/manifest.yaml.j2
@@ -73,7 +73,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # This enables your agent to run as a Temporal workflow for long-running tasks

--- a/src/agentex/lib/cli/templates/temporal-pydantic-ai/project/workflow.py.j2
+++ b/src/agentex/lib/cli/templates/temporal-pydantic-ai/project/workflow.py.j2
@@ -85,6 +85,13 @@ class {{ workflow_class }}(BaseWorkflow):
     async def on_task_event_send(self, params: SendEventParams) -> None:
         """Handle a new user message: echo it, then run the agent durably."""
         logger.info(f"Received task event: {params.task.id}")
+
+        content = params.event.content
+        if not isinstance(content, TextContent):
+            logger.warning("Ignoring non-text event content (type=%s)", getattr(content, "type", "?"))
+            return
+        user_message = content.content
+
         self._turn_number += 1
 
         # Echo the user's message so it shows up in the UI as a chat bubble.
@@ -94,7 +101,7 @@ class {{ workflow_class }}(BaseWorkflow):
             trace_id=params.task.id,
             task_id=params.task.id,
             name=f"Turn {self._turn_number}",
-            input={"message": params.event.content.content},
+            input={"message": user_message},
         ) as span:
             # temporal_agent.run() is the magic line. Internally it schedules
             # a model activity (LLM HTTP call) and, for each tool the model
@@ -107,7 +114,7 @@ class {{ workflow_class }}(BaseWorkflow):
             # without it the agent would respond to each user message as if
             # it had never seen the conversation before.
             result = await temporal_agent.run(
-                params.event.content.content,
+                user_message,
                 message_history=self._message_history,
                 deps=TaskDeps(
                     task_id=params.task.id,

--- a/src/agentex/lib/cli/templates/temporal/Dockerfile-uv.j2
+++ b/src/agentex/lib/cli/templates/temporal/Dockerfile-uv.j2
@@ -33,18 +33,18 @@ ENV UV_HTTP_TIMEOUT=1000
 WORKDIR /app/{{ project_path_from_build_root }}
 
 # Copy dependency files for layer caching
-COPY {{ project_path_from_build_root }}/pyproject.toml {{ project_path_from_build_root }}/uv.lock ./
+COPY {{ project_path_from_build_root }}/pyproject.toml ./
 
 # Install dependencies (without project itself, for layer caching)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --no-install-project --no-dev
 
 # Copy the project code
 COPY {{ project_path_from_build_root }}/project ./project
 
 # Install the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --no-dev
 
 ENV PATH="/app/{{ project_path_from_build_root }}/.venv/bin:$PATH"
 

--- a/src/agentex/lib/cli/templates/temporal/manifest.yaml.j2
+++ b/src/agentex/lib/cli/templates/temporal/manifest.yaml.j2
@@ -73,7 +73,7 @@ agent:
 
   # Description of what your agent does
   # Helps with documentation and discovery
-  description: {{ description }}
+  description: {{ description | tojson }}
 
   # Temporal workflow configuration
   # This enables your agent to run as a Temporal workflow for long-running tasks


### PR DESCRIPTION
## What

Applies the systemic template fixes Greptile called out across the init-template stack (#434 / #435 / #436 / #442) **suite-wide**, instead of in a single template family. Decided as a separate follow-up PR so the stack could merge cleanly first.

## Fixes

1. **Quote `description` in manifests (19 files).** Every `manifest.yaml.j2` now renders `description: {{ description | tojson }}`. A user-supplied description containing YAML-significant characters (`Answers questions: with Claude`, `Claude # helper`, embedded quotes) could previously produce an invalid or truncated `manifest.yaml`. `tojson` emits a valid JSON-quoted scalar, which is valid YAML and handles all cases.
2. **Don't require a `uv.lock` (19 files).** `agentex init` renders `pyproject.toml` but never a `uv.lock`, so the `COPY ... uv.lock ./` + `uv sync --locked` steps failed the Docker build for a freshly scaffolded uv project. Dropped `uv.lock` from the `COPY` and `--locked` from both `uv sync` invocations so a fresh project builds out of the box.
3. **Guard non-text event content (17 handlers).** `params(.event).content` is a `TaskMessageContent` union; reading `.content` on a data/tool message raised `AttributeError`. Each handler now guards with `isinstance(content, TextContent)`:
   - async base handlers: log + early `return`
   - sync coroutine handlers: return a `TextContent` notice
   - sync streaming (async-generator) handlers: end the stream
   - temporal workflow handlers: log + early `return`
4. **Serialize codex turns (default-codex).** Two near-simultaneous `task/event/send` calls could both read a stale `codex_thread_id` and fork the session. Added a per-task `asyncio.Lock` around the read-modify-write. (The `temporal-codex` variant already serializes via its own turn lock.)

## Verification

Rendered **every** template with a representative context (including a YAML-hostile `description`): all generated project Python compiles, and every generated `manifest.yaml` parses with the description value preserved exactly.

## Not included

- `README.md.j2` doc snippets still show the old `params.content.content` access (illustrative excerpts, not executed). Can follow up if we want docs to mirror the guarded pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Hardens CLI init templates across the suite.
- Quotes manifest descriptions as JSON-compatible YAML scalars.
- Removes fresh-project Docker build assumptions around `uv.lock` and `uv sync --locked`.
- Adds `TextContent` guards before reading event text in generated handlers.
- Serializes default Codex task turns with a per-task lock and updates related README snippets.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The template hardening changes are narrowly scoped and align with the described fresh-project initialization failures.

No code issues were identified in the reviewed changes, and the updates consistently address YAML rendering, Docker build assumptions, event content handling, and Codex turn serialization across the template suite.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the template hardening pass and confirmed the after-state where all 19 manifests parsed with PRESERVED=True and no manifest or Dockerfile failures.
- Validated the non-text content guard pass and confirmed the after-state results where async, sync, streaming, and temporal checks return the expected values and all templates pass the guard-pattern inspection.
- Validated the codex turn-lock behavior and confirmed the after-state where A and B synchronize on the per-task lock, session data is stored and resumed correctly, and the harness used for both runs is captured.

<a href="https://app.greptile.com/trex/runs/12103016/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agentex/lib/cli/templates/temporal-codex/project/workflow.py.j2`, line 87-96 ([link](https://github.com/scaleapi/scale-agentex-python/blob/6648b53b1733aa2a3aa20a9f52cacd8510e33ff8/src/agentex/lib/cli/templates/temporal-codex/project/workflow.py.j2#L87-L96)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Non-text is persisted**

   The guard runs after `self._turn_number += 1` and `adk.messages.create(...)`. When a non-text event arrives, it is still written to task messages and counted as a durable turn before the handler returns. That leaves later Codex turns mis-numbered and records content the handler says it ignored. Check for `TextContent` before incrementing or persisting the message.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: generated handler harness for non-text event persistence](https://app.greptile.com/trex/artifacts/b5fcff8d-4953-4f29-a516-c7091db6ee06)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: harness output showing message persistence and turn increment before early return](https://app.greptile.com/trex/artifacts/70eee904-7db0-4478-954f-7e0441a759ba)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12101983/artifacts?artifact=b5fcff8d-4953-4f29-a516-c7091db6ee06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/cli/templates/temporal-codex/project/workflow.py.j2
   Line: 87-96

   Comment:
   **Non-text is persisted**

   The guard runs after `self._turn_number += 1` and `adk.messages.create(...)`. When a non-text event arrives, it is still written to task messages and counted as a durable turn before the handler returns. That leaves later Codex turns mis-numbered and records content the handler says it ignored. Check for `TextContent` before incrementing or persisting the message.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcli%2Ftemplates%2Ftemporal-codex%2Fproject%2Fworkflow.py.j2%0ALine%3A%2087-96%0A%0AComment%3A%0A**Non-text%20is%20persisted**%0A%0AThe%20guard%20runs%20after%20%60self._turn_number%20%2B%3D%201%60%20and%20%60adk.messages.create%28...%29%60.%20When%20a%20non-text%20event%20arrives%2C%20it%20is%20still%20written%20to%20task%20messages%20and%20counted%20as%20a%20durable%20turn%20before%20the%20handler%20returns.%20That%20leaves%20later%20Codex%20turns%20mis-numbered%20and%20records%20content%20the%20handler%20says%20it%20ignored.%20Check%20for%20%60TextContent%60%20before%20incrementing%20or%20persisting%20the%20message.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=444&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(cli): make default-codex lock failur..."](https://github.com/scaleapi/scale-agentex-python/commit/7f7e1eaf5cb2a8e216318c1af3f4d361adc36c76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39459910)</sub>

<!-- /greptile_comment -->