### PR TITLE
fix(adk): release streaming buffer repair in sdk

### DIFF
--- a/adk/README.md
+++ b/adk/README.md
@@ -30,3 +30,5 @@ The two packages contribute disjoint files to the `agentex.*` namespace — `age
 ## Repo layout
 
 This package is hand-authored and lives at `adk/` inside [scaleapi/scale-agentex-python](https://github.com/scaleapi/scale-agentex-python). Stainless codegen never touches `adk/**` — it's outside the generated surface. The sibling `agentex-client` package lives at the repo root and IS Stainless-generated.
+
+The wheel source is assembled from `src/agentex/lib/**` by `adk/hatch_build.py`.


### PR DESCRIPTION
## Summary
- Adds an ADK-scoped change so release-please cuts a new `agentex-sdk` patch release.
- Documents that the SDK wheel is assembled from `src/agentex/lib/**`, which is where the already-merged streaming buffer fix lives.
- Ships the `StreamTaskMessageFull` buffer fix from #426, which was merged to `main` in source but mis-routed into the `agentex-client` 0.16.1 release instead of a new SDK release.

## Test plan
- Not run; documentation-only release repair.

## Notes
This is intended to repair the failed `agentex-client v0.16.1` release state: the client published, but the SDK did not bump even though its wheel contents changed. A manual workflow dispatch alone cannot repair this because the repo still says `agentex-sdk==0.15.0`; publishing again would rebuild the changed 0.15.0 wheel and collide with the immutable PyPI artifact.