### PR TITLE
ci(packaging): publish only the tagged pypi package

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,6 +4,16 @@
 name: Publish PyPI
 on:
   workflow_dispatch:
+    inputs:
+      package:
+        description: Package to publish
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - agentex-client
+          - agentex-sdk
 
   release:
     types: [published]
@@ -33,3 +43,5 @@ jobs:
           # Back-compat fallback — used by bin/publish-pypi when the
           # dedicated tokens above are unset.
           PYPI_TOKEN: ${{ secrets.AGENTEX_PYPI_TOKEN || secrets.PYPI_TOKEN }}
+          # Manual dispatches can override tag-derived package selection.
+          PYPI_PACKAGE: ${{ inputs.package }}

--- a/bin/publish-pypi
+++ b/bin/publish-pypi
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Publish slim (root) before heavy (adk/): heavy pins slim, so a slim-first
-# failure aborts before shipping a heavy that needs an unreleased client.
+# Publish only the package requested by the component tag. Manual dispatches can
+# set PYPI_PACKAGE=all to publish both packages; in that case publish slim
+# before heavy because the heavy package depends on the slim package.
 
 set -eux
 
@@ -9,6 +10,45 @@ rm -rf dist
 # --wheel: the heavy's cross-dir force-include can't build via sdist.
 uv build --all-packages --wheel
 
-# --check-url makes the per-component-tag double-trigger idempotent.
-uv publish --check-url https://pypi.org/simple/ --token="${AGENTEX_CLIENT_PYPI_TOKEN:-$PYPI_TOKEN}" dist/agentex_client-*.whl
-uv publish --check-url https://pypi.org/simple/ --token="${AGENTEX_PYPI_TOKEN:-$PYPI_TOKEN}" dist/agentex_sdk-*.whl
+publish_client() {
+  uv publish --check-url https://pypi.org/simple/ --token="${AGENTEX_CLIENT_PYPI_TOKEN:-${PYPI_TOKEN:-}}" dist/agentex_client-*.whl
+}
+
+publish_sdk() {
+  uv publish --check-url https://pypi.org/simple/ --token="${AGENTEX_PYPI_TOKEN:-${PYPI_TOKEN:-}}" dist/agentex_sdk-*.whl
+}
+
+package="${PYPI_PACKAGE:-}"
+
+if [ -z "$package" ]; then
+  tag_name="${GITHUB_REF_NAME:-}"
+  if [ -z "$tag_name" ] && [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+    tag_name="${GITHUB_REF#refs/tags/}"
+  fi
+
+  case "$tag_name" in
+    agentex-client-v*) package="agentex-client" ;;
+    agentex-sdk-v*) package="agentex-sdk" ;;
+    *)
+      echo "Unable to infer package from tag '$tag_name'. Set PYPI_PACKAGE to one of: all, agentex-client, agentex-sdk." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+case "$package" in
+  all)
+    publish_client
+    publish_sdk
+    ;;
+  agentex-client)
+    publish_client
+    ;;
+  agentex-sdk)
+    publish_sdk
+    ;;
+  *)
+    echo "Unknown PYPI_PACKAGE '$package'. Expected one of: all, agentex-client, agentex-sdk." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Publishes only the package implied by the component release tag (`agentex-client-v*` or `agentex-sdk-v*`).
- Adds a manual workflow input for intentional `all`, `agentex-client`, or `agentex-sdk` publishes.
- Prevents a client release from trying to republish an existing SDK wheel with the same version.

## Test plan
- `bash -n bin/publish-pypi`
- Checked IDE diagnostics for the edited workflow/script files.

## Notes
This prevents the PyPI immutability failure mode. It does not, by itself, solve release-please source attribution for `src/agentex/lib/**`; that still needs a structural source move under `adk/` or custom release attribution.

This intentionally uses a non-releasing PR title (`ci`) so the tooling-only change does not create a new client release. For future releases where both components bump, the component tags will publish in separate runs; the previous script attempted slim-before-heavy atomicity in one run, but that is what exposed sibling-wheel republish collisions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows PyPI publishing to the requested package. The main changes are:

- Adds a manual workflow choice for `all`, `agentex-client`, or `agentex-sdk` publishes.
- Passes the selected package into the publish script through `PYPI_PACKAGE`.
- Infers the publish target from component release tags when no manual input is set.
- Publishes only the selected wheel, with `all` preserving client-before-SDK order.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped to publishing target selection and does not alter runtime package code.

The edited workflow and script align with the intended tag/manual-input behavior, and no blocking issues were identified in the changed files.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The base workflow was analyzed and found to have a workflow\_dispatch trigger but no package input and no PYPI\_PACKAGE environment variable, and all test scenarios invoked uv publish for both dist/agentex\_client-...whl and dist/agentex\_sdk-...whl.
- The head workflow was updated to define workflow\_dispatch.inputs.package with choices all, agentex-client, and agentex-sdk, and it passes PYPI\_PACKAGE: ${{ inputs.package }} to the publish step.
- Execution results showed that publishing with the three scenarios produced the expected wheel outputs: agentex-client-v1.2.3 published only the client wheel, agentex-sdk-v1.2.3 published only the SDK wheel, and manual PYPI\_PACKAGE selections published the corresponding wheels; invalid or missing tags exited with an error.

<a href="https://app.greptile.com/trex/runs/12668273/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(packaging): publish only the tagged ..."](https://github.com/scaleapi/scale-agentex-python/commit/354991f842f743f3d8ad5cd6505d190e2af518fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40575168)</sub>

<!-- /greptile_comment -->