### PR TITLE
ci(release): link agentex-client and agentex-sdk versions in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,16 @@
       "component": "agentex-sdk"
     }
   },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "agentex",
+      "components": [
+        "agentex-client",
+        "agentex-sdk"
+      ]
+    }
+  ],
   "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": true,


### PR DESCRIPTION
## Summary

Root-cause fix for the SDK/client version divergence behind the failed `agentex-client-v0.16.1` release ([#426](https://github.com/scaleapi/scale-agentex-python/pull/426)).

`agentex-sdk` ships `src/agentex/lib/**` (force-included from outside `adk/` by `adk/hatch_build.py`), but release-please attributes changes by directory: anything under `adk/**` → `agentex-sdk`, everything else (including `src/agentex/lib/**`) → `agentex-client` (path `.`). So a `lib/**` change — which is exactly what the SDK ships and the client excludes — only ever bumps the **client**. The SDK bumps only when something physically under `adk/` happens to ride along in the same release window.

This has drifted since release #411 (client `0.14.0` / sdk `0.13.2`). #426 was the first lib-only window with no `adk/**` change → `agentex-client` cut `0.16.1`, `agentex-sdk` stayed `0.15.0`, and the rebuilt `agentex_sdk-0.15.0` wheel (now carrying the streaming fix) collided with the immutable PyPI artifact.

## Fix

Add the `linked-versions` plugin grouping `agentex-client` + `agentex-sdk`. release-please then keeps both components on one version and bumps them together (it takes the max version across the group), so any change that bumps the client also bumps the SDK. This matches the design the two packages already declare — co-released in lockstep, `agentex-sdk` pins `agentex-client` floor-only.

## How this composes with the other PRs

- [#449](https://github.com/scaleapi/scale-agentex-python/pull/449) — immediate repair to ship #426's fix as a new SDK version; orthogonal to this and should land first.
- [#450](https://github.com/scaleapi/scale-agentex-python/pull/450) — publishes only the tagged component. **#450 should land with this PR, not before it alone:** without a fix that bumps the SDK on `lib/**` changes, #450 converts today's loud PyPI collision into a *silent* failure (the SDK never rebuilds/publishes, so SDK consumers silently miss the fix and CI stays green). With this PR, a `lib/**` change bumps both components → both tags fire → #450 publishes each cleanly.

## Notes

- The config change is inert until the next `feat`/`fix` release (this `ci`-typed commit doesn't trigger a bump on its own).
- On the next release, `linked-versions` snaps `agentex-sdk` up to the client's line (`0.15.x → 0.16.x`); it skips an unreleased range, which is harmless.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `linked-versions` release-please plugin to keep `agentex-client` and `agentex-sdk` on the same version, fixing the root cause of the silent SDK drift first exposed by the failed `agentex-client-v0.16.1` release. Any change that bumps one component now automatically bumps the other to the same version.

- Adds a `plugins` block to `release-please-config.json` with a single `linked-versions` entry grouping `agentex-client` and `agentex-sdk`; component names match the existing `packages` entries exactly.
- On the next `feat`/`fix` release the SDK will be snapped from `0.15.0` up to the client's current `0.16.x` line, skipping the unreleased gap — acknowledged in the PR description as harmless.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a minimal, targeted config change with no runtime code involved.

The change is a single plugin block in a JSON config file. The linked-versions syntax is correct, both component names match the existing packages entries, and the version-snap behavior on the next release is intentional and documented. There are no code changes and no risk of regressions.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| release-please-config.json | Adds linked-versions plugin grouping agentex-client and agentex-sdk; component names exactly match the packages entries, syntax is correct, and the plugin will snap the SDK from 0.15.0 to the client's 0.16.x line on the next release as intended. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Conventional commit lands on next] --> B{Which paths changed?}
    B -->|adk/** touched| C[agentex-sdk gets a bump]
    B -->|src/agentex/lib/** or root touched| D[agentex-client gets a bump]
    B -->|both touched| E[Both components get independent bumps]
    C --> F[linked-versions plugin]
    D --> F
    E --> F
    F --> G{Take max version across group}
    G --> H[Both agentex-client and agentex-sdk set to the same version]
    H --> I[Release PR opened with both components at max version]
    I --> J[Tags: agentex-client-vX.Y.Z and agentex-sdk-vX.Y.Z]
    J --> K[publish-pypi.yml builds and uploads both wheels to PyPI]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Conventional commit lands on next] --> B{Which paths changed?}
    B -->|adk/** touched| C[agentex-sdk gets a bump]
    B -->|src/agentex/lib/** or root touched| D[agentex-client gets a bump]
    B -->|both touched| E[Both components get independent bumps]
    C --> F[linked-versions plugin]
    D --> F
    E --> F
    F --> G{Take max version across group}
    G --> H[Both agentex-client and agentex-sdk set to the same version]
    H --> I[Release PR opened with both components at max version]
    I --> J[Tags: agentex-client-vX.Y.Z and agentex-sdk-vX.Y.Z]
    J --> K[publish-pypi.yml builds and uploads both wheels to PyPI]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(release): link agentex-client and age..."](https://github.com/scaleapi/scale-agentex-python/commit/eb01f62a13379960c6e344466d7c5a974c16cf45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40596983)</sub>

<!-- /greptile_comment -->