### PR TITLE
test(tutorials): fix flaky streaming test that broke on first terminal event

### DIFF
--- a/examples/tutorials/10_async/10_temporal/010_agent_chat/tests/test_agent.py
+++ b/examples/tutorials/10_async/10_temporal/010_agent_chat/tests/test_agent.py
@@ -240,42 +240,28 @@ class TestStreamingEvents:
                 task_id=task.id,
                 timeout=90,  # Increased timeout for CI environments
             ):
+                # A turn emits several messages (user echo, reasoning, agent text),
+                # each ending in "full" or "done"; consume until the text reply lands.
                 msg_type = event.get("type")
                 if msg_type == "full":
-                    task_message_update = StreamTaskMessageFull.model_validate(event)
-                    if task_message_update.parent_task_message and task_message_update.parent_task_message.id:
-                        finished_message = await client.messages.retrieve(task_message_update.parent_task_message.id)
-                        if (
-                            finished_message.content
-                            and finished_message.content.type == "text"
-                            and finished_message.content.author == "user"
-                        ):
-                            user_message_found = True
-                        elif (
-                            finished_message.content
-                            and finished_message.content.type == "text"
-                            and finished_message.content.author == "agent"
-                        ):
-                            agent_response_found = True
-                        elif finished_message.content and finished_message.content.type == "reasoning":
-                            reasoning_found = True
-
-                    # Exit early if we have what we need
-                    if user_message_found and agent_response_found:
-                        break
-
+                    parent_task_message = StreamTaskMessageFull.model_validate(event).parent_task_message
                 elif msg_type == "done":
-                    task_message_update_done = StreamTaskMessageDone.model_validate(event)
-                    if task_message_update_done.parent_task_message and task_message_update_done.parent_task_message.id:
-                        finished_message = await client.messages.retrieve(task_message_update_done.parent_task_message.id)
-                        if finished_message.content and finished_message.content.type == "reasoning":
-                            reasoning_found = True
-                        elif (
-                            finished_message.content
-                            and finished_message.content.type == "text"
-                            and finished_message.content.author == "agent"
-                        ):
-                            agent_response_found = True
+                    parent_task_message = StreamTaskMessageDone.model_validate(event).parent_task_message
+                else:
+                    continue
+
+                if parent_task_message and parent_task_message.id:
+                    finished_message = await client.messages.retrieve(parent_task_message.id)
+                    content = finished_message.content
+                    if content and content.type == "text" and content.author == "user":
+                        user_message_found = True
+                    elif content and content.type == "text" and content.author == "agent":
+                        agent_response_found = True
+                    elif content and content.type == "reasoning":
+                        reasoning_found = True
+
+                # Stop once both the user echo and the agent's text reply are seen.
+                if user_message_found and agent_response_found:
                     break
 
         stream_task = asyncio.create_task(stream_messages())


### PR DESCRIPTION
## Problem

`test_send_event_and_stream_with_reasoning` in `010_agent_chat` intermittently reds CI on unrelated PRs (e.g. passes on one run, fails minutes later on a sibling PR whose diff is version-strings/changelogs only).

## Root cause — test-side early break

A single turn emits **several** task messages, each terminated by exactly one stream event:

| Message | Terminal event |
|---|---|
| user echo (`adk.messages.create`) | `full` |
| reasoning (gpt-5, `summary="detailed"`) | `full` (then `close()` is a no-op) |
| agent text reply (streamed) | `done` |

The stream loop **broke unconditionally on the first `done`**. When a reasoning message's terminal event reached the consumer before the agent text's `done`, the loop exited with `agent_response_found` still `False`.

The failure signature confirms it is an early break, not latency: the run fails with `AssertionError: Agent response not found in stream` at `tests/test_agent.py:287`, **not** a `TimeoutError` at the `await stream_task` line. A latency/timeout problem would surface as the latter. (It also fails at the *agent* assertion, not the *user* one, confirming the user echo reliably arrives.)

## Fix

Consume terminal events (`full` and `done`) until **both** the user echo and the agent's text reply are observed, keying off the retrieved message's content rather than stopping at the first terminal signal. The 90s timeout remains the backstop if the agent genuinely never responds.

As a bonus, the unified handler now catches the agent text whether it arrives as a `full` or a `done`, so it's robust to emission changes.

## Why test-side, not `streaming.py`

The producer correctly emits one terminal event per message, and real consumers key by message id (they don't break on the first `done`). That code path was just repaired in #449 for a duplicate-publish symptom; making reasoning also emit a `done` risks reintroducing it. The correct and lower-risk layer is the test.

## Testing

Full repro requires the `scale-agentex` server image + Redis + Temporal + real gpt-5 calls, which isn't reproducible in this environment (no OpenAI key). Verified locally: file compiles and `ruff check` passes. The fix is validated by the failure-signature analysis above rather than a mock-based regression test, which for a tutorial integration test would add more coupling than coverage.

🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the streaming tutorial test to avoid stopping on the first terminal event. The main changes are:

- Handles both `full` and `done` terminal events through one path.
- Retrieves completed messages before deciding which expected response was seen.
- Keeps consuming the stream until both the user echo and agent text reply are found.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is isolated to a tutorial integration test and aligns the stream consumer with the documented multi-message terminal-event behavior.

The update narrows the stopping condition without touching production streaming code, preserving the timeout backstop while making the assertion depend on observed message content.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The async harness trex-artifacts/stream-loop-early-terminal-harness.py was executed to run both the before and after scenarios.
- The before-run log trex-artifacts/stream-loop-early-terminal-01-before.log captured the base loop, showing it consumed EVENT full user and EVENT done reasoning and retrieved only \['user', 'reasoning'\], with agent\_response\_found=False.
- The after-run log trex-artifacts/stream-loop-early-terminal-02-after.log captured the head loop, showing it consumed the subsequent agent terminal event, retrieved \['user', 'reasoning', 'agent'\], and ended with user\_message\_found=True agent\_response\_found=True reasoning\_found=True for agent done and full variants.

<a href="https://app.greptile.com/trex/runs/12679718/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(tutorials): fix flaky streaming tes..."](https://github.com/scaleapi/scale-agentex-python/commit/00a435159773c4d5e4007fe158b33015c9190c5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40619508)</sub>

<!-- /greptile_comment -->