### PR TITLE
refactor(lib): remove the dead build-info.json registration read-path

### DIFF
--- a/src/agentex/lib/environment_variables.py
+++ b/src/agentex/lib/environment_variables.py
@@ -38,8 +38,6 @@ class EnvVarKeys(str, Enum):
     HEALTH_CHECK_PORT = "HEALTH_CHECK_PORT"
     # Auth Configuration
     AUTH_PRINCIPAL_B64 = "AUTH_PRINCIPAL_B64"
-    # Build Information
-    BUILD_INFO_PATH = "BUILD_INFO_PATH"
     AGENT_INPUT_TYPE = "AGENT_INPUT_TYPE"
     # Deployment
     AGENTEX_DEPLOYMENT_ID = "AGENTEX_DEPLOYMENT_ID"
@@ -85,8 +83,6 @@ class EnvironmentVariables(BaseModel):
     HEALTH_CHECK_PORT: int = 80
     # Auth Configuration
     AUTH_PRINCIPAL_B64: str | None = None
-    # Build Information
-    BUILD_INFO_PATH: str | None = None
     # Deployment
     AGENTEX_DEPLOYMENT_ID: str | None = None
     # Claude Agents SDK Configuration

--- a/src/agentex/lib/sdk/fastacp/fastacp.py
+++ b/src/agentex/lib/sdk/fastacp/fastacp.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import os
-import inspect
 from typing import Any, Literal
-from pathlib import Path
 from typing_extensions import deprecated
 
 from agentex.lib.types.fastacp import (
@@ -83,14 +80,6 @@ class FastACP:
         return FastACP.create_async_acp(config, **kwargs)
 
     @staticmethod
-    def locate_build_info_path() -> None:
-        """If a build-info.json file is present, set the BUILD_INFO_PATH environment variable"""
-        acp_root = Path(inspect.stack()[2].filename).resolve().parents[0]
-        build_info_path = acp_root / "build-info.json"
-        if build_info_path.exists():
-            os.environ["BUILD_INFO_PATH"] = str(build_info_path)
-
-    @staticmethod
     def create(
         acp_type: Literal["sync", "async", "agentic"],
         config: BaseACPConfig | None = None,
@@ -104,8 +93,6 @@ class FastACP:
             config: Configuration object. Required for async/agentic type.
             **kwargs: Additional configuration parameters
         """
-
-        FastACP.locate_build_info_path()
 
         if acp_type == "sync":
             sync_config = config if isinstance(config, SyncACPConfig) else None

--- a/src/agentex/lib/utils/registration.py
+++ b/src/agentex/lib/utils/registration.py
@@ -20,17 +20,6 @@ def get_auth_principal(env_vars: EnvironmentVariables):
     except Exception:
         return None
 
-def get_build_info():
-    build_info_path = os.environ.get("BUILD_INFO_PATH")
-    logger.info(f"Getting build info from {build_info_path}")
-    if not build_info_path:
-        return None
-    try:
-        with open(build_info_path, "r") as f:
-            return json.load(f)
-    except Exception:
-        return None
-
 async def register_agent(env_vars: EnvironmentVariables, agent_card=None):
     """Register this agent with the Agentex server"""
     if not env_vars.AGENTEX_BASE_URL:
@@ -44,8 +33,8 @@ async def register_agent(env_vars: EnvironmentVariables, agent_card=None):
         or f"Generic description for agent: {env_vars.AGENT_NAME}"
     )
 
-    # Build registration metadata from build-info.json + deployment env var
-    registration_metadata = get_build_info() or {}
+    # Registration metadata carries the deployment id and agent card.
+    registration_metadata: dict = {}
     if env_vars.AGENTEX_DEPLOYMENT_ID:
         registration_metadata["deployment_id"] = env_vars.AGENTEX_DEPLOYMENT_ID
     if agent_card is not None:

--- a/tests/lib/test_agent_card.py
+++ b/tests/lib/test_agent_card.py
@@ -358,40 +358,39 @@ class TestRegisterAgentCardMerge:
         card = AgentCard(input_types=["text"], data_events=["result"])
         mock_client = self._make_mock_client()
 
-        with patch("agentex.lib.utils.registration.get_build_info", return_value={"version": "1.0"}):
-            with patch("agentex.lib.utils.registration.httpx.AsyncClient", return_value=mock_client):
-                from agentex.lib.utils.registration import register_agent
-                await register_agent(mock_env_vars, agent_card=card)
+        with patch("agentex.lib.utils.registration.httpx.AsyncClient", return_value=mock_client):
+            from agentex.lib.utils.registration import register_agent
 
-                sent_data = mock_client.post.call_args.kwargs["json"]
-                metadata = sent_data["registration_metadata"]
+            await register_agent(mock_env_vars, agent_card=card)
 
-                assert "agent_card" in metadata
-                assert metadata["agent_card"]["input_types"] == ["text"]
-                assert metadata["agent_card"]["data_events"] == ["result"]
-                assert metadata["version"] == "1.0"
+            sent_data = mock_client.post.call_args.kwargs["json"]
+            metadata = sent_data["registration_metadata"]
 
-    async def test_none_preserved_when_no_card_no_build_info(self, mock_env_vars):
+            assert "agent_card" in metadata
+            assert metadata["agent_card"]["input_types"] == ["text"]
+            assert metadata["agent_card"]["data_events"] == ["result"]
+
+    async def test_none_preserved_when_no_card(self, mock_env_vars):
         mock_client = self._make_mock_client()
 
-        with patch("agentex.lib.utils.registration.get_build_info", return_value=None):
-            with patch("agentex.lib.utils.registration.httpx.AsyncClient", return_value=mock_client):
-                from agentex.lib.utils.registration import register_agent
-                await register_agent(mock_env_vars, agent_card=None)
+        with patch("agentex.lib.utils.registration.httpx.AsyncClient", return_value=mock_client):
+            from agentex.lib.utils.registration import register_agent
 
-                sent_data = mock_client.post.call_args.kwargs["json"]
-                assert sent_data["registration_metadata"] is None
+            await register_agent(mock_env_vars, agent_card=None)
 
-    async def test_card_creates_metadata_when_build_info_none(self, mock_env_vars):
+            sent_data = mock_client.post.call_args.kwargs["json"]
+            assert sent_data["registration_metadata"] is None
+
+    async def test_card_creates_metadata(self, mock_env_vars):
         card = AgentCard(input_types=["text"])
         mock_client = self._make_mock_client()
 
-        with patch("agentex.lib.utils.registration.get_build_info", return_value=None):
-            with patch("agentex.lib.utils.registration.httpx.AsyncClient", return_value=mock_client):
-                from agentex.lib.utils.registration import register_agent
-                await register_agent(mock_env_vars, agent_card=card)
+        with patch("agentex.lib.utils.registration.httpx.AsyncClient", return_value=mock_client):
+            from agentex.lib.utils.registration import register_agent
 
-                sent_data = mock_client.post.call_args.kwargs["json"]
-                metadata = sent_data["registration_metadata"]
-                assert metadata is not None
-                assert "agent_card" in metadata
+            await register_agent(mock_env_vars, agent_card=card)
+
+            sent_data = mock_client.post.call_args.kwargs["json"]
+            metadata = sent_data["registration_metadata"]
+            assert metadata is not None
+            assert "agent_card" in metadata


### PR DESCRIPTION
Removes the never-fed `build-info.json` → `registration_metadata` read-path.

## Why
- **Never fed.** No producer has ever written `build-info.json`. The read path landed 2025-09 (#103) expecting an external build system that never materialized, so the registration git-provenance fields have been null for ~9 months.
- **Redundant.** `AgentexCloudDeploy.build_id` is an FK to `AgentexCloudBuild`, so a deployment's source provenance derives from the build record (the `source_*` columns [AGX1-418](https://linear.app/scale-epd/issue/AGX1-418) adds) over that join — no need to denormalize onto `registration_metadata`.

## What
- Remove `FastACP.locate_build_info_path()` + its call in `FastACP.create()`.
- Remove `registration.get_build_info()` and the `registration_metadata = get_build_info()` seed — `registration_metadata` still carries `deployment_id` / `agent_card`.
- Remove the now-unused `BUILD_INFO_PATH` env-var const/field.
- Update the 3 `test_agent_card.py` tests that mocked `get_build_info`.

Full `lib` suite green (877 passed); `ruff`/`pyright` clean. Tracked in [AGX1-419](https://linear.app/scale-epd/issue/AGX1-419); the server-side `DeploymentHistory` git fields are the other (cross-team, breaking) half tracked there.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the unused build-info registration metadata path. The main changes are:

- Removed `BUILD_INFO_PATH` from environment variable parsing.
- Removed `FastACP` probing for nearby `build-info.json` files.
- Removed `get_build_info()` from agent registration.
- Kept registration metadata limited to deployment id and agent card.
- Updated agent card registration tests for the new metadata behavior.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the scoped removal of unused build-info metadata plumbing and corresponding test updates.

The changes are narrowly focused on deleting an unfed read path while preserving deployment id and agent card registration metadata, with no issues identified in the changed behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The register\_agent path was run with a mocked HTTP post capture to record the before-state metadata, confirming the base keys for the card+deployment+build-info path and that build-info-only shows non-null metadata.
- The register\_agent path was run again to capture the after-state metadata, showing head keys limited to agent\_card and deployment\_id for card+deployment+build-info; deployment-only includes deployment\_id; build-info-only/no-metadata yields registration\_metadata:null; and both runs exited with code 0.

<a href="https://app.greptile.com/trex/runs/12724059/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(lib): remove the dead build-inf..."](https://github.com/scaleapi/scale-agentex-python/commit/154add03e6eb02d04a9931b63f963e4725b8ad70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40706956)</sub>

<!-- /greptile_comment -->