### PR TITLE
fix: cap openai <2.45 for openai-agents 0.14.x compatibility

### DIFF
--- a/adk/pyproject.toml
+++ b/adk/pyproject.toml
@@ -41,7 +41,14 @@ dependencies = [
     # LLM provider integrations
     "litellm>=1.83.7,<2",
     "openai-agents>=0.14.3,<0.15",
-    "openai>=2.2,<3", # Required by openai-agents; litellm now supports openai 2.x (issue #13711 resolved: https://github.com/BerriAI/litellm/issues/13711)
+    # Cap <2.45: openai 2.45.0 makes InputTokensDetails.cache_write_tokens a
+    # required field, but openai-agents 0.14.x still builds
+    # InputTokensDetails(cached_tokens=0) (agents/usage.py), so every
+    # Runner.run_streamed raises a pydantic ValidationError at context setup.
+    # openai-agents 0.14.8 is the latest release, so there is no newer version
+    # to bump to; drop this ceiling once openai-agents ships a fix.
+    # litellm now supports openai 2.x (issue #13711 resolved: https://github.com/BerriAI/litellm/issues/13711)
+    "openai>=2.2,<2.45",
     "claude-agent-sdk>=0.1.0",
     "pydantic-ai-slim>=1.0,<2",
     "langgraph-checkpoint>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ dev = [
 
 [[package]]
 name = "agentex-sdk"
-version = "0.13.0"
+version = "0.17.0"
 source = { editable = "adk" }
 dependencies = [
     { name = "agentex-client" },
@@ -144,7 +144,7 @@ requires-dist = [
     { name = "langgraph-checkpoint", specifier = ">=2.0.0" },
     { name = "litellm", specifier = ">=1.83.7,<2" },
     { name = "mcp", specifier = ">=1.4.1" },
-    { name = "openai", specifier = ">=2.2,<3" },
+    { name = "openai", specifier = ">=2.2,<2.45" },
     { name = "openai-agents", specifier = ">=0.14.3,<0.15" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },


### PR DESCRIPTION
## Problem

The **Test Tutorial Agents** workflow has been failing on every branch (`next`, feature branches, and every release PR such as #457). The same set of tutorials fail deterministically:

- `00_sync/010_multiturn`, `00_sync/020_streaming`
- `10_async/10_temporal/070_open_ai_agents_sdk_tools`, `080_..._human_in_the_loop`
- `10_async/10_temporal/020_state_machine`
- `10_async/00_base/040_other_sdks`

The failures are **not** caused by any of those PRs (e.g. #457 is a Stainless release PR that never touches `examples/`). They are a pre-existing dependency incompatibility.

## Root cause

The agent-side logs (printed by the workflow's "Print agent logs on failure" step) show:

```
pydantic_core.ValidationError: 1 validation error for InputTokensDetails
cache_write_tokens
  Field required
```

Traceback: `Runner.run_streamed` -> `ensure_context_wrapper` -> `agents/usage.py:112` does `InputTokensDetails(cached_tokens=0)`.

- `openai==2.45.0` made `InputTokensDetails.cache_write_tokens` a **required** field (it was optional through 2.44.0).
- `openai-agents==0.14.8` (the latest release) still builds `InputTokensDetails(cached_tokens=0)` without it, so every `Runner.run_streamed` raises at context setup, before any LLM call.

Why only the tutorials break: the repo's own `uv.lock` pins `openai 2.40.0`, so unit tests pass. The tutorial agents have **no lockfile** and resolve dependencies fresh, so they pull `openai 2.45.0`. Every failing tutorial hits the same `InputTokensDetails` error (confirmed for the sync direct path, the temporal openai-agents plugin path, and the temporal worker/ADK path).

Reproduced locally with no API key needed (the crash is at run setup, not the LLM call):

```
openai 2.44.0 + openai-agents 0.14.8  -> Usage() / RunContextWrapper OK
openai 2.45.0 + openai-agents 0.14.8  -> ValidationError: cache_write_tokens Field required
```

## Fix

Cap `openai <2.45` in the `agentex-sdk` (`adk/pyproject.toml`) dependencies. Because the tutorials depend on `agentex-sdk`, this ceiling flows into their fresh resolves via the built wheel. Verified: a fresh resolve of the tutorial dependency set now lands on `openai 2.44.0`.

`openai-agents 0.14.8` is the latest release, so there is no newer version to bump to. The ceiling should be dropped once openai-agents ships a fix for its `InputTokensDetails` construction.

## Verification

- Reproduced the exact `InputTokensDetails` crash and confirmed openai 2.44.0 resolves it (no API key required, crash is pre-LLM).
- Dry-run resolved both tutorial dependency shapes (with and without an explicit `openai-agents` dep) and confirmed both now select `openai 2.44.0`.
- `uv lock` regenerated; the only changes are the `openai` specifier and a stale `agentex-sdk` version sync.
- End-to-end tutorial runs need live LLM keys (CI has them), so CI on this PR is the final verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caps the `openai` dependency to `<2.45` in `adk/pyproject.toml` to work around a breaking change in `openai 2.45.0` that made `InputTokensDetails.cache_write_tokens` a required field, while `openai-agents 0.14.x` still constructs `InputTokensDetails` without it — causing a `pydantic ValidationError` in every `Runner.run_streamed` call that was breaking tutorial CI.

- **`adk/pyproject.toml`**: Narrows `openai>=2.2,<3` to `>=2.2,<2.45` with an explanatory comment; the `uv.lock` is regenerated accordingly and syncs the `agentex-sdk` version from `0.13.0` to `0.17.0`.
- **`uv.lock`**: Only the `openai` specifier and the stale `agentex-sdk` version entry change; no other dependency pins are altered.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a targeted dependency ceiling with a clear, documented root cause and no impact on existing lockfile-pinned unit tests.

The fix correctly identifies and works around the openai 2.45.0 breaking change. The only gap is that the cleanup reminder comment has no linked ticket, making it easy to overlook when the upstream fix lands.

adk/pyproject.toml — the cleanup reminder comment should be linked to a Linear task so the ceiling does not outlive its usefulness.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| adk/pyproject.toml | Caps openai dependency at <2.45 to avoid the InputTokensDetails ValidationError introduced in openai 2.45.0; comment explains the reason well but lacks a ticket number for follow-up. |
| uv.lock | Lock file updated to reflect the new <2.45 openai specifier and syncs agentex-sdk version from 0.13.0 to 0.17.0. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Tutorial agent fresh resolve\n(no lockfile)"] --> B{openai version resolved}
    B -- "openai >=2.45\n(before fix)" --> C["InputTokensDetails construction\nagents/usage.py:112\ncached_tokens=0 only"]
    C --> D["pydantic ValidationError\ncache_write_tokens: Field required"]
    D --> E["Runner.run_streamed fails\nbefore any LLM call"]
    B -- "openai <2.45\n(after fix: cap in adk/pyproject.toml)" --> F["InputTokensDetails OK\ncache_write_tokens not required"]
    F --> G["Runner.run_streamed succeeds"]
    H["adk/pyproject.toml\nopenai>=2.2,<2.45"] --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Tutorial agent fresh resolve\n(no lockfile)"] --> B{openai version resolved}
    B -- "openai >=2.45\n(before fix)" --> C["InputTokensDetails construction\nagents/usage.py:112\ncached_tokens=0 only"]
    C --> D["pydantic ValidationError\ncache_write_tokens: Field required"]
    D --> E["Runner.run_streamed fails\nbefore any LLM call"]
    B -- "openai <2.45\n(after fix: cap in adk/pyproject.toml)" --> F["InputTokensDetails OK\ncache_write_tokens not required"]
    F --> G["Runner.run_streamed succeeds"]
    H["adk/pyproject.toml\nopenai>=2.2,<2.45"] --> B
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadk%2Fpyproject.toml%3A42-51%0A**Missing%20ticket%20link%20on%20the%20%22drop%20this%20ceiling%22%20reminder**%0A%0AThe%20comment%20says%20%22drop%20this%20ceiling%20once%20openai-agents%20ships%20a%20fix%2C%22%20but%20there%20is%20no%20Linear%20task%20number%20attached%20to%20make%20that%20cleanup%20traceable.%20Per%20team%20rules%2C%20TODO-style%20comments%20must%20include%20a%20ticket%20number%20so%20the%20follow-up%20can%20be%20found%20with%20a%20quick%20search.%20Without%20it%2C%20this%20ceiling%20is%20likely%20to%20linger%20long%20after%20%60openai-agents%60%20publishes%20a%20fix%20for%20the%20%60InputTokensDetails%60%20construction.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=459&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
adk/pyproject.toml:42-51
**Missing ticket link on the "drop this ceiling" reminder**

The comment says "drop this ceiling once openai-agents ships a fix," but there is no Linear task number attached to make that cleanup traceable. Per team rules, TODO-style comments must include a ticket number so the follow-up can be found with a quick search. Without it, this ceiling is likely to linger long after `openai-agents` publishes a fix for the `InputTokensDetails` construction.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: cap openai &lt;2.45 for openai-agents ..."](https://github.com/scaleapi/scale-agentex-python/commit/9a7b760f13af1d3701928693e66cc8a2443401c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43175837)</sub>

<!-- /greptile_comment -->