### PR TITLE
fix(tracing): capture span body exceptions and export SGP status=ERROR

### DIFF
--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -15,6 +15,7 @@ from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.core.observability import tracing_metrics_recording as _metrics
 from agentex.lib.environment_variables import EnvironmentVariables
+from agentex.lib.core.tracing.span_error import get_span_error
 from agentex.lib.core.tracing.processors.tracing_processor_interface import (
     SyncTracingProcessor,
     AsyncTracingProcessor,
@@ -83,6 +84,9 @@ def _build_sgp_span(span: Span, env_vars: EnvironmentVariables) -> SGPSpan:
         ),
     )
     sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]
+    error = get_span_error(span)
+    if error is not None:
+        sgp_span.set_error(error_type=error["type"], error_message=error["message"])
     return sgp_span
 
 

--- a/src/agentex/lib/core/tracing/span_error.py
+++ b/src/agentex/lib/core/tracing/span_error.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agentex.types.span import Span
+
+# Reserved key under ``Span.data`` carrying failure info for a span whose
+# context-manager body raised. Mirrors the existing ``__span_type__`` /
+# ``__source__`` reserved-key convention already read/written by the SGP
+# processor. Stored in ``data`` because the Span model is generated from the
+# OpenAPI spec and has no first-class status/error field; ``data`` is a real
+# field, so it survives ``model_copy(deep=True)`` and round-trips to both the
+# SGP and agentex-native span stores.
+SPAN_ERROR_KEY = "__error__"
+
+
+def set_span_error(span: Span, exc: BaseException) -> None:
+    """Record an exception on ``span`` under ``data[SPAN_ERROR_KEY]``.
+
+    No-op when ``span.data`` is a list (matching ``_add_source_to_span``, which
+    only attaches metadata to dict-shaped data).
+    """
+    error = {"type": type(exc).__name__, "message": str(exc)}
+    if span.data is None:
+        span.data = {}
+    if isinstance(span.data, dict):
+        span.data[SPAN_ERROR_KEY] = error
+
+
+def get_span_error(span: Span) -> dict[str, Any] | None:
+    """Return the error recorded by :func:`set_span_error`, or ``None``."""
+    if isinstance(span.data, dict):
+        value = span.data.get(SPAN_ERROR_KEY)
+        if isinstance(value, dict):
+            return value
+    return None

--- a/src/agentex/lib/core/tracing/trace.py
+++ b/src/agentex/lib/core/tracing/trace.py
@@ -11,6 +11,7 @@ from agentex import Agentex, AsyncAgentex
 from agentex.types.span import Span
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.utils.model_utils import recursive_model_dump
+from agentex.lib.core.tracing.span_error import set_span_error
 from agentex.lib.core.tracing.span_queue import (
     SpanEventType,
     AsyncSpanQueue,
@@ -165,6 +166,9 @@ class Trace:
         span = self.start_span(name, parent_id, input, data, task_id=task_id)
         try:
             yield span
+        except Exception as exc:
+            set_span_error(span, exc)
+            raise
         finally:
             self.end_span(span)
 
@@ -321,5 +325,8 @@ class AsyncTrace:
         span = await self.start_span(name, parent_id, input, data, task_id=task_id)
         try:
             yield span
+        except Exception as exc:
+            set_span_error(span, exc)
+            raise
         finally:
             await self.end_span(span)

--- a/tests/lib/core/tracing/test_span_error.py
+++ b/tests/lib/core/tracing/test_span_error.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentex.types.span import Span
+from agentex.lib.core.tracing.trace import Trace, AsyncTrace
+from agentex.lib.core.tracing.span_error import (
+    SPAN_ERROR_KEY,
+    get_span_error,
+    set_span_error,
+)
+
+PROCESSOR_MODULE = "agentex.lib.core.tracing.processors.sgp_tracing_processor"
+
+
+def _make_span(data=None) -> Span:
+    return Span(
+        id=str(uuid.uuid4()),
+        name="test-span",
+        start_time=datetime.now(UTC),
+        trace_id="trace-1",
+        data=data,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers: set_span_error / get_span_error
+# ---------------------------------------------------------------------------
+
+
+class TestSpanErrorHelpers:
+    def test_set_then_get_on_none_data(self):
+        span = _make_span(data=None)
+        set_span_error(span, ValueError("boom"))
+        assert get_span_error(span) == {"type": "ValueError", "message": "boom"}
+        assert isinstance(span.data, dict)
+        assert span.data[SPAN_ERROR_KEY] == {"type": "ValueError", "message": "boom"}
+
+    def test_set_preserves_existing_dict_keys(self):
+        span = _make_span(data={"__span_type__": "LLM"})
+        set_span_error(span, RuntimeError("nope"))
+        assert isinstance(span.data, dict)
+        assert span.data["__span_type__"] == "LLM"
+        err = get_span_error(span)
+        assert err is not None
+        assert err["type"] == "RuntimeError"
+
+    def test_get_returns_none_when_no_error(self):
+        assert get_span_error(_make_span(data={"foo": "bar"})) is None
+        assert get_span_error(_make_span(data=None)) is None
+
+    def test_set_is_noop_on_list_data(self):
+        span = _make_span(data=[{"a": 1}])
+        set_span_error(span, ValueError("boom"))
+        # list-shaped data is left untouched (mirrors _add_source_to_span)
+        assert span.data == [{"a": 1}]
+        assert get_span_error(span) is None
+
+
+# ---------------------------------------------------------------------------
+# Capture: the context managers record body exceptions onto the span
+# ---------------------------------------------------------------------------
+
+
+class TestContextManagerCapture:
+    def test_sync_span_records_error_and_reraises(self):
+        trace = Trace(processors=[], client=MagicMock(), trace_id="t1")
+        captured = {}
+        with pytest.raises(ValueError, match="boom"):
+            with trace.span("op") as span:
+                captured["span"] = span
+                raise ValueError("boom")
+        err = get_span_error(captured["span"])
+        assert err == {"type": "ValueError", "message": "boom"}
+
+    def test_sync_span_success_has_no_error(self):
+        trace = Trace(processors=[], client=MagicMock(), trace_id="t1")
+        with trace.span("op") as span:
+            pass
+        assert get_span_error(span) is None
+
+    @pytest.mark.asyncio
+    async def test_async_span_records_error_and_reraises(self):
+        trace = AsyncTrace(processors=[], client=MagicMock(), trace_id="t1")
+        captured = {}
+        with pytest.raises(RuntimeError, match="kaboom"):
+            async with trace.span("op") as span:
+                captured["span"] = span
+                raise RuntimeError("kaboom")
+        err = get_span_error(captured["span"])
+        assert err == {"type": "RuntimeError", "message": "kaboom"}
+
+
+# ---------------------------------------------------------------------------
+# Map: _build_sgp_span translates the recorded error into SGP status=ERROR
+# ---------------------------------------------------------------------------
+
+
+class _FakeSGPSpan:
+    def __init__(self, metadata: dict[str, Any] | None) -> None:
+        self.status = "SUCCESS"
+        self.metadata: dict[str, Any] = metadata if metadata is not None else {}
+        self.start_time = None
+
+    def set_error(
+        self,
+        error_type: str | None = None,
+        error_message: str | None = None,
+        exception: BaseException | None = None,
+    ) -> None:
+        self.status = "ERROR"
+        self.metadata["error"] = True
+        self.metadata["error_type"] = error_type
+        self.metadata["error_message"] = error_message
+
+
+def _fake_create_span(**kwargs: Any) -> _FakeSGPSpan:
+    return _FakeSGPSpan(kwargs.get("metadata"))
+
+
+class TestBuildSGPSpanMapping:
+    @staticmethod
+    def _env():
+        return MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None)
+
+    def test_error_maps_to_status_error(self):
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _build_sgp_span
+
+        span = _make_span(data={SPAN_ERROR_KEY: {"type": "ValueError", "message": "boom"}})
+        with patch(f"{PROCESSOR_MODULE}.create_span", side_effect=_fake_create_span):
+            sgp_span = _build_sgp_span(span, self._env())
+
+        assert sgp_span.status == "ERROR"
+        assert sgp_span.metadata["error"] is True
+        assert sgp_span.metadata["error_type"] == "ValueError"
+        assert sgp_span.metadata["error_message"] == "boom"
+
+    def test_no_error_leaves_status_success(self):
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _build_sgp_span
+
+        span = _make_span(data={"__span_type__": "LLM"})
+        with patch(f"{PROCESSOR_MODULE}.create_span", side_effect=_fake_create_span):
+            sgp_span = _build_sgp_span(span, self._env())
+
+        assert sgp_span.status == "SUCCESS"
+        assert "error" not in sgp_span.metadata


### PR DESCRIPTION
## Problem

Spans exported to SGP always show `status=SUCCESS`, even when the operation they represent failed.

Root cause, in three parts:
- The SGP span (`scale_gp_beta`) defaults `status="SUCCESS"` and only flips to `"ERROR"` inside its own `__exit__` context manager. The agentex processor builds SGP spans via `create_span(...)` and flushes them directly, so `__exit__` never runs.
- The agentex `Span` type (generated from the OpenAPI spec) has no `status`/`error` field.
- `Trace.span()` / `AsyncTrace.span()` ended spans in a bare `finally`, so a body exception was never recorded before the span was flushed.

Net effect: a failing operation is indistinguishable from a successful one in SGP.

## Fix (SDK-only, no schema/backend change)

Capture → carry → map:

1. **Capture** — both context managers now `except Exception as exc: set_span_error(span, exc); raise`.
2. **Carry** — `span_error.py` stores the failure under the reserved `span.data["__error__"]` key, following the existing `__span_type__`/`__source__` convention. `data` is a real field, so it survives `model_copy(deep=True)` and round-trips to both the SGP and agentex-native stores. (A first-class `status`/`error` field would require the OpenAPI → Stainless → backend → migration chain; this achieves the same SGP outcome without it.)
3. **Map** — `_build_sgp_span()` sets `sgp_span.status = "ERROR"` + `error`/`error.type`/`error.message` metadata when an error is present, matching SGP's native `__exit__` shape.

Exceptions still propagate unchanged. `asyncio.CancelledError` / `KeyboardInterrupt` are intentionally not flagged (control flow, not failures) — broaden the `except` to `BaseException` if that changes.

## Tests

`tests/lib/core/tracing/test_span_error.py`:
- `set_span_error`/`get_span_error` helpers (incl. list-shaped `data` no-op).
- Sync + async context managers record the error and re-raise; success path stays clean.
- `_build_sgp_span` maps error → `status=ERROR` + metadata; no-error path stays `SUCCESS`.

`ruff check` clean; new + existing tracing tests pass (40 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where all spans exported to SGP always showed `status=SUCCESS`, even when the operation they represented failed. The root cause was that the agentex processor builds SGP spans via `create_span` and flushes them directly, bypassing the `__exit__` context manager that normally flips status to ERROR.

- **New `span_error.py` module** — introduces `set_span_error`/`get_span_error` helpers that store exception info under the reserved `span.data["__error__"]` key, following the existing `__span_type__`/`__source__` convention. Handles `None`, `dict`, and `list`-shaped `data` correctly.
- **`trace.py`** — both `Trace.span()` and `AsyncTrace.span()` now catch `Exception`, record it on the span via `set_span_error`, then re-raise before the `finally` block flushes the span; `asyncio.CancelledError`/`KeyboardInterrupt` are intentionally excluded.
- **`sgp_tracing_processor.py`** — `_build_sgp_span` calls `get_span_error` after building the span and invokes `sgp_span.set_error(error_type, error_message)` to set `status="ERROR"` on the SGP side, matching SGP's native `__exit__` shape.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change only touches the tracing layer, exceptions always re-propagate unchanged, and the success path is unaffected.

The fix is well-scoped: error capture happens before the span is flushed, the __error__ key survives model_copy(deep=True) and recursive_model_dump, and the SGP status mapping is exercised by both the new unit tests and the existing tracing test suite (40 pass). No mutation of span identity fields, no change to public API surfaces, and no risk to callers that don't catch exceptions themselves.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/span_error.py | New module introducing set_span_error/get_span_error helpers that store exception info in span.data["__error__"]; correctly handles None/list/dict data shapes and follows the existing reserved-key convention. |
| src/agentex/lib/core/tracing/trace.py | Adds except Exception as exc: set_span_error(span, exc); raise before the existing finally in both Trace.span() and AsyncTrace.span(), ensuring errors are captured before end_span flushes the span; no-op path unchanged. |
| src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py | Reads error from span.data via get_span_error and calls sgp_span.set_error(error_type, error_message) to flip the SGP span status to ERROR; the __error__ key is also forwarded raw in metadata=span.data, resulting in slight redundancy but no incorrect behaviour. |
| tests/lib/core/tracing/test_span_error.py | Good coverage of helpers, sync/async context managers, and SGP span mapping; async success path (no error) is not explicitly tested but the logic is symmetric with the sync success test. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UC as User Code
    participant CM as Trace.span() / AsyncTrace.span()
    participant SE as span_error.py
    participant ES as end_span()
    participant SGP as _build_sgp_span()

    UC->>CM: enter context manager
    CM->>CM: start_span()
    CM-->>UC: yield span

    alt Exception raised in body
        UC-->>CM: raise Exception
        CM->>SE: set_span_error(span, exc)
        Note over SE: span.data["__error__"] = {type, message}
        CM->>CM: re-raise
        CM->>ES: finally: end_span(span)
        ES->>SGP: on_span_end(span)
        SGP->>SE: get_span_error(span)
        SE-->>SGP: "{type, message}"
        SGP->>SGP: sgp_span.set_error(error_type, error_message)
        Note over SGP: sgp_span.status = ERROR
        SGP->>SGP: sgp_span.flush()
    else Success
        UC-->>CM: normal return
        CM->>ES: finally: end_span(span)
        ES->>SGP: on_span_end(span)
        SGP->>SE: get_span_error(span) returns None
        Note over SGP: sgp_span.status stays SUCCESS
        SGP->>SGP: sgp_span.flush()
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UC as User Code
    participant CM as Trace.span() / AsyncTrace.span()
    participant SE as span_error.py
    participant ES as end_span()
    participant SGP as _build_sgp_span()

    UC->>CM: enter context manager
    CM->>CM: start_span()
    CM-->>UC: yield span

    alt Exception raised in body
        UC-->>CM: raise Exception
        CM->>SE: set_span_error(span, exc)
        Note over SE: span.data["__error__"] = {type, message}
        CM->>CM: re-raise
        CM->>ES: finally: end_span(span)
        ES->>SGP: on_span_end(span)
        SGP->>SE: get_span_error(span)
        SE-->>SGP: "{type, message}"
        SGP->>SGP: sgp_span.set_error(error_type, error_message)
        Note over SGP: sgp_span.status = ERROR
        SGP->>SGP: sgp_span.flush()
    else Success
        UC-->>CM: normal return
        CM->>ES: finally: end_span(span)
        ES->>SGP: on_span_end(span)
        SGP->>SE: get_span_error(span) returns None
        Note over SGP: sgp_span.status stays SUCCESS
        SGP->>SGP: sgp_span.flush()
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(tracing): capture span body exceptio..."](https://github.com/scaleapi/scale-agentex-python/commit/3f6fb40b6915467363aedd0a206f3b47c7a59964) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43342603)</sub>

<!-- /greptile_comment -->