### PR TITLE
feat(tracing): correlate business spans with active observability trace

### DIFF
--- a/src/agentex/lib/core/tracing/obs_ids.py
+++ b/src/agentex/lib/core/tracing/obs_ids.py
@@ -1,0 +1,83 @@
+"""Correlate adk business spans with the active observability trace.
+
+The adk business ``trace_id`` is the agent **task id** (run-level: it spans the
+whole agent run across many requests -- task/create, then each message/send turn),
+so we must NOT overwrite it with a per-request observability trace_id. Doing so
+would collapse the run-level grouping.
+
+Instead, each business span is *tagged* with the active observability
+trace_id/span_id (this is the OpenTelemetry "span link" pattern -- correlate
+across trace granularities rather than merging them). You can then pivot from a
+persisted business span to the Tempo/Datadog trace for the turn that produced it,
+while the business trace still groups the entire run by task id.
+
+Source selection follows SGP_OBS_MODE, matching egp-api-backend:
+  - unset / "dd_only": ddtrace context (current stack)
+  - "dual":            OTel/LGTM preferred, ddtrace fallback
+  - "lgtm":            OTel/LGTM only
+
+This never fabricates ids -- if no observability context is active, it returns
+an empty dict and the span is simply not tagged.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Tuple
+
+__all__ = ("get_obs_mode", "obs_correlation")
+
+DD_ONLY = "dd_only"
+DUAL = "dual"
+LGTM = "lgtm"
+_DEFAULT_MODE = DD_ONLY
+_VALID_MODES = (DD_ONLY, DUAL, LGTM)
+
+
+def get_obs_mode() -> str:
+    """Unset/empty/unrecognized -> ``dd_only`` (current behavior)."""
+    raw = os.getenv("SGP_OBS_MODE")
+    if not raw:
+        return _DEFAULT_MODE
+    mode = raw.strip().lower()
+    return mode if mode in _VALID_MODES else _DEFAULT_MODE
+
+
+def _lgtm_ids() -> Optional[Tuple[str, str]]:
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return None
+    ctx = trace.get_current_span().get_span_context()
+    if ctx and ctx.is_valid:
+        return format(ctx.trace_id, "032x"), format(ctx.span_id, "016x")
+    return None
+
+
+def _ddtrace_ids() -> Optional[Tuple[str, str]]:
+    try:
+        from ddtrace import tracer
+    except ImportError:
+        return None
+    ctx = tracer.current_trace_context()
+    if ctx and ctx.trace_id:
+        return format(ctx.trace_id, "032x"), format(ctx.span_id or 0, "016x")
+    return None
+
+
+def obs_correlation() -> Dict[str, str]:
+    """Return ``{"obs.trace_id": ..., "obs.span_id": ...}`` for the active
+    observability context, or ``{}`` if none is active.
+
+    Never fabricates ids -- this is a correlation tag, not the span's id.
+    """
+    mode = get_obs_mode()
+    if mode == LGTM:
+        ids = _lgtm_ids()
+    elif mode == DUAL:
+        ids = _lgtm_ids() or _ddtrace_ids()
+    else:  # dd_only
+        ids = _ddtrace_ids()
+
+    if not ids:
+        return {}
+    return {"obs.trace_id": ids[0], "obs.span_id": ids[1]}

--- a/src/agentex/lib/core/tracing/trace.py
+++ b/src/agentex/lib/core/tracing/trace.py
@@ -11,6 +11,7 @@ from agentex import Agentex, AsyncAgentex
 from agentex.types.span import Span
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.utils.model_utils import recursive_model_dump
+from agentex.lib.core.tracing.obs_ids import obs_correlation
 from agentex.lib.core.tracing.span_error import set_span_error
 from agentex.lib.core.tracing.span_queue import (
     SpanEventType,
@@ -79,6 +80,12 @@ class Trace:
 
         serialized_input = recursive_model_dump(input) if input else None
         serialized_data = recursive_model_dump(data) if data else None
+        # Tag the business span with the active observability trace_id/span_id
+        # (OTel/ddtrace) so it can be correlated to the per-turn obs trace. The
+        # business trace_id stays the run-level task id -- see obs_ids.py.
+        obs = obs_correlation()
+        if obs:
+            serialized_data = {**(serialized_data or {}), **obs}
         id = str(uuid.uuid4())
 
         span = Span(
@@ -229,6 +236,12 @@ class AsyncTrace:
 
         serialized_input = recursive_model_dump(input) if input else None
         serialized_data = recursive_model_dump(data) if data else None
+        # Tag the business span with the active observability trace_id/span_id
+        # (OTel/ddtrace) so it can be correlated to the per-turn obs trace. The
+        # business trace_id stays the run-level task id -- see obs_ids.py.
+        obs = obs_correlation()
+        if obs:
+            serialized_data = {**(serialized_data or {}), **obs}
         id = str(uuid.uuid4())
 
         span = Span(


### PR DESCRIPTION
## Stack (1/3)
1. **feat(tracing): correlate business spans with active observability trace** ← this PR
2. feat(tracing): establish W3C trace context at FastACP ingress
3. feat(tracing): propagate trace context into Temporal via OTel interceptor

## What this PR does
Tags each adk business span, **at creation time**, with the active observability `trace_id`/`span_id` (OpenTelemetry preferred, ddtrace fallback), so a persisted span can be pivoted to its per-turn Tempo/Datadog trace.

- New `core/tracing/obs_ids.py`: `get_obs_mode()` (reads `SGP_OBS_MODE`; unset/empty/unrecognized → `dd_only`) and `obs_correlation()` returning `{"obs.trace_id", "obs.span_id"}` for the active obs context, or `{}` if none.
- `core/tracing/trace.py`: both `start_span` (sync + async) merge `obs_correlation()` into the span's `data`.

## Design notes
- **Business `trace_id` is unchanged** — it stays the run-level task id. We use the OTel *span-link* pattern (correlate across granularities) instead of overwriting the trace_id, which would shatter one agent run across N per-request obs traces.
- **Emit-time capture, never at ingest.** Correlation is taken from the context active when the span is created, so batched `/v5/spans/batch` flushing cannot mis-group spans.
- **Safe no-op by default.** `SGP_OBS_MODE` unset → `dd_only`; returns no tag when no obs context is active. Behavior only changes once an obs context exists (see PRs 2 & 3).

## Verification
`py_compile` + unit smoke: default mode `dd_only`, empty dict when no active context, correct id widths (32-hex / 16-hex).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces obs-correlation tagging: at span creation time, each business span is stamped with the active observability `trace_id`/`span_id` (OTel preferred, ddtrace fallback) so a persisted span can be pivoted to its per-turn Tempo/Datadog trace without overwriting the run-level business `trace_id`.

- **`obs_ids.py`** (new): `get_obs_mode()` reads `SGP_OBS_MODE` (default `dd_only`) and `obs_correlation()` returns `{\"obs.trace_id\", \"obs.span_id\"}` or `{}` when no context is active.
- **`trace.py`**: Both `Trace.start_span` and `AsyncTrace.start_span` now merge `obs_correlation()` into `serialized_data` at emission time, ensuring the correct per-request context is captured rather than waiting for batch flush.
- **CI**: Runner condition broadened from an exact repo-name match to a `startsWith('stainless-sdks/')` prefix check.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The obs-correlation logic runs in the hot path of every span creation; an unhandled exception from ddtrace or OTel would silently crash all span creation for that agent run.

Two issues in obs_ids.py directly affect span creation reliability: the narrow except ImportError leaves runtime errors from ddtrace/OTel unhandled, and the span_id or 0 null-sentinel path (flagged in a prior thread). Both live in the critical start_span path shared by every caller of Trace and AsyncTrace.

src/agentex/lib/core/tracing/obs_ids.py and src/agentex/lib/core/tracing/trace.py need attention before merge.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/obs_ids.py | New correlation helper — correctly handles ImportError and OTel is_valid checks, but exception handling is too narrow: any runtime error from ddtrace/OTel propagates into start_span. Also emits the OTel null-sentinel span_id (already flagged in a previous thread). |
| src/agentex/lib/core/tracing/trace.py | Merges obs_correlation() into serialized_data at span creation. The dict-unpack pattern crashes with TypeError when data is list[dict] (already flagged in previous thread); otherwise the logic is sound. |
| .github/workflows/ci.yml | Runner condition broadened from an exact repo-name match to startsWith('stainless-sdks/'), allowing the depot runner for any fork under that org prefix. Change is intentional and safe. |
| .stats.yml | Auto-generated openapi spec URL and hash update — no logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant Trace/AsyncTrace
    participant obs_ids
    participant OTel/ddtrace

    Caller->>Trace/AsyncTrace: "start_span(name, data=...)"
    Trace/AsyncTrace->>obs_ids: obs_correlation()
    obs_ids->>obs_ids: get_obs_mode() reads SGP_OBS_MODE
    alt "mode == lgtm"
        obs_ids->>OTel/ddtrace: _lgtm_ids() get_current_span()
    else "mode == dual"
        obs_ids->>OTel/ddtrace: _lgtm_ids() or _ddtrace_ids()
    else "mode == dd_only default"
        obs_ids->>OTel/ddtrace: _ddtrace_ids() current_trace_context()
    end
    OTel/ddtrace-->>obs_ids: (trace_id, span_id) or None
    obs_ids-->>Trace/AsyncTrace: obs.trace_id and obs.span_id or empty dict
    Trace/AsyncTrace->>Trace/AsyncTrace: merge obs into serialized_data
    Trace/AsyncTrace->>Trace/AsyncTrace: create Span with merged data
    Trace/AsyncTrace-->>Caller: Span
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant Trace/AsyncTrace
    participant obs_ids
    participant OTel/ddtrace

    Caller->>Trace/AsyncTrace: "start_span(name, data=...)"
    Trace/AsyncTrace->>obs_ids: obs_correlation()
    obs_ids->>obs_ids: get_obs_mode() reads SGP_OBS_MODE
    alt "mode == lgtm"
        obs_ids->>OTel/ddtrace: _lgtm_ids() get_current_span()
    else "mode == dual"
        obs_ids->>OTel/ddtrace: _lgtm_ids() or _ddtrace_ids()
    else "mode == dd_only default"
        obs_ids->>OTel/ddtrace: _ddtrace_ids() current_trace_context()
    end
    OTel/ddtrace-->>obs_ids: (trace_id, span_id) or None
    obs_ids-->>Trace/AsyncTrace: obs.trace_id and obs.span_id or empty dict
    Trace/AsyncTrace->>Trace/AsyncTrace: merge obs into serialized_data
    Trace/AsyncTrace->>Trace/AsyncTrace: create Span with merged data
    Trace/AsyncTrace-->>Caller: Span
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(tracing): correlate business spans ..."](https://github.com/scaleapi/scale-agentex-python/commit/cd91ba78185af365bc4ed98d68475b216de1a861) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46082434)</sub>

<!-- /greptile_comment -->