### PR TITLE
feat(tracing): establish W3C trace context at FastACP ingress

### DIFF
--- a/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
+++ b/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
@@ -46,6 +46,41 @@ logger = make_logger(__name__)
 task_message_update_adapter = TypeAdapter(TaskMessageUpdate)
 
 
+def _attach_incoming_trace_context(scope: Scope) -> Any:
+    """Extract the W3C trace context (traceparent/tracestate) from the inbound
+    request headers and attach it as the current OpenTelemetry context, so spans
+    created while handling this request adopt the caller's observability trace.
+
+    Returns a detach token (pass to opentelemetry.context.detach) or None if OTel
+    is unavailable or no context could be established. Best-effort: never raises.
+    """
+    try:
+        from opentelemetry import context as otel_context
+        from opentelemetry.propagate import extract
+    except ImportError:
+        return None
+    try:
+        carrier = {
+            k.decode("latin-1"): v.decode("latin-1")
+            for k, v in scope.get("headers", [])
+        }
+        ctx = extract(carrier)
+        return otel_context.attach(ctx)
+    except Exception:  # pragma: no cover - propagation must never break a request
+        return None
+
+
+def _detach_trace_context(token: Any) -> None:
+    if token is None:
+        return
+    try:
+        from opentelemetry import context as otel_context
+
+        otel_context.detach(token)
+    except Exception:  # pragma: no cover
+        pass
+
+
 class RequestIDMiddleware:
     """Pure ASGI middleware to set request IDs without buffering streaming responses."""
 
@@ -53,12 +88,23 @@ class RequestIDMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "http":
-            headers = dict(scope.get("headers", []))
-            raw_request_id = headers.get(b"x-request-id", b"")
-            request_id = raw_request_id.decode() if raw_request_id else uuid.uuid4().hex
-            ctx_var_request_id.set(request_id)
-        await self.app(scope, receive, send)
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        raw_request_id = headers.get(b"x-request-id", b"")
+        request_id = raw_request_id.decode() if raw_request_id else uuid.uuid4().hex
+        ctx_var_request_id.set(request_id)
+
+        # Establish the caller's W3C trace context for the duration of the
+        # request so business spans created here (and any downstream Temporal
+        # workflow started from this request) share the same observability trace.
+        token = _attach_incoming_trace_context(scope)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _detach_trace_context(token)
 
 
 class BaseACPServer(FastAPI):


### PR DESCRIPTION
## Stack (2/3)
1. feat(tracing): correlate business spans with active observability trace (#465)
2. **feat(tracing): establish W3C trace context at FastACP ingress** ← this PR
3. feat(tracing): propagate trace context into Temporal via OTel interceptor

> Based on `obs/01-span-obs-correlation`. Review/merge after #465.

## What this PR does
Extends `RequestIDMiddleware` in `base_acp_server.py` to extract the inbound **W3C trace context** (`traceparent`/`tracestate`) and attach it as the current OpenTelemetry context for the lifetime of the request.

This gives `obs_correlation()` (PR 1) a real **emit-time** context: business spans created while handling an RPC — and any Temporal workflow started from that request (PR 3) — now adopt the caller's observability `trace_id`.

## Why it's needed
PR 1 only *reads* the active obs context; without this, there is no context to read on the ACP request path (the SGP `/v5/spans/batch` transport doesn't carry it). This is the client-side propagation half.

## Safety
Best-effort and lazy-imported: no `traceparent` header, or OTel unavailable, is a safe no-op and never breaks a request. Context is detached in a `finally`.

## Verification
`py_compile` + functional smoke: a `traceparent` header yields a valid current span context with the expected `trace_id`; no header → invalid context (no-op).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `RequestIDMiddleware` in `base_acp_server.py` to extract the inbound W3C trace context (`traceparent`/`tracestate`) and attach it as the active OpenTelemetry context for the lifetime of each HTTP request, enabling downstream business spans and Temporal workflows to share the caller's observability trace ID.

- Two small helper functions (`_attach_incoming_trace_context`, `_detach_trace_context`) are added; both are best-effort with lazy OTel imports so a missing `opentelemetry` package or a missing header is always a safe no-op.
- `RequestIDMiddleware.__call__` is refactored from a guard-and-fall-through pattern to an early-return for non-HTTP scope types, and the trace context attach/detach is wrapped in a `try/finally` block alongside the existing request-ID logic.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is additive, never raises, and the existing request-handling path is functionally unchanged in the absence of OTel.

The attach/detach lifecycle is correct and properly guarded with try/finally; asyncio.create_task inherits the contextvars copy at creation time so background tasks correctly retain the trace context. The one imprecision is the plain-dict carrier that silently drops all but the last value when a caller forwards multiple tracestate headers, which is spec-legal but uncommon in practice.

base_acp_server.py — the multi-value tracestate edge case in _attach_incoming_trace_context is the only area that warrants a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/sdk/fastacp/base/base_acp_server.py | Extends RequestIDMiddleware to extract and attach W3C trace context (traceparent/tracestate) from inbound ASGI headers using lazy OTel imports and a try/finally detach; one edge case where duplicate tracestate headers are silently collapsed by the plain-dict carrier. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as Caller (SGP/upstream)
    participant MW as RequestIDMiddleware
    participant OTel as OpenTelemetry
    participant App as FastAPI App
    participant BG as Background Task

    Caller->>MW: HTTP Request (traceparent header)
    MW->>MW: Extract x-request-id → ctx_var_request_id.set()
    MW->>OTel: extract(carrier) → W3C context
    OTel-->>MW: ctx (with trace_id from traceparent)
    MW->>OTel: context.attach(ctx) → token
    MW->>App: await self.app(scope, receive, send)
    App->>App: asyncio.create_task(_process_request) copies current context
    App-->>MW: response sent
    BG->>BG: runs with copied context (trace_id still active)
    MW->>OTel: context.detach(token) [finally]
    Note over MW,OTel: original context restored
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as Caller (SGP/upstream)
    participant MW as RequestIDMiddleware
    participant OTel as OpenTelemetry
    participant App as FastAPI App
    participant BG as Background Task

    Caller->>MW: HTTP Request (traceparent header)
    MW->>MW: Extract x-request-id → ctx_var_request_id.set()
    MW->>OTel: extract(carrier) → W3C context
    OTel-->>MW: ctx (with trace_id from traceparent)
    MW->>OTel: context.attach(ctx) → token
    MW->>App: await self.app(scope, receive, send)
    App->>App: asyncio.create_task(_process_request) copies current context
    App-->>MW: response sent
    BG->>BG: runs with copied context (trace_id still active)
    MW->>OTel: context.detach(token) [finally]
    Note over MW,OTel: original context restored
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%3A62-67%0A**Duplicate%20%60tracestate%60%20headers%20silently%20dropped**%0A%0AThe%20plain-dict%20carrier%20overwrites%20duplicate%20keys%2C%20so%20if%20an%20intermediary%20forwards%20multiple%20%60tracestate%60%20headers%20%28which%20the%20W3C%20Trace%20Context%20spec%20explicitly%20permits%29%2C%20all%20but%20the%20last%20entry%20are%20silently%20discarded.%20The%20OTel%20%60DefaultGetter%60%20calls%20%60carrier.get%28key%29%60%20on%20a%20plain%20dict%2C%20which%20can%20only%20return%20a%20single%20string%20value%2C%20so%20combined%20trace-state%20from%20several%20systems%20in%20the%20propagation%20chain%20would%20be%20partially%20lost.%0A%0ATo%20handle%20multi-value%20headers%20correctly%2C%20the%20carrier%20should%20concatenate%20repeated%20values%20with%20a%20comma%20separator%20before%20inserting%20them%20into%20the%20dict%2C%20or%20use%20a%20multi-value%20mapping%20with%20a%20custom%20%60Getter%60.%0A%0A&pr=466&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%3A62-67%0A**Duplicate%20%60tracestate%60%20headers%20silently%20dropped**%0A%0AThe%20plain-dict%20carrier%20overwrites%20duplicate%20keys%2C%20so%20if%20an%20intermediary%20forwards%20multiple%20%60tracestate%60%20headers%20%28which%20the%20W3C%20Trace%20Context%20spec%20explicitly%20permits%29%2C%20all%20but%20the%20last%20entry%20are%20silently%20discarded.%20The%20OTel%20%60DefaultGetter%60%20calls%20%60carrier.get%28key%29%60%20on%20a%20plain%20dict%2C%20which%20can%20only%20return%20a%20single%20string%20value%2C%20so%20combined%20trace-state%20from%20several%20systems%20in%20the%20propagation%20chain%20would%20be%20partially%20lost.%0A%0ATo%20handle%20multi-value%20headers%20correctly%2C%20the%20carrier%20should%20concatenate%20repeated%20values%20with%20a%20comma%20separator%20before%20inserting%20them%20into%20the%20dict%2C%20or%20use%20a%20multi-value%20mapping%20with%20a%20custom%20%60Getter%60.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=466&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22obs%2F02-fastacp-w3c-ingress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22obs%2F02-fastacp-w3c-ingress%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%3A62-67%0A**Duplicate%20%60tracestate%60%20headers%20silently%20dropped**%0A%0AThe%20plain-dict%20carrier%20overwrites%20duplicate%20keys%2C%20so%20if%20an%20intermediary%20forwards%20multiple%20%60tracestate%60%20headers%20%28which%20the%20W3C%20Trace%20Context%20spec%20explicitly%20permits%29%2C%20all%20but%20the%20last%20entry%20are%20silently%20discarded.%20The%20OTel%20%60DefaultGetter%60%20calls%20%60carrier.get%28key%29%60%20on%20a%20plain%20dict%2C%20which%20can%20only%20return%20a%20single%20string%20value%2C%20so%20combined%20trace-state%20from%20several%20systems%20in%20the%20propagation%20chain%20would%20be%20partially%20lost.%0A%0ATo%20handle%20multi-value%20headers%20correctly%2C%20the%20carrier%20should%20concatenate%20repeated%20values%20with%20a%20comma%20separator%20before%20inserting%20them%20into%20the%20dict%2C%20or%20use%20a%20multi-value%20mapping%20with%20a%20custom%20%60Getter%60.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=466&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/agentex/lib/sdk/fastacp/base/base_acp_server.py:62-67
**Duplicate `tracestate` headers silently dropped**

The plain-dict carrier overwrites duplicate keys, so if an intermediary forwards multiple `tracestate` headers (which the W3C Trace Context spec explicitly permits), all but the last entry are silently discarded. The OTel `DefaultGetter` calls `carrier.get(key)` on a plain dict, which can only return a single string value, so combined trace-state from several systems in the propagation chain would be partially lost.

To handle multi-value headers correctly, the carrier should concatenate repeated values with a comma separator before inserting them into the dict, or use a multi-value mapping with a custom `Getter`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tracing): establish W3C trace conte..."](https://github.com/scaleapi/scale-agentex-python/commit/24f083575b495bb11d19c81a88be766f9c4c60b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46082559)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->