### PR TITLE
feat(tracing): propagate trace context into Temporal via OTel interceptor

### DIFF
--- a/src/agentex/lib/core/clients/temporal/utils.py
+++ b/src/agentex/lib/core/clients/temporal/utils.py
@@ -81,6 +81,26 @@ def validate_worker_interceptors(interceptors: list[Any]) -> None:
             )
 
 
+def _build_otel_interceptors() -> list:
+    """Return an OpenTelemetry Temporal interceptor when an OTel observability
+    mode is active (SGP_OBS_MODE in {dual, lgtm}), so trace context propagates
+    across the workflow -> activity boundary. This lets business spans created
+    inside the model-loop activity adopt the caller's observability trace_id.
+
+    Empty in the default dd_only mode, or when the temporalio OTel contrib is
+    unavailable (safe no-op).
+    """
+    import os
+
+    if os.getenv("SGP_OBS_MODE", "").strip().lower() not in ("dual", "lgtm"):
+        return []
+    try:
+        from temporalio.contrib.opentelemetry import TracingInterceptor
+    except ImportError:
+        return []
+    return [TracingInterceptor()]
+
+
 async def get_temporal_client(
     temporal_address: str,
     metrics_url: str | None = None,
@@ -145,6 +165,10 @@ async def get_temporal_client(
         if payload_codec:
             dc = dataclasses.replace(dc, payload_codec=payload_codec)
         connect_kwargs["data_converter"] = dc
+
+    otel_interceptors = _build_otel_interceptors()
+    if otel_interceptors:
+        connect_kwargs["interceptors"] = otel_interceptors
 
     if not metrics_url:
         client = await Client.connect(**connect_kwargs)

--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -91,6 +91,24 @@ def _validate_interceptors(interceptors: list) -> None:
             )
 
 
+def _build_otel_interceptors() -> list:
+    """Return an OpenTelemetry Temporal interceptor when an OTel observability
+    mode is active (SGP_OBS_MODE in {dual, lgtm}), so trace context propagates
+    across the workflow -> activity boundary. This lets business spans created
+    inside the model-loop activity adopt the caller's observability trace_id.
+
+    Empty in the default dd_only mode, or when the temporalio OTel contrib is
+    unavailable (safe no-op).
+    """
+    if os.getenv("SGP_OBS_MODE", "").strip().lower() not in ("dual", "lgtm"):
+        return []
+    try:
+        from temporalio.contrib.opentelemetry import TracingInterceptor
+    except ImportError:
+        return []
+    return [TracingInterceptor()]
+
+
 async def get_temporal_client(
     temporal_address: str,
     metrics_url: str | None = None,
@@ -135,6 +153,10 @@ async def get_temporal_client(
         if payload_codec:
             dc = dataclasses.replace(dc, payload_codec=payload_codec)
         connect_kwargs["data_converter"] = dc
+
+    otel_interceptors = _build_otel_interceptors()
+    if otel_interceptors:
+        connect_kwargs["interceptors"] = otel_interceptors
 
     if not metrics_url:
         client = await Client.connect(**connect_kwargs)


### PR DESCRIPTION
## Stack (3/3)
1. feat(tracing): correlate business spans with active observability trace (#465)
2. feat(tracing): establish W3C trace context at FastACP ingress
3. **feat(tracing): propagate trace context into Temporal via OTel interceptor** ← this PR

> Based on `obs/02-fastacp-w3c-ingress`. Review/merge after PR 2.

## What this PR does
Attaches `temporalio.contrib.opentelemetry.TracingInterceptor` to the Temporal client (both `get_temporal_client` entrypoints — `workers/worker.py` and `clients/temporal/utils.py`) when an OTel observability mode is active (`SGP_OBS_MODE` in `{dual, lgtm}`).

This threads the caller's W3C trace context (established at ingress in PR 2) across the **workflow → activity** boundary, so business spans created inside the model-loop activity see an active observability context and get tagged with its `trace_id` via `obs_correlation()` (PR 1).

## Why it's needed
The agent model loop runs in Temporal activities. Without context propagation there is no active obs context inside the activity, so `obs_correlation()` would return `{}` for the very spans we most want to correlate (invoke_agent / plan / execute_tool / chat).

## Safety
Gated on `SGP_OBS_MODE in {dual, lgtm}` and lazy-imported — the default `dd_only` mode adds no interceptor, so this is a no-op unless opted in.

## Verification
`py_compile` + unit smoke on both entrypoints: empty in `dd_only`/unset, `[TracingInterceptor]` in `dual`.

## Not in this stack (follow-ups)
- Configuring an OTel **TracerProvider/OTLP exporter** in the pod (this stack handles context *propagation*; span *export* to Tempo is separate).
- The `egp-api-backend` side (app-graph collector + `CustomJSONFormatter` unified `trace_id`) — tracked separately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attaches `TracingInterceptor` from `temporalio.contrib.opentelemetry` to both Temporal client entrypoints (`clients/temporal/utils.py` and `temporal/workers/worker.py`) so W3C trace context established at FastACP ingress propagates into scheduled workflow calls. The change is gated on `SGP_OBS_MODE in {dual, lgtm}` with a lazy import and ImportError fallback, making it a no-op in the default `dd_only` mode.

- Both files gain an identical `_build_otel_interceptors()` helper that conditionally returns a `[TracingInterceptor()]` list and is wired into `connect_kwargs[\"interceptors\"]` before `Client.connect()`.
- The interceptor attaches at the **client** level (outbound workflow scheduling), but the `Worker` constructor in `AgentexWorker.run()` still receives only `self.interceptors` — it does not include the OTel interceptors, so trace context will not be extracted during inbound activity execution (see previously raised issue).

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the client-side path; the worker-side activity context extraction remains broken until the OTel interceptors are also merged into the Worker constructor.

The _build_otel_interceptors() result is wired into Client.connect() in both entrypoints, correctly propagating trace context for outbound workflow scheduling. However, AgentexWorker.run() builds Worker(interceptors=self.interceptors) without including the OTel interceptors, so the TracingInterceptor is never registered on the worker side. Trace context from incoming workflow execution headers will not be extracted into activities, meaning obs_correlation() inside the model-loop activity will still return {} — the core goal stated in the PR description is not yet achieved.

src/agentex/lib/core/temporal/workers/worker.py — specifically the Worker construction in AgentexWorker.run() which needs to merge _build_otel_interceptors() output with self.interceptors.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/clients/temporal/utils.py | Adds _build_otel_interceptors() and wires it into Client.connect(); correct for the client-only (FastACP scheduler) path where propagating context into outbound workflow starts is the goal. |
| src/agentex/lib/core/temporal/workers/worker.py | Adds _build_otel_interceptors() and wires it into Client.connect() inside get_temporal_client(), but AgentexWorker.run() still constructs Worker(interceptors=self.interceptors) without merging the OTel interceptors — trace context will not be extracted during activity execution, which is the stated goal of this PR. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agentex/lib/core/temporal/workers/worker.py`, line 228-255 ([link](https://github.com/scaleapi/scale-agentex-python/blob/78738ee8a34c6cc80c5664f2d82728b25bdcd166/src/agentex/lib/core/temporal/workers/worker.py#L228-L255)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Worker-side TracingInterceptor never attached**

   `_build_otel_interceptors()` runs inside `get_temporal_client()` and sets `connect_kwargs["interceptors"]`, which lands on `Client.connect()`. That covers outbound calls *from* the client (e.g. scheduling a workflow). However, for the W3C context to be extracted and made active *during activity execution*, `TracingInterceptor` must also be passed to the `Worker` constructor. The current `Worker(interceptors=self.interceptors)` receives only user-provided interceptors — not the OTel ones — so `obs_correlation()` inside activities will still see an empty context, defeating the stated goal of this PR.

   A fix requires `_build_otel_interceptors()` to be called in `AgentexWorker.run()` (in addition to inside `get_temporal_client()`), and its result merged into the `Worker`'s `interceptors` argument alongside `self.interceptors`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/core/temporal/workers/worker.py
   Line: 228-255

   Comment:
   **Worker-side TracingInterceptor never attached**

   `_build_otel_interceptors()` runs inside `get_temporal_client()` and sets `connect_kwargs["interceptors"]`, which lands on `Client.connect()`. That covers outbound calls *from* the client (e.g. scheduling a workflow). However, for the W3C context to be extracted and made active *during activity execution*, `TracingInterceptor` must also be passed to the `Worker` constructor. The current `Worker(interceptors=self.interceptors)` receives only user-provided interceptors — not the OTel ones — so `obs_correlation()` inside activities will still see an empty context, defeating the stated goal of this PR.

   A fix requires `_build_otel_interceptors()` to be called in `AgentexWorker.run()` (in addition to inside `get_temporal_client()`), and its result merged into the `Worker`'s `interceptors` argument alongside `self.interceptors`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fworkers%2Fworker.py%0ALine%3A%20228-255%0A%0AComment%3A%0A**Worker-side%20TracingInterceptor%20never%20attached**%0A%0A%60_build_otel_interceptors%28%29%60%20runs%20inside%20%60get_temporal_client%28%29%60%20and%20sets%20%60connect_kwargs%5B%22interceptors%22%5D%60%2C%20which%20lands%20on%20%60Client.connect%28%29%60.%20That%20covers%20outbound%20calls%20*from*%20the%20client%20%28e.g.%20scheduling%20a%20workflow%29.%20However%2C%20for%20the%20W3C%20context%20to%20be%20extracted%20and%20made%20active%20*during%20activity%20execution*%2C%20%60TracingInterceptor%60%20must%20also%20be%20passed%20to%20the%20%60Worker%60%20constructor.%20The%20current%20%60Worker%28interceptors%3Dself.interceptors%29%60%20receives%20only%20user-provided%20interceptors%20%E2%80%94%20not%20the%20OTel%20ones%20%E2%80%94%20so%20%60obs_correlation%28%29%60%20inside%20activities%20will%20still%20see%20an%20empty%20context%2C%20defeating%20the%20stated%20goal%20of%20this%20PR.%0A%0AA%20fix%20requires%20%60_build_otel_interceptors%28%29%60%20to%20be%20called%20in%20%60AgentexWorker.run%28%29%60%20%28in%20addition%20to%20inside%20%60get_temporal_client%28%29%60%29%2C%20and%20its%20result%20merged%20into%20the%20%60Worker%60's%20%60interceptors%60%20argument%20alongside%20%60self.interceptors%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=467&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fworkers%2Fworker.py%0ALine%3A%20228-255%0A%0AComment%3A%0A**Worker-side%20TracingInterceptor%20never%20attached**%0A%0A%60_build_otel_interceptors%28%29%60%20runs%20inside%20%60get_temporal_client%28%29%60%20and%20sets%20%60connect_kwargs%5B%22interceptors%22%5D%60%2C%20which%20lands%20on%20%60Client.connect%28%29%60.%20That%20covers%20outbound%20calls%20*from*%20the%20client%20%28e.g.%20scheduling%20a%20workflow%29.%20However%2C%20for%20the%20W3C%20context%20to%20be%20extracted%20and%20made%20active%20*during%20activity%20execution*%2C%20%60TracingInterceptor%60%20must%20also%20be%20passed%20to%20the%20%60Worker%60%20constructor.%20The%20current%20%60Worker%28interceptors%3Dself.interceptors%29%60%20receives%20only%20user-provided%20interceptors%20%E2%80%94%20not%20the%20OTel%20ones%20%E2%80%94%20so%20%60obs_correlation%28%29%60%20inside%20activities%20will%20still%20see%20an%20empty%20context%2C%20defeating%20the%20stated%20goal%20of%20this%20PR.%0A%0AA%20fix%20requires%20%60_build_otel_interceptors%28%29%60%20to%20be%20called%20in%20%60AgentexWorker.run%28%29%60%20%28in%20addition%20to%20inside%20%60get_temporal_client%28%29%60%29%2C%20and%20its%20result%20merged%20into%20the%20%60Worker%60's%20%60interceptors%60%20argument%20alongside%20%60self.interceptors%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=467&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22obs%2F03-temporal-otel-interceptor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22obs%2F03-temporal-otel-interceptor%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fworkers%2Fworker.py%0ALine%3A%20228-255%0A%0AComment%3A%0A**Worker-side%20TracingInterceptor%20never%20attached**%0A%0A%60_build_otel_interceptors%28%29%60%20runs%20inside%20%60get_temporal_client%28%29%60%20and%20sets%20%60connect_kwargs%5B%22interceptors%22%5D%60%2C%20which%20lands%20on%20%60Client.connect%28%29%60.%20That%20covers%20outbound%20calls%20*from*%20the%20client%20%28e.g.%20scheduling%20a%20workflow%29.%20However%2C%20for%20the%20W3C%20context%20to%20be%20extracted%20and%20made%20active%20*during%20activity%20execution*%2C%20%60TracingInterceptor%60%20must%20also%20be%20passed%20to%20the%20%60Worker%60%20constructor.%20The%20current%20%60Worker%28interceptors%3Dself.interceptors%29%60%20receives%20only%20user-provided%20interceptors%20%E2%80%94%20not%20the%20OTel%20ones%20%E2%80%94%20so%20%60obs_correlation%28%29%60%20inside%20activities%20will%20still%20see%20an%20empty%20context%2C%20defeating%20the%20stated%20goal%20of%20this%20PR.%0A%0AA%20fix%20requires%20%60_build_otel_interceptors%28%29%60%20to%20be%20called%20in%20%60AgentexWorker.run%28%29%60%20%28in%20addition%20to%20inside%20%60get_temporal_client%28%29%60%29%2C%20and%20its%20result%20merged%20into%20the%20%60Worker%60's%20%60interceptors%60%20argument%20alongside%20%60self.interceptors%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=467&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(tracing): propagate trace context i..."](https://github.com/scaleapi/scale-agentex-python/commit/cbcd20aa4af76baa4410c949212e2515f16d20ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46082570)</sub>

<!-- /greptile_comment -->