### PR TITLE
feat(tracing): make ddtrace adopt the OTel trace id in dual mode

### DIFF
--- a/src/agentex/lib/core/tracing/obs_ids.py
+++ b/src/agentex/lib/core/tracing/obs_ids.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import os
 from typing import Dict, Optional, Tuple
 
-__all__ = ("get_obs_mode", "obs_correlation")
+__all__ = ("get_obs_mode", "obs_correlation", "sync_ddtrace_to_lgtm")
 
 DD_ONLY = "dd_only"
 DUAL = "dual"
@@ -81,3 +81,31 @@ def obs_correlation() -> Dict[str, str]:
     if not ids:
         return {}
     return {"obs.trace_id": ids[0], "obs.span_id": ids[1]}
+
+
+def sync_ddtrace_to_lgtm() -> None:
+    """In ``dual`` mode, make ddtrace adopt the active OpenTelemetry/LGTM trace
+    context so ddtrace-emitted spans (best-effort Datadog) share the SAME
+    trace_id as the OTel trace. Call at request ingress once the OTel span is
+    active, and after any context boundary (e.g. entering a Temporal activity).
+
+    No-op outside ``dual`` mode, or when OTel/ddtrace is unavailable or no OTel
+    span is active. Never raises.
+    """
+    if get_obs_mode() != DUAL:
+        return
+    try:
+        from opentelemetry import trace
+
+        try:
+            from ddtrace.trace import Context  # ddtrace 3.x
+        except ImportError:  # pragma: no cover - older ddtrace layout
+            from ddtrace.context import Context  # type: ignore[no-redef]
+        from ddtrace import tracer
+    except ImportError:
+        return
+
+    sc = trace.get_current_span().get_span_context()
+    if not (sc and sc.is_valid):
+        return
+    tracer.context_provider.activate(Context(trace_id=sc.trace_id, span_id=sc.span_id))

--- a/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
+++ b/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
@@ -33,6 +33,7 @@ from agentex.lib.utils.registration import register_agent
 from agentex.lib.environment_variables import EnvironmentVariables, refreshed_environment_variables
 from agentex.types.task_message_update import TaskMessageUpdate, StreamTaskMessageFull
 from agentex.types.task_message_content import TaskMessageContent
+from agentex.lib.core.tracing.obs_ids import sync_ddtrace_to_lgtm as _sync_ddtrace_to_lgtm
 from agentex.lib.core.tracing.span_queue import shutdown_default_span_queue
 from agentex.lib.core.compat.version_guard import assert_backend_compatible
 from agentex.lib.sdk.fastacp.base.constants import (
@@ -101,6 +102,9 @@ class RequestIDMiddleware:
         # request so business spans created here (and any downstream Temporal
         # workflow started from this request) share the same observability trace.
         token = _attach_incoming_trace_context(scope)
+        # In dual mode, make ddtrace adopt this OTel trace id so its best-effort
+        # Datadog spans share the same trace_id. No-op outside dual mode.
+        _sync_ddtrace_to_lgtm()
         try:
             await self.app(scope, receive, send)
         finally:


### PR DESCRIPTION
## Stack (4/4)
1. correlate business spans with active obs trace (#465)
2. W3C trace context at FastACP ingress (#466)
3. Temporal OTel interceptor (#467)
4. **make ddtrace adopt the OTel trace id in dual mode** ← this PR

> Based on `obs/03`. Review/merge after #467.

## What
Adds `sync_ddtrace_to_lgtm()` — in `SGP_OBS_MODE=dual`, reads the active OpenTelemetry span context and activates a matching ddtrace `Context`, so ddtrace-emitted (best-effort Datadog) spans share the **same `trace_id`** as the OTel/LGTM trace. Called at FastACP ingress right after the W3C context is attached.

## Why
In dual mode we keep ddtrace running for best-effort Datadog but let **OTel own HTTP** (`DD_TRACE_FASTAPI_ENABLED=false` / `DD_TRACE_STARLETTE_ENABLED=false`). Without this, ddtrace's outbound spans start their *own* trace id → the two backends show different ids. This bridges them: OTel is canonical, ddtrace follows.

Mechanism is the explicit context-sync (not `DD_TRACE_OTEL_ENABLED`, which conflicts with the operator-injected OTel SDK). Mirrors the egp-api-backend `sync_ddtrace_to_lgtm()`.

## Safety
- **No-op** outside `dual` mode, or when OTel/ddtrace is unavailable, or no OTel span is active. Never raises.
- 128-bit alignment assumed (`DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=true`) so ids match.

## Verify
`py_compile` + smoke: no-op in `lgtm`/`dd_only`, and in `dual` with no active OTel span (safe fallback).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `sync_ddtrace_to_lgtm()` to bridge OTel and ddtrace in `dual` mode: at FastACP ingress, after the W3C trace context is attached, the active OTel span's `trace_id`/`span_id` are propagated into a ddtrace `Context` so both backends share the same trace identifier.

- **`obs_ids.py`**: New `sync_ddtrace_to_lgtm()` — guards on mode, handles ddtrace 2.x/3.x import paths, checks span validity, and activates the ddtrace context. All error paths return early without raising.
- **`base_acp_server.py`**: One-line call in `RequestIDMiddleware.__call__` immediately after `_attach_incoming_trace_context`, before `await self.app(...)`. The OTel context uses a token/detach cleanup but the ddtrace context has no corresponding cleanup, creating an asymmetry that can leak across HTTP/1.1 keep-alive requests on the same connection.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The ddtrace context activated in the middleware is never cleaned up, so a stale trace id from one request can bleed into the next request on the same keep-alive connection if that subsequent request carries no OTel context.

The context-sync logic itself is sound and the no-op guards are correct, but the missing ddtrace context reset in the `finally` block creates a real cross-request contamination path. The OTel side correctly uses a token/detach pattern; the ddtrace side needs the same treatment before this is safe to merge.

Both changed files warrant a second look: `base_acp_server.py` for the missing cleanup in `RequestIDMiddleware`, and `obs_ids.py` for propagating sampling priority when activating the ddtrace `Context`.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/obs_ids.py | Adds `sync_ddtrace_to_lgtm()` that reads the active OTel span context and activates a matching ddtrace Context in dual mode; no-op guard logic and import fallbacks are correct, but sampling priority is not forwarded to ddtrace. |
| src/agentex/lib/sdk/fastacp/base/base_acp_server.py | Calls `_sync_ddtrace_to_lgtm()` after OTel context attachment in the middleware; OTel context is properly detached in finally but the activated ddtrace context has no corresponding cleanup, risking context leakage across keep-alive requests. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant M as RequestIDMiddleware
    participant OTel as OpenTelemetry Context
    participant DD as ddtrace Context
    participant App as ASGI App

    C->>M: HTTP request (traceparent header)
    M->>OTel: _attach_incoming_trace_context(scope)
    Note over OTel: OTel context attached,<br/>token returned for cleanup
    M->>DD: _sync_ddtrace_to_lgtm()
    Note over DD: Reads active OTel span context<br/>Activates matching ddtrace Context<br/>(same trace_id, span_id)
    M->>App: await self.app(scope, receive, send)
    App-->>M: response
    M->>OTel: _detach_trace_context(token)
    Note over OTel: OTel context cleaned up
    Note over DD: ddtrace context NOT cleaned up<br/>(persists in asyncio task)
    M-->>C: HTTP response
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agentex/lib/sdk/fastacp/base/base_acp_server.py`, line 104-111 ([link](https://github.com/scaleapi/scale-agentex-python/blob/31f86609eb3efa528465c35bc6302c459275feda/src/agentex/lib/sdk/fastacp/base/base_acp_server.py#L104-L111)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Ddtrace context not cleaned up, risks leaking across keep-alive requests**

   `_attach_incoming_trace_context` returns a detach token that is cleaned up in `finally`. `_sync_ddtrace_to_lgtm()` activates a ddtrace `Context` but never restores the previous one. In uvicorn's HTTP/1.1 keep-alive loop, all requests on the same connection share a single asyncio `Task` (and therefore the same `contextvars` scope). Request A sets ddtrace context to `trace_X`; the `finally` block detaches the OTel context but leaves `trace_X` active in ddtrace. Request B arrives with no `traceparent` — `_sync_ddtrace_to_lgtm()` becomes a no-op (no valid OTel span), and B's ddtrace spans are incorrectly attributed to `trace_X`.

   The fix mirrors the OTel pattern: capture `tracer.context_provider.get()` before activation and restore it in `finally`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentex/lib/sdk/fastacp/base/base_acp_server.py
   Line: 104-111

   Comment:
   **Ddtrace context not cleaned up, risks leaking across keep-alive requests**

   `_attach_incoming_trace_context` returns a detach token that is cleaned up in `finally`. `_sync_ddtrace_to_lgtm()` activates a ddtrace `Context` but never restores the previous one. In uvicorn's HTTP/1.1 keep-alive loop, all requests on the same connection share a single asyncio `Task` (and therefore the same `contextvars` scope). Request A sets ddtrace context to `trace_X`; the `finally` block detaches the OTel context but leaves `trace_X` active in ddtrace. Request B arrives with no `traceparent` — `_sync_ddtrace_to_lgtm()` becomes a no-op (no valid OTel span), and B's ddtrace spans are incorrectly attributed to `trace_X`.

   The fix mirrors the OTel pattern: capture `tracer.context_provider.get()` before activation and restore it in `finally`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%0ALine%3A%20104-111%0A%0AComment%3A%0A**Ddtrace%20context%20not%20cleaned%20up%2C%20risks%20leaking%20across%20keep-alive%20requests**%0A%0A%60_attach_incoming_trace_context%60%20returns%20a%20detach%20token%20that%20is%20cleaned%20up%20in%20%60finally%60.%20%60_sync_ddtrace_to_lgtm%28%29%60%20activates%20a%20ddtrace%20%60Context%60%20but%20never%20restores%20the%20previous%20one.%20In%20uvicorn's%20HTTP%2F1.1%20keep-alive%20loop%2C%20all%20requests%20on%20the%20same%20connection%20share%20a%20single%20asyncio%20%60Task%60%20%28and%20therefore%20the%20same%20%60contextvars%60%20scope%29.%20Request%20A%20sets%20ddtrace%20context%20to%20%60trace_X%60%3B%20the%20%60finally%60%20block%20detaches%20the%20OTel%20context%20but%20leaves%20%60trace_X%60%20active%20in%20ddtrace.%20Request%20B%20arrives%20with%20no%20%60traceparent%60%20%E2%80%94%20%60_sync_ddtrace_to_lgtm%28%29%60%20becomes%20a%20no-op%20%28no%20valid%20OTel%20span%29%2C%20and%20B's%20ddtrace%20spans%20are%20incorrectly%20attributed%20to%20%60trace_X%60.%0A%0AThe%20fix%20mirrors%20the%20OTel%20pattern%3A%20capture%20%60tracer.context_provider.get%28%29%60%20before%20activation%20and%20restore%20it%20in%20%60finally%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=471&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%0ALine%3A%20104-111%0A%0AComment%3A%0A**Ddtrace%20context%20not%20cleaned%20up%2C%20risks%20leaking%20across%20keep-alive%20requests**%0A%0A%60_attach_incoming_trace_context%60%20returns%20a%20detach%20token%20that%20is%20cleaned%20up%20in%20%60finally%60.%20%60_sync_ddtrace_to_lgtm%28%29%60%20activates%20a%20ddtrace%20%60Context%60%20but%20never%20restores%20the%20previous%20one.%20In%20uvicorn's%20HTTP%2F1.1%20keep-alive%20loop%2C%20all%20requests%20on%20the%20same%20connection%20share%20a%20single%20asyncio%20%60Task%60%20%28and%20therefore%20the%20same%20%60contextvars%60%20scope%29.%20Request%20A%20sets%20ddtrace%20context%20to%20%60trace_X%60%3B%20the%20%60finally%60%20block%20detaches%20the%20OTel%20context%20but%20leaves%20%60trace_X%60%20active%20in%20ddtrace.%20Request%20B%20arrives%20with%20no%20%60traceparent%60%20%E2%80%94%20%60_sync_ddtrace_to_lgtm%28%29%60%20becomes%20a%20no-op%20%28no%20valid%20OTel%20span%29%2C%20and%20B's%20ddtrace%20spans%20are%20incorrectly%20attributed%20to%20%60trace_X%60.%0A%0AThe%20fix%20mirrors%20the%20OTel%20pattern%3A%20capture%20%60tracer.context_provider.get%28%29%60%20before%20activation%20and%20restore%20it%20in%20%60finally%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=471&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22obs%2F04-ddtrace-dual-sync%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22obs%2F04-ddtrace-dual-sync%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%0ALine%3A%20104-111%0A%0AComment%3A%0A**Ddtrace%20context%20not%20cleaned%20up%2C%20risks%20leaking%20across%20keep-alive%20requests**%0A%0A%60_attach_incoming_trace_context%60%20returns%20a%20detach%20token%20that%20is%20cleaned%20up%20in%20%60finally%60.%20%60_sync_ddtrace_to_lgtm%28%29%60%20activates%20a%20ddtrace%20%60Context%60%20but%20never%20restores%20the%20previous%20one.%20In%20uvicorn's%20HTTP%2F1.1%20keep-alive%20loop%2C%20all%20requests%20on%20the%20same%20connection%20share%20a%20single%20asyncio%20%60Task%60%20%28and%20therefore%20the%20same%20%60contextvars%60%20scope%29.%20Request%20A%20sets%20ddtrace%20context%20to%20%60trace_X%60%3B%20the%20%60finally%60%20block%20detaches%20the%20OTel%20context%20but%20leaves%20%60trace_X%60%20active%20in%20ddtrace.%20Request%20B%20arrives%20with%20no%20%60traceparent%60%20%E2%80%94%20%60_sync_ddtrace_to_lgtm%28%29%60%20becomes%20a%20no-op%20%28no%20valid%20OTel%20span%29%2C%20and%20B's%20ddtrace%20spans%20are%20incorrectly%20attributed%20to%20%60trace_X%60.%0A%0AThe%20fix%20mirrors%20the%20OTel%20pattern%3A%20capture%20%60tracer.context_provider.get%28%29%60%20before%20activation%20and%20restore%20it%20in%20%60finally%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex-python&pr=471&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%3A104-111%0A**Ddtrace%20context%20not%20cleaned%20up%2C%20risks%20leaking%20across%20keep-alive%20requests**%0A%0A%60_attach_incoming_trace_context%60%20returns%20a%20detach%20token%20that%20is%20cleaned%20up%20in%20%60finally%60.%20%60_sync_ddtrace_to_lgtm%28%29%60%20activates%20a%20ddtrace%20%60Context%60%20but%20never%20restores%20the%20previous%20one.%20In%20uvicorn's%20HTTP%2F1.1%20keep-alive%20loop%2C%20all%20requests%20on%20the%20same%20connection%20share%20a%20single%20asyncio%20%60Task%60%20%28and%20therefore%20the%20same%20%60contextvars%60%20scope%29.%20Request%20A%20sets%20ddtrace%20context%20to%20%60trace_X%60%3B%20the%20%60finally%60%20block%20detaches%20the%20OTel%20context%20but%20leaves%20%60trace_X%60%20active%20in%20ddtrace.%20Request%20B%20arrives%20with%20no%20%60traceparent%60%20%E2%80%94%20%60_sync_ddtrace_to_lgtm%28%29%60%20becomes%20a%20no-op%20%28no%20valid%20OTel%20span%29%2C%20and%20B's%20ddtrace%20spans%20are%20incorrectly%20attributed%20to%20%60trace_X%60.%0A%0AThe%20fix%20mirrors%20the%20OTel%20pattern%3A%20capture%20%60tracer.context_provider.get%28%29%60%20before%20activation%20and%20restore%20it%20in%20%60finally%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftracing%2Fobs_ids.py%3A111%0A**Sampling%20priority%20not%20forwarded%2C%20ddtrace%20may%20make%20an%20independent%20sampling%20decision**%0A%0A%60Context%28trace_id%3Dsc.trace_id%2C%20span_id%3Dsc.span_id%29%60%20leaves%20%60sampling_priority%60%20unset.%20ddtrace%20will%20then%20apply%20its%20own%20sampler%20for%20this%20activated%20context%2C%20which%20can%20differ%20from%20the%20sampling%20decision%20already%20made%20by%20the%20OTel%20SDK%20for%20the%20same%20trace.%20In%20practice%20this%20means%20a%20span%20that%20OTel%20keeps%20may%20be%20dropped%20by%20Datadog%20%28or%20vice-versa%29%2C%20making%20the%20two%20backends%20show%20different%20coverage%20for%20the%20same%20trace%20id%20even%20when%20%60DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED%3Dtrue%60%20guarantees%20matching%20ids.%20If%20the%20egp-api-backend%20reference%20sets%20%60sampling_priority%3DUSER_KEEP%60%20%28or%20forwards%20it%20from%20the%20W3C%20%60tracestate%60%29%2C%20doing%20the%20same%20here%20would%20ensure%20consistent%20sampling%20across%20both%20backends.%0A%0A&pr=471&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%3A104-111%0A**Ddtrace%20context%20not%20cleaned%20up%2C%20risks%20leaking%20across%20keep-alive%20requests**%0A%0A%60_attach_incoming_trace_context%60%20returns%20a%20detach%20token%20that%20is%20cleaned%20up%20in%20%60finally%60.%20%60_sync_ddtrace_to_lgtm%28%29%60%20activates%20a%20ddtrace%20%60Context%60%20but%20never%20restores%20the%20previous%20one.%20In%20uvicorn's%20HTTP%2F1.1%20keep-alive%20loop%2C%20all%20requests%20on%20the%20same%20connection%20share%20a%20single%20asyncio%20%60Task%60%20%28and%20therefore%20the%20same%20%60contextvars%60%20scope%29.%20Request%20A%20sets%20ddtrace%20context%20to%20%60trace_X%60%3B%20the%20%60finally%60%20block%20detaches%20the%20OTel%20context%20but%20leaves%20%60trace_X%60%20active%20in%20ddtrace.%20Request%20B%20arrives%20with%20no%20%60traceparent%60%20%E2%80%94%20%60_sync_ddtrace_to_lgtm%28%29%60%20becomes%20a%20no-op%20%28no%20valid%20OTel%20span%29%2C%20and%20B's%20ddtrace%20spans%20are%20incorrectly%20attributed%20to%20%60trace_X%60.%0A%0AThe%20fix%20mirrors%20the%20OTel%20pattern%3A%20capture%20%60tracer.context_provider.get%28%29%60%20before%20activation%20and%20restore%20it%20in%20%60finally%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftracing%2Fobs_ids.py%3A111%0A**Sampling%20priority%20not%20forwarded%2C%20ddtrace%20may%20make%20an%20independent%20sampling%20decision**%0A%0A%60Context%28trace_id%3Dsc.trace_id%2C%20span_id%3Dsc.span_id%29%60%20leaves%20%60sampling_priority%60%20unset.%20ddtrace%20will%20then%20apply%20its%20own%20sampler%20for%20this%20activated%20context%2C%20which%20can%20differ%20from%20the%20sampling%20decision%20already%20made%20by%20the%20OTel%20SDK%20for%20the%20same%20trace.%20In%20practice%20this%20means%20a%20span%20that%20OTel%20keeps%20may%20be%20dropped%20by%20Datadog%20%28or%20vice-versa%29%2C%20making%20the%20two%20backends%20show%20different%20coverage%20for%20the%20same%20trace%20id%20even%20when%20%60DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED%3Dtrue%60%20guarantees%20matching%20ids.%20If%20the%20egp-api-backend%20reference%20sets%20%60sampling_priority%3DUSER_KEEP%60%20%28or%20forwards%20it%20from%20the%20W3C%20%60tracestate%60%29%2C%20doing%20the%20same%20here%20would%20ensure%20consistent%20sampling%20across%20both%20backends.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=471&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22obs%2F04-ddtrace-dual-sync%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22obs%2F04-ddtrace-dual-sync%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fagentex%2Flib%2Fsdk%2Ffastacp%2Fbase%2Fbase_acp_server.py%3A104-111%0A**Ddtrace%20context%20not%20cleaned%20up%2C%20risks%20leaking%20across%20keep-alive%20requests**%0A%0A%60_attach_incoming_trace_context%60%20returns%20a%20detach%20token%20that%20is%20cleaned%20up%20in%20%60finally%60.%20%60_sync_ddtrace_to_lgtm%28%29%60%20activates%20a%20ddtrace%20%60Context%60%20but%20never%20restores%20the%20previous%20one.%20In%20uvicorn's%20HTTP%2F1.1%20keep-alive%20loop%2C%20all%20requests%20on%20the%20same%20connection%20share%20a%20single%20asyncio%20%60Task%60%20%28and%20therefore%20the%20same%20%60contextvars%60%20scope%29.%20Request%20A%20sets%20ddtrace%20context%20to%20%60trace_X%60%3B%20the%20%60finally%60%20block%20detaches%20the%20OTel%20context%20but%20leaves%20%60trace_X%60%20active%20in%20ddtrace.%20Request%20B%20arrives%20with%20no%20%60traceparent%60%20%E2%80%94%20%60_sync_ddtrace_to_lgtm%28%29%60%20becomes%20a%20no-op%20%28no%20valid%20OTel%20span%29%2C%20and%20B's%20ddtrace%20spans%20are%20incorrectly%20attributed%20to%20%60trace_X%60.%0A%0AThe%20fix%20mirrors%20the%20OTel%20pattern%3A%20capture%20%60tracer.context_provider.get%28%29%60%20before%20activation%20and%20restore%20it%20in%20%60finally%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fagentex%2Flib%2Fcore%2Ftracing%2Fobs_ids.py%3A111%0A**Sampling%20priority%20not%20forwarded%2C%20ddtrace%20may%20make%20an%20independent%20sampling%20decision**%0A%0A%60Context%28trace_id%3Dsc.trace_id%2C%20span_id%3Dsc.span_id%29%60%20leaves%20%60sampling_priority%60%20unset.%20ddtrace%20will%20then%20apply%20its%20own%20sampler%20for%20this%20activated%20context%2C%20which%20can%20differ%20from%20the%20sampling%20decision%20already%20made%20by%20the%20OTel%20SDK%20for%20the%20same%20trace.%20In%20practice%20this%20means%20a%20span%20that%20OTel%20keeps%20may%20be%20dropped%20by%20Datadog%20%28or%20vice-versa%29%2C%20making%20the%20two%20backends%20show%20different%20coverage%20for%20the%20same%20trace%20id%20even%20when%20%60DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED%3Dtrue%60%20guarantees%20matching%20ids.%20If%20the%20egp-api-backend%20reference%20sets%20%60sampling_priority%3DUSER_KEEP%60%20%28or%20forwards%20it%20from%20the%20W3C%20%60tracestate%60%29%2C%20doing%20the%20same%20here%20would%20ensure%20consistent%20sampling%20across%20both%20backends.%0A%0A&repo=scaleapi%2Fscale-agentex-python&pr=471&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/agentex/lib/sdk/fastacp/base/base_acp_server.py:104-111
**Ddtrace context not cleaned up, risks leaking across keep-alive requests**

`_attach_incoming_trace_context` returns a detach token that is cleaned up in `finally`. `_sync_ddtrace_to_lgtm()` activates a ddtrace `Context` but never restores the previous one. In uvicorn's HTTP/1.1 keep-alive loop, all requests on the same connection share a single asyncio `Task` (and therefore the same `contextvars` scope). Request A sets ddtrace context to `trace_X`; the `finally` block detaches the OTel context but leaves `trace_X` active in ddtrace. Request B arrives with no `traceparent` — `_sync_ddtrace_to_lgtm()` becomes a no-op (no valid OTel span), and B's ddtrace spans are incorrectly attributed to `trace_X`.

The fix mirrors the OTel pattern: capture `tracer.context_provider.get()` before activation and restore it in `finally`.

### Issue 2 of 2
src/agentex/lib/core/tracing/obs_ids.py:111
**Sampling priority not forwarded, ddtrace may make an independent sampling decision**

`Context(trace_id=sc.trace_id, span_id=sc.span_id)` leaves `sampling_priority` unset. ddtrace will then apply its own sampler for this activated context, which can differ from the sampling decision already made by the OTel SDK for the same trace. In practice this means a span that OTel keeps may be dropped by Datadog (or vice-versa), making the two backends show different coverage for the same trace id even when `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=true` guarantees matching ids. If the egp-api-backend reference sets `sampling_priority=USER_KEEP` (or forwards it from the W3C `tracestate`), doing the same here would ensure consistent sampling across both backends.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tracing): make ddtrace adopt the OT..."](https://github.com/scaleapi/scale-agentex-python/commit/31f86609eb3efa528465c35bc6302c459275feda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46910145)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->