### PR TITLE
feat(codex): republish todo_list revisions as they are ticked off

### DIFF
--- a/examples/tutorials/10_async/10_temporal/020_state_machine/project/workflows/deep_research/performing_deep_research.py
+++ b/examples/tutorials/10_async/10_temporal/020_state_machine/project/workflows/deep_research/performing_deep_research.py
@@ -13,21 +13,28 @@ from agentex.lib.sdk.state_machine.state_workflow import StateWorkflow
 
 logger = make_logger(__name__)
 
+# These reference MCP servers still import the mcp 1.x API (``McpError``), which
+# mcp 2.0.0 renamed to ``MCPError``. uvx gives each server its own isolated env and
+# resolves ``mcp`` unpinned there, ignoring the version this project pins, so without
+# this constraint every server dies at import and the agent silently makes zero tool
+# calls. Drop the pin once the servers support mcp 2.x.
+_MCP_PIN = ["--with", "mcp<2"]
+
 MCP_SERVERS = [
     StdioServerParameters(
         command="uvx",
-        args=["mcp-server-time", "--local-timezone", "America/Los_Angeles"],
+        args=[*_MCP_PIN, "mcp-server-time", "--local-timezone", "America/Los_Angeles"],
     ),
     StdioServerParameters(
         command="uvx",
-        args=["openai-websearch-mcp"],
+        args=[*_MCP_PIN, "openai-websearch-mcp"],
         env={
             "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", "")
         }
     ),
     StdioServerParameters(
         command="uvx",
-        args=["mcp-server-fetch"],
+        args=[*_MCP_PIN, "mcp-server-fetch"],
     ),
 ]
 

--- a/src/agentex/lib/adk/_modules/_codex_sync.py
+++ b/src/agentex/lib/adk/_modules/_codex_sync.py
@@ -60,7 +60,13 @@ Item sub-types (item.started / item.updated / item.completed)
                              a synthetic ToolRequestContent Full is emitted before the response.
   mcp_tool_call           -> same as command_execution
   web_search              -> same as command_execution
-  todo_list               -> same as command_execution
+  todo_list               -> same as command_execution, plus:
+                               item.updated -> StreamTaskMessageFull(ToolResponseContent)
+                             Codex ticks one in-place todo_list item through
+                             item.updated; each revision is republished under
+                             the same tool_call_id so consumers can render the
+                             checklist filling in rather than jumping to its
+                             final state at end of turn.
   collab_tool_call        -> same as command_execution
   error (item type)       -> StreamTaskMessageFull(TextContent, error text) on completed only
 
@@ -75,9 +81,10 @@ UNMAPPED / PARTIALLY MAPPED EVENTS
                           without this module needing to know about spans.
   item.updated (reasoning): the intermediate cumulative text is discarded;
                             only item.completed carries the final text.
-  item.updated (tool):    tool item types other than agent_message do not
-                          emit updates; item.started opens the request and
-                          item.completed closes it.
+  item.updated (tool):    only todo_list is republished (see above). For the
+                          other tool item types item.started opens the request
+                          and item.completed closes it; any updates in between
+                          carry no state a consumer could act on.
 """
 
 from __future__ import annotations
@@ -110,6 +117,11 @@ _MAX_RESULT_LENGTH = 4000
 
 def _truncate(text: str, max_len: int = _MAX_RESULT_LENGTH) -> str:
     return str(text)[:max_len]
+
+
+# Tool items codex revises in place rather than reopening. Their item.updated
+# events carry real intermediate state, so they are forwarded as responses.
+_PROGRESSIVE_TOOL_ITEMS = frozenset({"todo_list"})
 
 
 def _tool_name_for(item_type: str, payload: dict[str, Any]) -> str:
@@ -466,6 +478,33 @@ class _CodexStreamProcessor:
                     )
                 )
                 out.append(StreamTaskMessageDone(type="done", index=req_idx))
+
+            elif evt_type == "item.updated" and item_type in _PROGRESSIVE_TOOL_ITEMS:
+                # Codex revises its plan in place: one todo_list item is opened
+                # at the start of the turn and ticked off through item.updated,
+                # with item.completed only arriving at the very end. Forwarding
+                # each revision as a response for the SAME tool_call_id lets a
+                # consumer show the checklist filling in as the turn runs; the
+                # last response received is the current state.
+                if item_id in self._tool_open:
+                    actual_type = self._tool_item_types.get(item_id, item_type)
+                    result_text, is_error = _tool_output_for(actual_type, item)
+                    resp_content: dict[str, Any] = {"result": result_text}
+                    if is_error:
+                        resp_content["is_error"] = True
+                    out.append(
+                        StreamTaskMessageFull(
+                            type="full",
+                            index=self._alloc(),
+                            content=ToolResponseContent(
+                                type="tool_response",
+                                author="agent",
+                                tool_call_id=tool_call_id,
+                                name=_tool_name_for(actual_type, item),
+                                content=resp_content,
+                            ),
+                        )
+                    )
 
             elif evt_type == "item.completed":
                 # file_change items may only emit item.completed (no started).

--- a/src/agentex/lib/core/tracing/obs_ids.py
+++ b/src/agentex/lib/core/tracing/obs_ids.py
@@ -22,7 +22,7 @@ an empty dict and the span is simply not tagged.
 from __future__ import annotations
 
 import os
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple, Optional
 
 __all__ = ("get_obs_mode", "obs_correlation")
 
@@ -55,7 +55,7 @@ def _lgtm_ids() -> Optional[Tuple[str, str]]:
 
 def _ddtrace_ids() -> Optional[Tuple[str, str]]:
     try:
-        from ddtrace import tracer
+        from ddtrace.trace import tracer
     except ImportError:
         return None
     ctx = tracer.current_trace_context()

--- a/tests/lib/adk/test_codex_sync.py
+++ b/tests/lib/adk/test_codex_sync.py
@@ -47,6 +47,13 @@ async def _collect(stream: AsyncIterator[Any]) -> list[Any]:
     return [e async for e in stream]
 
 
+def _result_text(event: StreamTaskMessageFull) -> str:
+    content = event.content
+    assert isinstance(content, ToolResponseContent)
+    assert isinstance(content.content, dict)
+    return str(content.content["result"])
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -358,6 +365,107 @@ class TestToolCallStreaming:
         )
         assert req.index is not None and resp.index is not None
         assert req.index < resp.index
+
+
+# ---------------------------------------------------------------------------
+# Progressive tool items (todo_list)
+# ---------------------------------------------------------------------------
+
+
+def _todo_item(item_id: str, *completed: bool) -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "type": "todo_list",
+        "items": [{"text": f"step {i + 1}", "completed": done} for i, done in enumerate(completed)],
+    }
+
+
+class TestTodoListUpdates:
+    async def test_each_update_republishes_the_checklist(self) -> None:
+        """Codex ticks ONE in-place todo_list item, so every item.updated is
+        forwarded as a response under the same tool_call_id. Without this a
+        consumer only sees the plan as first written and then, at end of turn,
+        as finished."""
+        events = [
+            {"type": "item.started", "item": _todo_item("item_1", False, False)},
+            {"type": "item.updated", "item": _todo_item("item_1", True, False)},
+            {"type": "item.updated", "item": _todo_item("item_1", True, True)},
+            {"type": "item.completed", "item": _todo_item("item_1", True, True)},
+        ]
+        out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
+
+        requests = [
+            e for e in out if isinstance(e, StreamTaskMessageStart) and isinstance(e.content, ToolRequestContent)
+        ]
+        responses = [
+            e for e in out if isinstance(e, StreamTaskMessageFull) and isinstance(e.content, ToolResponseContent)
+        ]
+
+        assert len(requests) == 1
+        assert len(responses) == 3
+
+        request_content = requests[0].content
+        assert isinstance(request_content, ToolRequestContent)
+        for response in responses:
+            content = response.content
+            assert isinstance(content, ToolResponseContent)
+            assert content.name == "todo_list"
+            assert content.tool_call_id == request_content.tool_call_id
+
+        first, second, final = (json.loads(_result_text(r)) for r in responses)
+        assert [i["completed"] for i in first["items"]] == [True, False]
+        assert [i["completed"] for i in second["items"]] == [True, True]
+        assert [i["completed"] for i in final["items"]] == [True, True]
+
+    async def test_counts_the_call_once_across_its_updates(self) -> None:
+        events = [
+            {"type": "item.started", "item": _todo_item("item_1", False)},
+            {"type": "item.updated", "item": _todo_item("item_1", True)},
+            {"type": "item.completed", "item": _todo_item("item_1", True)},
+        ]
+        counters: dict[str, Any] = {}
+        await _collect(convert_codex_to_agentex_events(_aiter(events), on_result=counters.update))
+        assert counters.get("tool_call_count") == 1
+
+    async def test_ignores_an_update_for_an_unopened_item(self) -> None:
+        """An update with no preceding start has no request to answer; a
+        response would dangle with a tool_call_id nothing points at."""
+        events = [{"type": "item.updated", "item": _todo_item("orphan", True)}]
+        out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
+        assert [e for e in out if isinstance(e, StreamTaskMessageFull)] == []
+
+    async def test_does_not_republish_other_tool_items(self) -> None:
+        events = [
+            {
+                "type": "item.started",
+                "item": {"id": "cmd1", "type": "command_execution", "command": "sleep 1"},
+            },
+            {
+                "type": "item.updated",
+                "item": {
+                    "id": "cmd1",
+                    "type": "command_execution",
+                    "command": "sleep 1",
+                    "aggregated_output": "partial",
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd1",
+                    "type": "command_execution",
+                    "command": "sleep 1",
+                    "aggregated_output": "done",
+                    "exit_code": 0,
+                },
+            },
+        ]
+        out = await _collect(convert_codex_to_agentex_events(_aiter(events)))
+        responses = [
+            e for e in out if isinstance(e, StreamTaskMessageFull) and isinstance(e.content, ToolResponseContent)
+        ]
+        assert len(responses) == 1
+        assert _result_text(responses[0]) == "done"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Codex does not reopen its plan. One `todo_list` item is opened at the start of a turn and revised **in place** through `item.updated`, with `item.completed` only arriving at the very end. The tap dropped those updates, so a consumer saw the plan exactly twice:

- as first written, nothing done
- at end of turn, everything done

Real trace from the golden agent (`item_1`), request vs response of the same call:

```
arguments: [{"text": "Probe safe local utility tools", "completed": false}, ... x4]
result:    [{"text": "Probe safe local utility tools", "completed": true},  ... x4]
```

Nothing in between, though the agent ticked them off over ~7 minutes.

This forwards each revision as a `ToolResponseContent` under the item's existing `tool_call_id`. Consumers that key responses by call id (the GenAI Ops Hub chat does) now render the checklist filling in as the turn runs, and the last response received is still the final state.

## Scope

`_PROGRESSIVE_TOOL_ITEMS` is `{"todo_list"}` only. The other tool item types carry no intermediate state worth acting on, and republishing `command_execution` output on every chunk would be pure noise. Updates for an item that was never opened are ignored — there is no request for them to answer.

`tool_call_count` still counts the call once, not once per revision.

## Testing

- `pytest tests/lib/adk/test_codex_sync.py` — 55 pass, 4 new (`TestTodoListUpdates`: republish per revision, call counted once, orphan update ignored, other tool items unaffected)
- `pytest tests/lib/core/harness/test_harness_codex_sync.py` — 9 pass
- `./scripts/lint` — ruff + pyright clean

## Paired change

The GenAI Ops Hub side of this is scaleapi/scaleapi#153721's follow-up, which maps every codex tool name onto a real chat block. It already takes the newest response per call id, so it picks these up with no further change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a gap in the Codex event-stream tap where `todo_list` plan revisions were invisible to consumers: previously only the initial state and the final completed state were forwarded, with nothing in between even though Codex ticks items off over the course of a turn. Now each `item.updated` for a `todo_list` item is republished as a `ToolResponseContent` under the same `tool_call_id`, so consumers (e.g. the GenAI Ops Hub chat) can render the checklist filling in progressively.

- **`_codex_sync.py`**: Adds `_PROGRESSIVE_TOOL_ITEMS = frozenset({"todo_list"})` and a new branch in `_handle_item` that, for `item.updated` events on progressive items, emits a `StreamTaskMessageFull(ToolResponseContent)` under the existing `tool_call_id` — guarded by `item_id in self._tool_open` so orphan updates are silently dropped. `tool_call_count` is still incremented only once on `item.started`.
- **`obs_ids.py`**: Updates the ddtrace import from the deprecated `ddtrace.tracer` to `ddtrace.trace.tracer` (ddtrace v3 API path); the existing `except ImportError` guard ensures graceful degradation on older installs.
- **`performing_deep_research.py`** (example): Pins `mcp<2` via `uvx --with` for all MCP server invocations to avoid the `McpError`→`MCPError` rename introduced in mcp 2.0.0.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The new progressive-update path is narrowly scoped to todo_list items, guarded by the _tool_open membership check, and covered by four targeted tests.

The change is purely additive — a new elif branch that only fires for todo_list item.updated events. The existing item.started / item.completed paths are untouched. The orphan-update guard and unchanged tool_call_count semantics both hold up under the new tests.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/adk/_modules/_codex_sync.py | Adds progressive republishing of todo_list item.updated events as ToolResponseContent under the same tool_call_id; logic is sound, guarded by the _tool_open membership check, and tool_call_count is correctly incremented only once on item.started. |
| tests/lib/adk/test_codex_sync.py | Four new tests in TestTodoListUpdates covering: progressive republish, single call count, orphan update ignored, and other tool types unaffected. |
| src/agentex/lib/core/tracing/obs_ids.py | Updates ddtrace import to ddtrace.trace.tracer for ddtrace v3 compatibility; gracefully falls back via the existing ImportError catch. |
| examples/tutorials/10_async/10_temporal/020_state_machine/project/workflows/deep_research/performing_deep_research.py | Pins mcp<2 via uvx --with to avoid mcp 2.x breaking import. Well-commented with a drop condition. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Codex as Codex CLI
    participant Tap as _CodexStreamProcessor
    participant Consumer as Consumer

    Codex->>Tap: "item.started {id: item_1, type: todo_list}"
    Tap->>Consumer: "StreamTaskMessageStart(ToolRequestContent, tool_call_id=item_1)"
    Tap->>Consumer: StreamTaskMessageDone

    Note over Codex,Consumer: Agent ticks items off over many minutes

    Codex->>Tap: "item.updated {id: item_1, items: [true, false]}"
    Tap->>Consumer: "StreamTaskMessageFull(ToolResponseContent, tool_call_id=item_1)"

    Codex->>Tap: "item.updated {id: item_1, items: [true, true]}"
    Tap->>Consumer: "StreamTaskMessageFull(ToolResponseContent, tool_call_id=item_1)"

    Codex->>Tap: "item.completed {id: item_1, items: [true, true]}"
    Tap->>Consumer: "StreamTaskMessageFull(ToolResponseContent, tool_call_id=item_1)"
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(tutorials): pin mcp&lt;2 for uvx-spawne..."](https://github.com/scaleapi/scale-agentex-python/commit/023e1719588404106c444a2dd7e2af87c7534df7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47825827)</sub>

<!-- /greptile_comment -->