### PR TITLE
fix(lib): default 'agentex agents build' to --no-cache so stale layers can't ship stale source

### DIFF
--- a/.github/workflows/build-and-push-tutorial-agent.yml
+++ b/.github/workflows/build-and-push-tutorial-agent.yml
@@ -185,10 +185,15 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.rebuild_all }}" = "true" ]; then
             SHOULD_PUSH=true
             VERSION_TAG="latest"
+            # ':latest' is a moving tag, so build without cache: a stale cached layer
+            # must never silently ship source that differs from the checkout.
+            CACHE_FLAG="--no-cache"
             echo "🚀 Building agent (will push after validation): ${{ matrix.agent_path }}"
           else
             SHOULD_PUSH=false
             VERSION_TAG="${{ github.sha }}"
+            # SHA-tagged validation build is immutable, so the cache is safe (and faster).
+            CACHE_FLAG="--cache"
             echo "🔍 Building agent for validation: ${{ matrix.agent_path }}"
             # Set full image name for validation step (local build)
             echo "FULL_IMAGE=${REGISTRY}/${REPOSITORY_NAME}:${VERSION_TAG}" >> $GITHUB_ENV
@@ -197,7 +202,7 @@ jobs:
           fi
 
           # Always build locally first (without push)
-          BUILD_ARGS="--manifest ${{ matrix.agent_path }}/manifest.yaml --registry ${REGISTRY} --tag ${VERSION_TAG} --platforms linux/amd64,linux/arm64 --repository-name ${REPOSITORY_NAME}"
+          BUILD_ARGS="--manifest ${{ matrix.agent_path }}/manifest.yaml --registry ${REGISTRY} --tag ${VERSION_TAG} --platforms linux/amd64,linux/arm64 --repository-name ${REPOSITORY_NAME} ${CACHE_FLAG}"
 
           agentex agents build $BUILD_ARGS
           echo "✅ Successfully built: ${REGISTRY}/${REPOSITORY_NAME}:${VERSION_TAG}"

--- a/.github/workflows/build-and-push-tutorial-agent.yml
+++ b/.github/workflows/build-and-push-tutorial-agent.yml
@@ -185,15 +185,10 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.rebuild_all }}" = "true" ]; then
             SHOULD_PUSH=true
             VERSION_TAG="latest"
-            # ':latest' is a moving tag, so build without cache: a stale cached layer
-            # must never silently ship source that differs from the checkout.
-            CACHE_FLAG="--no-cache"
             echo "🚀 Building agent (will push after validation): ${{ matrix.agent_path }}"
           else
             SHOULD_PUSH=false
             VERSION_TAG="${{ github.sha }}"
-            # SHA-tagged validation build is immutable, so the cache is safe (and faster).
-            CACHE_FLAG="--cache"
             echo "🔍 Building agent for validation: ${{ matrix.agent_path }}"
             # Set full image name for validation step (local build)
             echo "FULL_IMAGE=${REGISTRY}/${REPOSITORY_NAME}:${VERSION_TAG}" >> $GITHUB_ENV
@@ -201,8 +196,10 @@ jobs:
             echo "SKIP_VALIDATION=true" >> $GITHUB_ENV
           fi
 
-          # Always build locally first (without push)
-          BUILD_ARGS="--manifest ${{ matrix.agent_path }}/manifest.yaml --registry ${REGISTRY} --tag ${VERSION_TAG} --platforms linux/amd64,linux/arm64 --repository-name ${REPOSITORY_NAME} ${CACHE_FLAG}"
+          # Always build without cache: a stale cached layer must never silently ship
+          # source that differs from the checkout (this is how a merged fix once failed
+          # to reach ':latest'). Correctness over a few minutes of build time.
+          BUILD_ARGS="--manifest ${{ matrix.agent_path }}/manifest.yaml --registry ${REGISTRY} --tag ${VERSION_TAG} --platforms linux/amd64,linux/arm64 --repository-name ${REPOSITORY_NAME} --no-cache"
 
           agentex agents build $BUILD_ARGS
           echo "✅ Successfully built: ${REGISTRY}/${REPOSITORY_NAME}:${VERSION_TAG}"

--- a/.github/workflows/build-and-push-tutorial-agent.yml
+++ b/.github/workflows/build-and-push-tutorial-agent.yml
@@ -196,10 +196,8 @@ jobs:
             echo "SKIP_VALIDATION=true" >> $GITHUB_ENV
           fi
 
-          # Always build without cache: a stale cached layer must never silently ship
-          # source that differs from the checkout (this is how a merged fix once failed
-          # to reach ':latest'). Correctness over a few minutes of build time.
-          BUILD_ARGS="--manifest ${{ matrix.agent_path }}/manifest.yaml --registry ${REGISTRY} --tag ${VERSION_TAG} --platforms linux/amd64,linux/arm64 --repository-name ${REPOSITORY_NAME} --no-cache"
+          # Always build locally first (without push)
+          BUILD_ARGS="--manifest ${{ matrix.agent_path }}/manifest.yaml --registry ${REGISTRY} --tag ${VERSION_TAG} --platforms linux/amd64,linux/arm64 --repository-name ${REPOSITORY_NAME}"
 
           agentex agents build $BUILD_ARGS
           echo "✅ Successfully built: ${REGISTRY}/${REPOSITORY_NAME}:${VERSION_TAG}"

--- a/src/agentex/lib/cli/commands/agents.py
+++ b/src/agentex/lib/cli/commands/agents.py
@@ -128,10 +128,11 @@ def build(
         help="Docker build argument in the format 'KEY=VALUE' (can be used multiple times)",
     ),
     cache: bool = typer.Option(
-        True,
+        False,
         "--cache/--no-cache",
-        help="Use the build cache (default). Pass --no-cache when republishing a moving "
-        "tag like ':latest' so a stale cached layer can't ship outdated source.",
+        help="Whether to use the build cache. Defaults to off so a stale cached layer "
+        "can't silently ship source that no longer matches the checkout (notably when "
+        "republishing a moving tag like ':latest'). Pass --cache to opt back in.",
     ),
 ):
     """

--- a/src/agentex/lib/cli/commands/agents.py
+++ b/src/agentex/lib/cli/commands/agents.py
@@ -127,6 +127,12 @@ def build(
         None,
         help="Docker build argument in the format 'KEY=VALUE' (can be used multiple times)",
     ),
+    cache: bool = typer.Option(
+        True,
+        "--cache/--no-cache",
+        help="Use the build cache (default). Pass --no-cache when republishing a moving "
+        "tag like ':latest' so a stale cached layer can't ship outdated source.",
+    ),
 ):
     """
     Build an agent image locally from the given manifest.
@@ -155,6 +161,7 @@ def build(
             secret=secret or "",  # Provide default empty string
             tag=tag or "latest",  # Provide default
             build_args=build_arg or [],  # Provide default empty list
+            cache=cache,
         )
         if image_url:
             typer.echo(f"Successfully built image: {image_url}")

--- a/src/agentex/lib/cli/handlers/agent_handlers.py
+++ b/src/agentex/lib/cli/handlers/agent_handlers.py
@@ -39,7 +39,7 @@ def build_agent(
     secret: str | None = None,
     tag: str | None = None,
     build_args: list[str] | None = None,
-    cache: bool = True,
+    cache: bool = False,
 ) -> str:
     """Build the agent locally and optionally push to registry
 
@@ -50,10 +50,10 @@ def build_agent(
         secret: Docker build secret in format 'id=secret-id,src=path-to-secret-file'
         tag: Image tag to use (defaults to 'latest')
         build_args: List of Docker build arguments in format 'KEY=VALUE'
-        cache: Whether to use the build cache. Defaults to True. Set to False (passes
-            --no-cache to buildx) when republishing a moving tag like ':latest' so a
-            stale cached layer can't silently ship source that no longer matches the
-            checkout.
+        cache: Whether to use the build cache. Defaults to False (passes --no-cache to
+            buildx) so a stale cached layer can't silently ship source that no longer
+            matches the checkout, notably when republishing a moving tag like ':latest'.
+            Pass True to opt back in for faster local rebuilds.
 
     Returns:
         The image URL

--- a/src/agentex/lib/cli/handlers/agent_handlers.py
+++ b/src/agentex/lib/cli/handlers/agent_handlers.py
@@ -39,6 +39,7 @@ def build_agent(
     secret: str | None = None,
     tag: str | None = None,
     build_args: list[str] | None = None,
+    cache: bool = True,
 ) -> str:
     """Build the agent locally and optionally push to registry
 
@@ -49,6 +50,10 @@ def build_agent(
         secret: Docker build secret in format 'id=secret-id,src=path-to-secret-file'
         tag: Image tag to use (defaults to 'latest')
         build_args: List of Docker build arguments in format 'KEY=VALUE'
+        cache: Whether to use the build cache. Defaults to True. Set to False (passes
+            --no-cache to buildx) when republishing a moving tag like ':latest' so a
+            stale cached layer can't silently ship source that no longer matches the
+            checkout.
 
     Returns:
         The image URL
@@ -85,7 +90,10 @@ def build_agent(
                 "file": str(build_context.path / build_context.dockerfile_path),  # type: ignore[operator]
                 "tags": [image_name],
                 "platforms": platforms,
+                "cache": cache,  # cache=False -> `docker buildx build --no-cache`
             }
+            if not cache:
+                logger.info("Build cache disabled (--no-cache)")
 
             # Add Docker build args if provided
             if build_args:


### PR DESCRIPTION
## Problem

The tutorial-agent build/publish pipeline can silently republish a **stale** image to the moving `:latest` tag. `agentex agents build` calls `docker.buildx.build(...)` with **no cache control**, so a cached layer can ship source that no longer matches the checkout — and the publish job still reports success, so the staleness is invisible.

**Concrete failure:** the `mcp<2` pin merged for the `020_state_machine` agent (`2b7649c`) never reached `…/020_state_machine:latest`. The build re-published a byte-identical **December 2025** image (pre-pin source). `scale-agentex`'s integration suite pulls `:latest`, so the `10-async-10-temporal-020-state-machine` test runs the months-old image, `uvx mcp-server-time` resolves `mcp==2.0.0`, and the `McpError`→`MCPError` rename crashes it:

```
ImportError: cannot import name 'McpError' from 'mcp.shared.exceptions'. Did you mean: 'MCPError'?
```

This currently reddens that required check on unrelated PRs (e.g. `scale-agentex` #384, #385).

## Fix

Make the build cache-free by default and expose a toggle:

- `build_agent()` gains `cache: bool = False` → passed through to `docker.buildx.build` (`cache=False` ⇒ `docker buildx build --no-cache`).
- `agentex agents build` exposes `--cache/--no-cache`, **defaulting to `--no-cache`**.

So a bare `agentex agents build` no longer caches — which means the existing `build-and-push-tutorial-agent.yml` needs **no change** (it already runs a bare build). A stale cached layer can no longer get published. `--cache` is available to opt back in for faster local rebuilds when you know the cache is safe.

## Effect / rollout

This changes the SDK CLI, and the build workflow installs `agentex-sdk` **from PyPI** (`pip install agentex-sdk==<latest>`), not from the repo checkout. So it takes effect once:
1. this merges and `agentex-sdk` is released to PyPI with it, then
2. a tutorial-agent build runs (push to `main` touching `examples/tutorials/**`, or a `rebuild_all` dispatch) and pip-installs that version.

That rebuild will produce `020_state_machine:latest` from current source (which already has the `mcp<2` pin), turning the `scale-agentex` integration check green. It also prevents this silent-stale-publish class for every tutorial agent.

## Related

Build-provenance work (#454, releasing in #475) records a deterministic working-tree hash; if later wired in as a cache key it would be a more surgical fix. This is the immediate, guaranteed prevention and doesn't touch those files.

## Testing

- `python -m py_compile` on both changed modules ✓
- `cache=False` maps to python-on-whales `docker.buildx.build(cache=False)` → buildx `--no-cache` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent stale-layer problem where `agentex agents build` could republish a byte-identical cached image to a moving tag like `:latest` without any indication that the source had changed.

- Adds `cache: bool = False` to `build_agent()` in `agent_handlers.py`, passing it directly into `docker_build_kwargs["cache"]` before both `docker.buildx.build()` call-sites; the python-on-whales library maps `cache=False` to `docker buildx build --no-cache`.
- Exposes `--cache/--no-cache` on the `agentex agents build` CLI command (via `typer.Option`), defaulting to `--no-cache`, so existing bare invocations in CI workflows immediately benefit without any workflow changes.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a two-parameter addition with no behavioural regressions on the happy path.

Both changed files are small and self-contained. The cache parameter maps correctly to the python-on-whales docker.buildx.build(cache=False) API (confirmed via docs), the typer option is wired end-to-end without any intermediate transform, the default of False matches the stated intent, and the pre-existing --push/--registry guard is untouched. No edge-case issues were found.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/cli/handlers/agent_handlers.py | Adds `cache: bool = False` to `build_agent()`, correctly threads it into `docker_build_kwargs["cache"]` before both `docker.buildx.build()` calls; python-on-whales API confirms `cache=False` emits `--no-cache`. |
| src/agentex/lib/cli/commands/agents.py | Exposes `--cache/--no-cache` via a `typer.Option` defaulting to `False`; wires the value through to `build_agent()`. No logic issues. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as CLI User
    participant CLI as agents.py (build cmd)
    participant Handler as agent_handlers.py (build_agent)
    participant Docker as docker.buildx.build (python-on-whales)

    User->>CLI: "agentex agents build [--cache | --no-cache]"
    Note over CLI: cache: bool = False (default = --no-cache)
    CLI->>Handler: "build_agent(..., cache=cache)"
    Handler->>Handler: "Assemble docker_build_kwargs {cache: cache}"
    alt "cache == False (default)"
        Handler->>Handler: logger.info(Build cache disabled)
        Handler->>Docker: "docker.buildx.build(**kwargs) → --no-cache"
    else "cache == True"
        Handler->>Docker: "docker.buildx.build(**kwargs) → with cache"
    end
    Docker-->>Handler: image built
    Handler-->>CLI: image_name
    CLI-->>User: Successfully built image: ...
```
</details>

<sub>Reviews (3): Last reviewed commit: ["make no-cache the default and drop the w..."](https://github.com/scaleapi/scale-agentex-python/commit/951e7dc7a42646f1b941ad724f196d52e240583d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48457658)</sub>

<!-- /greptile_comment -->