### PR TITLE
fix(ci): push tutorial images from buildx instead of re-pushing a stale local tag

### DIFF
--- a/.github/workflows/build-and-push-tutorial-agent.yml
+++ b/.github/workflows/build-and-push-tutorial-agent.yml
@@ -196,8 +196,16 @@ jobs:
             echo "SKIP_VALIDATION=true" >> $GITHUB_ENV
           fi
 
-          # Always build locally first (without push)
+          # Build the image. On the publish path, push straight from buildx.
+          # A multi-platform build cannot be loaded into the local Docker image
+          # store, so a subsequent `docker push` has no freshly-built image to send
+          # and ends up re-pushing whatever :latest was pulled during validation —
+          # i.e. the previous, stale image. Pushing from the build itself is the
+          # only way the newly-built multi-arch image actually lands on the tag.
           BUILD_ARGS="--manifest ${{ matrix.agent_path }}/manifest.yaml --registry ${REGISTRY} --tag ${VERSION_TAG} --platforms linux/amd64,linux/arm64 --repository-name ${REPOSITORY_NAME}"
+          if [ "$SHOULD_PUSH" = "true" ]; then
+            BUILD_ARGS="$BUILD_ARGS --push"
+          fi
 
           agentex agents build $BUILD_ARGS
           echo "✅ Successfully built: ${REGISTRY}/${REPOSITORY_NAME}:${VERSION_TAG}"
@@ -278,14 +286,6 @@ jobs:
           docker rm "$CONTAINER_NAME" > /dev/null 2>&1 || true
 
           echo "✅ All validations passed for: $FULL_IMAGE"
-
-      - name: Push Agent Image
-        if: env.SHOULD_PUSH == 'true'
-        run: |
-          FULL_IMAGE="${{ env.FULL_IMAGE }}"
-          echo "🚀 Pushing validated image: $FULL_IMAGE"
-          docker push "$FULL_IMAGE"
-          echo "✅ Successfully pushed: $FULL_IMAGE"
 
   deprecate-agents:
     name: "Deprecate Removed Agents"

--- a/.github/workflows/build-and-push-tutorial-agent.yml
+++ b/.github/workflows/build-and-push-tutorial-agent.yml
@@ -181,27 +181,30 @@ jobs:
           AGENT_NAME="${{ steps.image-name.outputs.agent_name }}"
           REPOSITORY_NAME="${{ github.repository }}/tutorial-agents/${AGENT_NAME}"
 
-          # Determine if we should push based on event type
+          # Determine if we should publish based on event type.
+          # Publish path: push to an immutable candidate tag (the commit SHA) first,
+          # validate that exact pushed artifact, then promote :latest onto it. This
+          # keeps an unvalidated image off :latest — if validation fails, :latest is
+          # left pointing at the last known-good build, and only the SHA tag is dirty.
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.rebuild_all }}" = "true" ]; then
             SHOULD_PUSH=true
-            VERSION_TAG="latest"
-            echo "🚀 Building agent (will push after validation): ${{ matrix.agent_path }}"
+            PROMOTE_LATEST=true
+            VERSION_TAG="${{ github.sha }}"
+            echo "🚀 Building agent (push candidate ${VERSION_TAG}, promote :latest after validation): ${{ matrix.agent_path }}"
           else
             SHOULD_PUSH=false
+            PROMOTE_LATEST=false
             VERSION_TAG="${{ github.sha }}"
             echo "🔍 Building agent for validation: ${{ matrix.agent_path }}"
-            # Set full image name for validation step (local build)
-            echo "FULL_IMAGE=${REGISTRY}/${REPOSITORY_NAME}:${VERSION_TAG}" >> $GITHUB_ENV
             # Skip image validation for PRs since Buildx doesn't load multi-platform images locally
             echo "SKIP_VALIDATION=true" >> $GITHUB_ENV
           fi
 
-          # Build the image. On the publish path, push straight from buildx.
-          # A multi-platform build cannot be loaded into the local Docker image
-          # store, so a subsequent `docker push` has no freshly-built image to send
-          # and ends up re-pushing whatever :latest was pulled during validation —
-          # i.e. the previous, stale image. Pushing from the build itself is the
-          # only way the newly-built multi-arch image actually lands on the tag.
+          # Build the image. On the publish path, push straight from buildx to the
+          # candidate tag: a multi-platform build cannot be loaded into the local
+          # Docker store, so it must be pushed by the build itself rather than by a
+          # later `docker push` (which would have no fresh local image and would
+          # re-push a stale tag instead).
           BUILD_ARGS="--manifest ${{ matrix.agent_path }}/manifest.yaml --registry ${REGISTRY} --tag ${VERSION_TAG} --platforms linux/amd64,linux/arm64 --repository-name ${REPOSITORY_NAME}"
           if [ "$SHOULD_PUSH" = "true" ]; then
             BUILD_ARGS="$BUILD_ARGS --push"
@@ -212,7 +215,9 @@ jobs:
 
           # Set environment variables for subsequent steps
           echo "FULL_IMAGE=${REGISTRY}/${REPOSITORY_NAME}:${VERSION_TAG}" >> $GITHUB_ENV
+          echo "LATEST_IMAGE=${REGISTRY}/${REPOSITORY_NAME}:latest" >> $GITHUB_ENV
           echo "SHOULD_PUSH=${SHOULD_PUSH}" >> $GITHUB_ENV
+          echo "PROMOTE_LATEST=${PROMOTE_LATEST}" >> $GITHUB_ENV
 
       - name: Validate agent image
         if: env.SKIP_VALIDATION != 'true'
@@ -286,6 +291,16 @@ jobs:
           docker rm "$CONTAINER_NAME" > /dev/null 2>&1 || true
 
           echo "✅ All validations passed for: $FULL_IMAGE"
+
+      - name: Promote validated image to :latest
+        if: env.PROMOTE_LATEST == 'true'
+        run: |
+          echo "🏷️  Promoting validated ${{ env.FULL_IMAGE }} -> ${{ env.LATEST_IMAGE }}"
+          # Registry-side manifest copy: no rebuild, preserves the multi-arch
+          # manifest list, and only runs after validation passed — so :latest never
+          # points at an unvalidated image.
+          docker buildx imagetools create --tag "${{ env.LATEST_IMAGE }}" "${{ env.FULL_IMAGE }}"
+          echo "✅ Promoted to ${{ env.LATEST_IMAGE }}"
 
   deprecate-agents:
     name: "Deprecate Removed Agents"

--- a/src/agentex/lib/cli/commands/agents.py
+++ b/src/agentex/lib/cli/commands/agents.py
@@ -128,11 +128,9 @@ def build(
         help="Docker build argument in the format 'KEY=VALUE' (can be used multiple times)",
     ),
     cache: bool = typer.Option(
-        False,
+        True,
         "--cache/--no-cache",
-        help="Whether to use the build cache. Defaults to off so a stale cached layer "
-        "can't silently ship source that no longer matches the checkout (notably when "
-        "republishing a moving tag like ':latest'). Pass --cache to opt back in.",
+        help="Whether to use the build cache (default on). Pass --no-cache for a clean rebuild.",
     ),
 ):
     """

--- a/src/agentex/lib/cli/handlers/agent_handlers.py
+++ b/src/agentex/lib/cli/handlers/agent_handlers.py
@@ -39,7 +39,7 @@ def build_agent(
     secret: str | None = None,
     tag: str | None = None,
     build_args: list[str] | None = None,
-    cache: bool = False,
+    cache: bool = True,
 ) -> str:
     """Build the agent locally and optionally push to registry
 
@@ -50,10 +50,8 @@ def build_agent(
         secret: Docker build secret in format 'id=secret-id,src=path-to-secret-file'
         tag: Image tag to use (defaults to 'latest')
         build_args: List of Docker build arguments in format 'KEY=VALUE'
-        cache: Whether to use the build cache. Defaults to False (passes --no-cache to
-            buildx) so a stale cached layer can't silently ship source that no longer
-            matches the checkout, notably when republishing a moving tag like ':latest'.
-            Pass True to opt back in for faster local rebuilds.
+        cache: Whether to use the build cache. Defaults to True. Set to False to pass
+            --no-cache to buildx for a clean rebuild.
 
     Returns:
         The image URL


### PR DESCRIPTION
## Problem

`020_state_machine:latest` (and other tutorial-agent images) have been frozen at a **December 2025** build and re-published unchanged on every run — which is why the merged `mcp<2` pin never reached the image and `scale-agentex`'s `020-state-machine` integration test keeps failing on the `mcp 2.0.0` `McpError`→`MCPError` crash.

**Root cause — the publish path re-pushes a stale image, not the one it just built:**

```yaml
# build step: multi-platform, NO --push
agentex agents build ... --platforms linux/amd64,linux/arm64
# validate step:
docker run "$FULL_IMAGE" ...     # pulls the EXISTING :latest from ghcr
# push step:
docker push "$FULL_IMAGE"        # re-pushes that pulled (stale) image
```

A multi-platform buildx build **cannot be loaded into the local Docker image store**, so the build step never creates a local `:latest`. The validation step's `docker run "$FULL_IMAGE"` then pulls the *existing* (stale) `:latest` from the registry, and the separate `docker push` re-pushes that same stale image back. The freshly-built image is silently discarded — so `:latest` is self-perpetuating and stuck at its December digest.

This was verified end-to-end:
- A local **single-arch** `docker build` from the pinned source produces a fresh image **with** the pin.
- CI (multi-arch, build-then-`docker push`) re-pushed the identical December digest (`1f90…`, `Created 2025-12-30`, no pin) even with `--no-cache` and SDK 0.22.0.

## Fix

- On the publish path, pass `--push` to `agentex agents build` so buildx sends the freshly-built multi-arch image **straight to the registry**.
- Drop the now-redundant separate `docker push` step. Validation still runs and now exercises the freshly-pushed image.
- Revert the CLI build-cache **default** back to `True` (keeping the `--cache/--no-cache` flag). The staleness was never a layer-cache problem, so forcing `--no-cache` globally only slowed builds.

## Effect

The next publish (push to `main` under `examples/tutorials/**`, or a `rebuild_all` dispatch) will push the freshly-built, pinned `020_state_machine:latest`, turning the `scale-agentex` integration check green — and fixes the same silent-stale-publish for every tutorial agent.

## Note on the earlier PR

This supersedes the root-cause theory behind the earlier no-cache change (#476): `--no-cache` was confirmed to run in CI yet the image stayed stale, which is what led to finding the real build/push bug here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a long-standing silent publish bug where multi-platform buildx builds were being silently discarded and a stale `:latest` re-pushed in its place. The fix changes the publish path to push directly from buildx to an immutable SHA-tagged candidate, validate that exact image, then promote it to `:latest` via `docker buildx imagetools create` — keeping `:latest` clean until validation passes. The `cache` default is also reverted to `True` since caching was never the root cause of staleness.

- **Publish path overhauled**: build step now passes `--push` so buildx sends the fresh multi-arch manifest straight to the SHA tag; a separate "promote" step then points `:latest` at that validated digest with `docker buildx imagetools create`, preserving the multi-arch manifest list without rebuilding.
- **Validation now exercises the live SHA-tagged image**: because multi-platform images cannot be loaded into the local Docker store, validation pulls the freshly-pushed registry image — an inherent constraint of multi-arch buildx noted in the PR description.
- **Cache default reverted**: `cache: bool = True` in both `agents.py` and `agent_handlers.py`; `--no-cache` remains available but is no longer the default since layer-cache staleness was not the root cause.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change correctly routes the publish path through buildx --push, validates the live SHA-tagged image, and only then promotes :latest.

The three changed files are tightly scoped: the workflow correctly pushes from buildx to an immutable SHA tag, validates that exact image, and promotes :latest via a registry-side manifest copy. The Python cache-default reversal is a one-line change with no side effects. The only finding is a dead env variable that is exported but never read, which has no functional impact.

**Files Needing Attention:** No files require special attention beyond a quick read of the SHOULD_PUSH vs PROMOTE_LATEST interplay in the workflow.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-and-push-tutorial-agent.yml | Core fix: publish path now pushes from buildx directly to a SHA tag, then promotes to :latest after validation — eliminating the stale-re-push bug. One dead env-var (SHOULD_PUSH) is exported but never referenced by any subsequent step condition. |
| src/agentex/lib/cli/commands/agents.py | Reverts cache default from False to True; docstring updated to match. Straightforward and correct. |
| src/agentex/lib/cli/handlers/agent_handlers.py | Reverts cache default from False to True; docstring updated accordingly. No logic changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["validate before promoting :latest (candi..."](https://github.com/scaleapi/scale-agentex-python/commit/8929503463af07882943fa846295745080d73231) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48496911)</sub>

<!-- /greptile_comment -->