### PR TITLE
fix(tutorials): install pytest-asyncio in async agent images so their tests run

### DIFF
--- a/examples/tutorials/10_async/00_base/090_multi_agent_non_temporal/Dockerfile
+++ b/examples/tutorials/10_async/00_base/090_multi_agent_non_temporal/Dockerfile
@@ -39,7 +39,7 @@ COPY 10_async/00_base/090_multi_agent_non_temporal/tests /app/090_multi_agent_no
 COPY test_utils /app/test_utils
 
 # Install the required Python packages with dev dependencies
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 # Set environment variables
 ENV PYTHONPATH=/app

--- a/examples/tutorials/10_async/00_base/130_claude_code/Dockerfile
+++ b/examples/tutorials/10_async/00_base/130_claude_code/Dockerfile
@@ -34,7 +34,7 @@ COPY 10_async/00_base/130_claude_code/project /app/130_claude_code/project
 COPY 10_async/00_base/130_claude_code/tests /app/130_claude_code/tests
 COPY test_utils /app/test_utils
 
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 ENV PYTHONPATH=/app
 

--- a/examples/tutorials/10_async/00_base/140_codex/Dockerfile
+++ b/examples/tutorials/10_async/00_base/140_codex/Dockerfile
@@ -37,7 +37,7 @@ COPY 10_async/00_base/140_codex/project /app/140_codex/project
 COPY 10_async/00_base/140_codex/tests /app/140_codex/tests
 COPY test_utils /app/test_utils
 
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 ENV PYTHONPATH=/app
 ENV AGENT_NAME=ab140-codex

--- a/examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/Dockerfile
@@ -46,7 +46,7 @@ COPY 10_async/10_temporal/060_open_ai_agents_sdk_hello_world/tests /app/060_open
 COPY test_utils /app/test_utils
 
 # Install the required Python packages with dev dependencies
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 WORKDIR /app/060_open_ai_agents_sdk_hello_world
 

--- a/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/Dockerfile
@@ -46,7 +46,7 @@ COPY 10_async/10_temporal/070_open_ai_agents_sdk_tools/tests /app/070_open_ai_ag
 COPY test_utils /app/test_utils
 
 # Install the required Python packages with dev dependencies
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 WORKDIR /app/070_open_ai_agents_sdk_tools
 

--- a/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/Dockerfile
@@ -46,7 +46,7 @@ COPY 10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/tests /app/08
 COPY test_utils /app/test_utils
 
 # Install the required Python packages with dev dependencies
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 WORKDIR /app/080_open_ai_agents_sdk_human_in_the_loop
 

--- a/examples/tutorials/10_async/10_temporal/090_claude_agents_sdk_mvp/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/090_claude_agents_sdk_mvp/Dockerfile
@@ -46,7 +46,7 @@ COPY 10_async/10_temporal/090_claude_agents_sdk_mvp/tests /app/090_claude_agents
 COPY test_utils /app/test_utils
 
 # Install the required Python packages with dev dependencies
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 WORKDIR /app/090_claude_agents_sdk_mvp
 

--- a/examples/tutorials/10_async/10_temporal/100_gemini_litellm/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/100_gemini_litellm/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /app/100_gemini_litellm
 COPY 10_async/10_temporal/100_gemini_litellm/project /app/100_gemini_litellm/project
 
 # Install the required Python packages
-RUN uv pip install --system .
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 WORKDIR /app/100_gemini_litellm
 

--- a/examples/tutorials/10_async/10_temporal/110_pydantic_ai/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/110_pydantic_ai/Dockerfile
@@ -31,7 +31,7 @@ COPY 10_async/10_temporal/110_pydantic_ai/project /app/110_pydantic_ai/project
 COPY 10_async/10_temporal/110_pydantic_ai/tests /app/110_pydantic_ai/tests
 COPY test_utils /app/test_utils
 
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 ENV PYTHONPATH=/app
 

--- a/examples/tutorials/10_async/10_temporal/120_openai_agents/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/120_openai_agents/Dockerfile
@@ -31,7 +31,7 @@ COPY 10_async/10_temporal/120_openai_agents/project /app/120_openai_agents/proje
 COPY 10_async/10_temporal/120_openai_agents/tests /app/120_openai_agents/tests
 COPY test_utils /app/test_utils
 
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 ENV PYTHONPATH=/app
 

--- a/examples/tutorials/10_async/10_temporal/130_langgraph/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/130_langgraph/Dockerfile
@@ -31,7 +31,7 @@ COPY 10_async/10_temporal/130_langgraph/project /app/130_langgraph/project
 COPY 10_async/10_temporal/130_langgraph/tests /app/130_langgraph/tests
 COPY test_utils /app/test_utils
 
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 ENV PYTHONPATH=/app
 

--- a/examples/tutorials/10_async/10_temporal/140_claude_code/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/140_claude_code/Dockerfile
@@ -34,7 +34,7 @@ COPY 10_async/10_temporal/140_claude_code/project /app/140_claude_code/project
 COPY 10_async/10_temporal/140_claude_code/tests /app/140_claude_code/tests
 COPY test_utils /app/test_utils
 
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 ENV PYTHONPATH=/app
 

--- a/examples/tutorials/10_async/10_temporal/150_codex/Dockerfile
+++ b/examples/tutorials/10_async/10_temporal/150_codex/Dockerfile
@@ -37,7 +37,7 @@ COPY 10_async/10_temporal/150_codex/project /app/150_codex/project
 COPY 10_async/10_temporal/150_codex/tests /app/150_codex/tests
 COPY test_utils /app/test_utils
 
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
 
 ENV PYTHONPATH=/app
 ENV AGENT_NAME=at150-codex


### PR DESCRIPTION
## Problem

The integration suite runs each tutorial agent's `test_agent.py` **inside its published image**. The async agents' tests use `@pytest.mark.asyncio`, but their Dockerfiles installed only `.[dev]` — which does **not** include `pytest-asyncio`. So the tests fail to import:

```
E   ModuleNotFoundError: No module named 'pytest_asyncio'
❌ Test attempt failed with exit code 2   (x3 retries → job fails)
```

`100_gemini_litellm` was worse — it installed just `.` (no dev deps at all).

This is why unrelated PRs (e.g. `scale-agentex` #385) keep going red on `060/070/080/090/110/...` — the failure is a missing test dependency in the images, not the PR's code.

## Fix

Bring the **13 async agents** in line with the agents that already work (`010_agent_chat`, `020_state_machine`, etc.), which install `.[dev] pytest-asyncio httpx`:

```diff
-RUN uv pip install --system .[dev]
+RUN uv pip install --system .[dev] pytest-asyncio httpx
```

Sync agents (`00_sync/*`) are untouched — their tests are synchronous and pass without `pytest-asyncio`.

## Effect

Once released and the images are rebuilt, each async agent's `test_agent.py` can import and run, and the `10-async-*` integration jobs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `pytest-asyncio` and `httpx` to the `uv pip install` line in 13 async tutorial agent Dockerfiles, matching the pattern already used by working agents. The missing packages were causing `ModuleNotFoundError: No module named 'pytest_asyncio'` when the integration suite ran each agent's `test_agent.py` inside its published image.

- **12 of 13 agents** are fully fixed: each already had `COPY \u2026 /tests` and `COPY test_utils` in its Dockerfile and only needed the install line updated.
- **`100_gemini_litellm`** had the worst starting state (bare `.` install) and receives the same install fix, but has no `tests/` directory in the repo and no corresponding `COPY` instructions in its Dockerfile \u2014 so its integration job will still have nothing to run after the image is rebuilt.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the one-line install change is correct and unblocks 12 of the 13 agents; only 100_gemini_litellm remains incomplete.

Twelve agents get a complete fix: they already had their test files copied into the image and just needed pytest-asyncio and httpx added to the install command. The thirteenth, 100_gemini_litellm, has no tests/ directory in the repo at all and no COPY instructions for tests or test_utils in its Dockerfile, so its integration job will still produce no runnable tests after the image is rebuilt.

**Files Needing Attention:** examples/tutorials/10_async/10_temporal/100_gemini_litellm/Dockerfile — needs a tests/ directory created and corresponding COPY instructions added alongside the install fix.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| examples/tutorials/10_async/00_base/090_multi_agent_non_temporal/Dockerfile | Adds pytest-asyncio and httpx to the uv install line; test and test_utils COPY instructions already present. |
| examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/Dockerfile | Adds pytest-asyncio and httpx; COPY for tests/test_utils already present. |
| examples/tutorials/10_async/10_temporal/100_gemini_litellm/Dockerfile | Upgrades install from . to .[dev] pytest-asyncio httpx, but this agent has no tests directory and no COPY for tests/test_utils — integration tests will still not run. |
| examples/tutorials/10_async/10_temporal/110_pydantic_ai/Dockerfile | Adds pytest-asyncio and httpx; COPY for tests/test_utils already present. |
| examples/tutorials/10_async/10_temporal/150_codex/Dockerfile | Adds pytest-asyncio and httpx; COPY for tests/test_utils already present. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Integration Suite] --> B{Agent Image}
    B --> C[COPY project/]
    B --> D[COPY tests/]
    B --> E[COPY test_utils/]
    C --> F["uv pip install .[dev] pytest-asyncio httpx"]
    D --> F
    E --> F
    F --> G[pytest runs test_agent.py]
    G --> H{pytest-asyncio present?}
    H -- Yes --> I[Tests pass]
    H -- No --> J[ModuleNotFoundError]

    subgraph gemini[100_gemini_litellm still incomplete]
        K[COPY project/]
        L["uv pip install .[dev] pytest-asyncio httpx"]
        M[No tests directory or COPY in Dockerfile]
    end

    K --> L
    L --> M
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `examples/tutorials/10_async/10_temporal/100_gemini_litellm/Dockerfile`, line 39-43 ([link](https://github.com/scaleapi/scale-agentex-python/blob/5908c213f4ac4631daf35e89d365ae7ef9aa75a7/examples/tutorials/10_async/10_temporal/100_gemini_litellm/Dockerfile#L39-L43)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing tests COPY — integration test still won't run**

   `pytest-asyncio` is now installed, but there is no `tests` directory in this agent (confirmed: the tree shows only `project/`, `pyproject.toml`, `README.md`, and `.dockerignore`), and the Dockerfile does not `COPY` a `tests` directory or `test_utils` into the image. Every other agent fixed in this PR has both `COPY ... /tests` and `COPY test_utils /app/test_utils` before the `RUN` line. For `100_gemini_litellm`, the integration runner will still fail — either "no tests found" or a missing module — because the test files are never placed in the image.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: examples/tutorials/10_async/10_temporal/100_gemini_litellm/Dockerfile
   Line: 39-43

   Comment:
   **Missing tests COPY — integration test still won't run**

   `pytest-asyncio` is now installed, but there is no `tests` directory in this agent (confirmed: the tree shows only `project/`, `pyproject.toml`, `README.md`, and `.dockerignore`), and the Dockerfile does not `COPY` a `tests` directory or `test_utils` into the image. Every other agent fixed in this PR has both `COPY ... /tests` and `COPY test_utils /app/test_utils` before the `RUN` line. For `100_gemini_litellm`, the integration runner will still fail — either "no tests found" or a missing module — because the test files are never placed in the image.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Ftutorials%2F10_async%2F10_temporal%2F100_gemini_litellm%2FDockerfile%0ALine%3A%2039-43%0A%0AComment%3A%0A**Missing%20tests%20COPY%20%E2%80%94%20integration%20test%20still%20won't%20run**%0A%0A%60pytest-asyncio%60%20is%20now%20installed%2C%20but%20there%20is%20no%20%60tests%60%20directory%20in%20this%20agent%20%28confirmed%3A%20the%20tree%20shows%20only%20%60project%2F%60%2C%20%60pyproject.toml%60%2C%20%60README.md%60%2C%20and%20%60.dockerignore%60%29%2C%20and%20the%20Dockerfile%20does%20not%20%60COPY%60%20a%20%60tests%60%20directory%20or%20%60test_utils%60%20into%20the%20image.%20Every%20other%20agent%20fixed%20in%20this%20PR%20has%20both%20%60COPY%20...%20%2Ftests%60%20and%20%60COPY%20test_utils%20%2Fapp%2Ftest_utils%60%20before%20the%20%60RUN%60%20line.%20For%20%60100_gemini_litellm%60%2C%20the%20integration%20runner%20will%20still%20fail%20%E2%80%94%20either%20%22no%20tests%20found%22%20or%20a%20missing%20module%20%E2%80%94%20because%20the%20test%20files%20are%20never%20placed%20in%20the%20image.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=480&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Ftutorials%2F10_async%2F10_temporal%2F100_gemini_litellm%2FDockerfile%0ALine%3A%2039-43%0A%0AComment%3A%0A**Missing%20tests%20COPY%20%E2%80%94%20integration%20test%20still%20won't%20run**%0A%0A%60pytest-asyncio%60%20is%20now%20installed%2C%20but%20there%20is%20no%20%60tests%60%20directory%20in%20this%20agent%20%28confirmed%3A%20the%20tree%20shows%20only%20%60project%2F%60%2C%20%60pyproject.toml%60%2C%20%60README.md%60%2C%20and%20%60.dockerignore%60%29%2C%20and%20the%20Dockerfile%20does%20not%20%60COPY%60%20a%20%60tests%60%20directory%20or%20%60test_utils%60%20into%20the%20image.%20Every%20other%20agent%20fixed%20in%20this%20PR%20has%20both%20%60COPY%20...%20%2Ftests%60%20and%20%60COPY%20test_utils%20%2Fapp%2Ftest_utils%60%20before%20the%20%60RUN%60%20line.%20For%20%60100_gemini_litellm%60%2C%20the%20integration%20runner%20will%20still%20fail%20%E2%80%94%20either%20%22no%20tests%20found%22%20or%20a%20missing%20module%20%E2%80%94%20because%20the%20test%20files%20are%20never%20placed%20in%20the%20image.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex-python&pr=480&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22fix%2Ftutorial-async-test-deps%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftutorial-async-test-deps%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Ftutorials%2F10_async%2F10_temporal%2F100_gemini_litellm%2FDockerfile%0ALine%3A%2039-43%0A%0AComment%3A%0A**Missing%20tests%20COPY%20%E2%80%94%20integration%20test%20still%20won't%20run**%0A%0A%60pytest-asyncio%60%20is%20now%20installed%2C%20but%20there%20is%20no%20%60tests%60%20directory%20in%20this%20agent%20%28confirmed%3A%20the%20tree%20shows%20only%20%60project%2F%60%2C%20%60pyproject.toml%60%2C%20%60README.md%60%2C%20and%20%60.dockerignore%60%29%2C%20and%20the%20Dockerfile%20does%20not%20%60COPY%60%20a%20%60tests%60%20directory%20or%20%60test_utils%60%20into%20the%20image.%20Every%20other%20agent%20fixed%20in%20this%20PR%20has%20both%20%60COPY%20...%20%2Ftests%60%20and%20%60COPY%20test_utils%20%2Fapp%2Ftest_utils%60%20before%20the%20%60RUN%60%20line.%20For%20%60100_gemini_litellm%60%2C%20the%20integration%20runner%20will%20still%20fail%20%E2%80%94%20either%20%22no%20tests%20found%22%20or%20a%20missing%20module%20%E2%80%94%20because%20the%20test%20files%20are%20never%20placed%20in%20the%20image.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex-python&pr=480&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F100_gemini_litellm%2FDockerfile%3A39-43%0A**Missing%20tests%20COPY%20%E2%80%94%20integration%20test%20still%20won't%20run**%0A%0A%60pytest-asyncio%60%20is%20now%20installed%2C%20but%20there%20is%20no%20%60tests%60%20directory%20in%20this%20agent%20%28confirmed%3A%20the%20tree%20shows%20only%20%60project%2F%60%2C%20%60pyproject.toml%60%2C%20%60README.md%60%2C%20and%20%60.dockerignore%60%29%2C%20and%20the%20Dockerfile%20does%20not%20%60COPY%60%20a%20%60tests%60%20directory%20or%20%60test_utils%60%20into%20the%20image.%20Every%20other%20agent%20fixed%20in%20this%20PR%20has%20both%20%60COPY%20...%20%2Ftests%60%20and%20%60COPY%20test_utils%20%2Fapp%2Ftest_utils%60%20before%20the%20%60RUN%60%20line.%20For%20%60100_gemini_litellm%60%2C%20the%20integration%20runner%20will%20still%20fail%20%E2%80%94%20either%20%22no%20tests%20found%22%20or%20a%20missing%20module%20%E2%80%94%20because%20the%20test%20files%20are%20never%20placed%20in%20the%20image.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=480&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F100_gemini_litellm%2FDockerfile%3A39-43%0A**Missing%20tests%20COPY%20%E2%80%94%20integration%20test%20still%20won't%20run**%0A%0A%60pytest-asyncio%60%20is%20now%20installed%2C%20but%20there%20is%20no%20%60tests%60%20directory%20in%20this%20agent%20%28confirmed%3A%20the%20tree%20shows%20only%20%60project%2F%60%2C%20%60pyproject.toml%60%2C%20%60README.md%60%2C%20and%20%60.dockerignore%60%29%2C%20and%20the%20Dockerfile%20does%20not%20%60COPY%60%20a%20%60tests%60%20directory%20or%20%60test_utils%60%20into%20the%20image.%20Every%20other%20agent%20fixed%20in%20this%20PR%20has%20both%20%60COPY%20...%20%2Ftests%60%20and%20%60COPY%20test_utils%20%2Fapp%2Ftest_utils%60%20before%20the%20%60RUN%60%20line.%20For%20%60100_gemini_litellm%60%2C%20the%20integration%20runner%20will%20still%20fail%20%E2%80%94%20either%20%22no%20tests%20found%22%20or%20a%20missing%20module%20%E2%80%94%20because%20the%20test%20files%20are%20never%20placed%20in%20the%20image.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex-python&pr=480&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22fix%2Ftutorial-async-test-deps%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftutorial-async-test-deps%22.%0A%0A%23%23%23%20Issue%201%0Aexamples%2Ftutorials%2F10_async%2F10_temporal%2F100_gemini_litellm%2FDockerfile%3A39-43%0A**Missing%20tests%20COPY%20%E2%80%94%20integration%20test%20still%20won't%20run**%0A%0A%60pytest-asyncio%60%20is%20now%20installed%2C%20but%20there%20is%20no%20%60tests%60%20directory%20in%20this%20agent%20%28confirmed%3A%20the%20tree%20shows%20only%20%60project%2F%60%2C%20%60pyproject.toml%60%2C%20%60README.md%60%2C%20and%20%60.dockerignore%60%29%2C%20and%20the%20Dockerfile%20does%20not%20%60COPY%60%20a%20%60tests%60%20directory%20or%20%60test_utils%60%20into%20the%20image.%20Every%20other%20agent%20fixed%20in%20this%20PR%20has%20both%20%60COPY%20...%20%2Ftests%60%20and%20%60COPY%20test_utils%20%2Fapp%2Ftest_utils%60%20before%20the%20%60RUN%60%20line.%20For%20%60100_gemini_litellm%60%2C%20the%20integration%20runner%20will%20still%20fail%20%E2%80%94%20either%20%22no%20tests%20found%22%20or%20a%20missing%20module%20%E2%80%94%20because%20the%20test%20files%20are%20never%20placed%20in%20the%20image.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex-python&pr=480&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
examples/tutorials/10_async/10_temporal/100_gemini_litellm/Dockerfile:39-43
**Missing tests COPY — integration test still won't run**

`pytest-asyncio` is now installed, but there is no `tests` directory in this agent (confirmed: the tree shows only `project/`, `pyproject.toml`, `README.md`, and `.dockerignore`), and the Dockerfile does not `COPY` a `tests` directory or `test_utils` into the image. Every other agent fixed in this PR has both `COPY ... /tests` and `COPY test_utils /app/test_utils` before the `RUN` line. For `100_gemini_litellm`, the integration runner will still fail — either "no tests found" or a missing module — because the test files are never placed in the image.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tutorials): install pytest-asyncio i..."](https://github.com/scaleapi/scale-agentex-python/commit/5908c213f4ac4631daf35e89d365ae7ef9aa75a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48747833)</sub>

<!-- /greptile_comment -->