### PR TITLE
fix(tutorials): add pytest-asyncio to async tutorial dev deps

### DIFF
--- a/examples/tutorials/10_async/00_base/090_multi_agent_non_temporal/pyproject.toml
+++ b/examples/tutorials/10_async/00_base/090_multi_agent_non_temporal/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-asyncio",
+    "httpx",
     "black",
     "isort",
     "flake8",

--- a/examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/pyproject.toml
+++ b/examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-asyncio",
+    "httpx",
     "black",
     "isort",
     "flake8",

--- a/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/pyproject.toml
+++ b/examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-asyncio",
+    "httpx",
     "black",
     "isort",
     "flake8",

--- a/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/pyproject.toml
+++ b/examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-asyncio",
+    "httpx",
     "black",
     "isort",
     "flake8",

--- a/examples/tutorials/10_async/10_temporal/090_claude_agents_sdk_mvp/pyproject.toml
+++ b/examples/tutorials/10_async/10_temporal/090_claude_agents_sdk_mvp/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-asyncio",
+    "httpx",
     "black",
     "isort",
     "flake8",


### PR DESCRIPTION
## Problem

The `Run Integration Tests` jobs for four async SDK tutorials fail at pytest **collection**:

```
ERROR collecting tests/test_agent.py
ModuleNotFoundError: No module named 'pytest_asyncio'
1 error during collection  (exit code 2)
```

Tutorial tests run via `docker exec <agent> pytest tests/test_agent.py` inside the agent image. These tutorials' `tests/test_agent.py` `import pytest_asyncio` and use `@pytest_asyncio.fixture`, but the dependency is provided **nowhere**: it's not in their pyproject `dev` extras, and the image installs only `.[dev]`.

## Fix

Declare `pytest-asyncio` and `httpx` in each affected tutorial's `dev` optional-dependencies, so `uv pip install .[dev]` picks them up. This matches the tutorials that already run their async tests correctly (e.g. `110_pydantic_ai`, all of `00_sync`), and keeps the test deps with the project — so `pytest` also works when run locally, not just inside the built image.

```diff
 dev = [
     "pytest",
+    "pytest-asyncio",
+    "httpx",
     "black",
     "isort",
     "flake8",
 ]
```

Affected tutorials:
- `10_async/00_base/090_multi_agent_non_temporal` (latent — not currently in the CI matrix)
- `10_async/10_temporal/060_open_ai_agents_sdk_hello_world`
- `10_async/10_temporal/070_open_ai_agents_sdk_tools`
- `10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop`
- `10_async/10_temporal/090_claude_agents_sdk_mvp`

## How the set was determined

Enumerated every tutorial whose `test_agent.py` imports `pytest_asyncio`, then kept only those where **neither** the pyproject `dev` extras **nor** the Dockerfile provide it — exactly the four red CI jobs plus one latent case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes pytest collection failures in five async tutorial packages by declaring `pytest-asyncio` and `httpx` as `dev` optional-dependencies in each tutorial's `pyproject.toml`. Without these entries, `uv pip install .[dev]` inside the agent image omitted both packages, causing an immediate `ModuleNotFoundError` when pytest tried to collect `test_agent.py`.

- Adds `pytest-asyncio` and `httpx` to the `[project.optional-dependencies] dev` section of five `pyproject.toml` files across `10_async/00_base/090_multi_agent_non_temporal` and four `10_async/10_temporal/0{60..90}_*` tutorials.
- Matches the pattern already used by tutorials that pass CI (e.g. `110_pydantic_ai`), keeping test dependencies co-located with the project for both local and Docker-based runs.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All five files receive an identical, minimal additive change to dev-only dependencies; no production code or runtime behaviour is touched.

Every change is a two-line addition of well-known test tooling to dev optional-dependencies. The fix directly mirrors the working pattern used by other tutorials in the same repo, the test files confirm both imports are required, and there is no risk of side effects on the installed agent images in production.

**Files Needing Attention:** No files require special attention; all changes are confined to dev dependency declarations in tutorial pyproject.toml files.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/tutorials/10_async/00_base/090_multi_agent_non_temporal/pyproject.toml | Adds pytest-asyncio and httpx to dev optional-dependencies; fixes pytest collection error caused by missing import. |
| examples/tutorials/10_async/10_temporal/060_open_ai_agents_sdk_hello_world/pyproject.toml | Adds pytest-asyncio and httpx to dev optional-dependencies; aligns deps with what test_agent.py imports. |
| examples/tutorials/10_async/10_temporal/070_open_ai_agents_sdk_tools/pyproject.toml | Adds pytest-asyncio and httpx to dev optional-dependencies; same fix as sibling tutorials. |
| examples/tutorials/10_async/10_temporal/080_open_ai_agents_sdk_human_in_the_loop/pyproject.toml | Adds pytest-asyncio and httpx to dev optional-dependencies; same fix as sibling tutorials. |
| examples/tutorials/10_async/10_temporal/090_claude_agents_sdk_mvp/pyproject.toml | Adds pytest-asyncio and httpx to dev optional-dependencies; same fix as sibling tutorials. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as CI Job
    participant Docker as Docker Image Build
    participant uv as uv pip install .[dev]
    participant pytest as pytest (inside container)

    CI->>Docker: Build agent image
    Docker->>uv: Install project + dev extras
    Note over uv: Before PR: pytest-asyncio & httpx missing from dev
    uv-->>Docker: packages installed (pytest-asyncio absent)
    CI->>pytest: pytest tests/test_agent.py
    pytest-->>CI: ❌ ModuleNotFoundError: No module named 'pytest_asyncio'

    Note over uv: After PR: pytest-asyncio & httpx declared in dev
    Docker->>uv: Install project + dev extras
    uv-->>Docker: packages installed (pytest-asyncio ✓, httpx ✓)
    CI->>pytest: pytest tests/test_agent.py
    pytest-->>CI: ✅ Tests collected and run
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tutorials): add pytest-asyncio to as..."](https://github.com/scaleapi/scale-agentex-python/commit/ab6044daa8efd95a30b88b9615fc99b7d6185b36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48777214)</sub>

<!-- /greptile_comment -->