### PR TITLE
feat: propagate error categories to SGP spans

### DIFF
--- a/adk/pyproject.toml
+++ b/adk/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "pydantic-ai-slim>=1.0,<2",
     "langgraph-checkpoint>=2.0.0",
     "scale-gp>=0.1.0a59",
-    "scale-gp-beta>=0.2.0",
+    "scale-gp-beta>=0.5.0",
     "mcp>=1.4.1",
     # Observability
     "ddtrace>=3.13.0",

--- a/src/agentex/lib/adk/_modules/tracing.py
+++ b/src/agentex/lib/adk/_modules/tracing.py
@@ -19,6 +19,7 @@ from agentex.lib.core.temporal.activities.adk.tracing_activities import (
     StartSpanParams,
     TracingActivityName,
 )
+from agentex.lib.core.tracing.span_error import set_span_error
 from agentex.lib.core.tracing.tracer import AsyncTracer
 from agentex.lib.core.harness.types import TurnUsage
 from agentex.types.span import Span
@@ -236,6 +237,10 @@ class TracingModule:
         )
         try:
             yield span
+        except Exception as exc:
+            if span:
+                set_span_error(span, exc)
+            raise
         finally:
             if span:
                 await self.end_span(

--- a/src/agentex/lib/core/tracing/__init__.py
+++ b/src/agentex/lib/core/tracing/__init__.py
@@ -1,6 +1,11 @@
 from agentex.types.span import Span
 from agentex.lib.core.tracing.trace import Trace, AsyncTrace
 from agentex.lib.core.tracing.tracer import Tracer, AsyncTracer
+from agentex.lib.core.tracing.span_error import (
+    PlatformError,
+    ApplicationError,
+    CategorizedError,
+)
 from agentex.lib.core.tracing.span_queue import (
     AsyncSpanQueue,
     get_default_span_queue,
@@ -13,6 +18,9 @@ __all__ = [
     "Span",
     "Tracer",
     "AsyncTracer",
+    "CategorizedError",
+    "ApplicationError",
+    "PlatformError",
     "AsyncSpanQueue",
     "get_default_span_queue",
     "shutdown_default_span_queue",

--- a/src/agentex/lib/core/tracing/__init__.py
+++ b/src/agentex/lib/core/tracing/__init__.py
@@ -2,6 +2,7 @@ from agentex.types.span import Span
 from agentex.lib.core.tracing.trace import Trace, AsyncTrace
 from agentex.lib.core.tracing.tracer import Tracer, AsyncTracer
 from agentex.lib.core.tracing.span_error import (
+    ErrorCategory,
     PlatformError,
     ApplicationError,
     CategorizedError,
@@ -21,6 +22,7 @@ __all__ = [
     "CategorizedError",
     "ApplicationError",
     "PlatformError",
+    "ErrorCategory",
     "AsyncSpanQueue",
     "get_default_span_queue",
     "shutdown_default_span_queue",

--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -87,6 +87,7 @@ def _build_sgp_span(span: Span, env_vars: EnvironmentVariables) -> SGPSpan:
     error = get_span_error(span)
     if error is not None:
         sgp_span.set_error(error_type=error["type"], error_message=error["message"])
+        sgp_span.metadata["error_category"] = error.get("category", "unknown")
     return sgp_span
 
 

--- a/src/agentex/lib/core/tracing/span_error.py
+++ b/src/agentex/lib/core/tracing/span_error.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal, cast
 
 from agentex.types.span import Span
 
@@ -13,14 +13,49 @@ from agentex.types.span import Span
 # SGP and agentex-native span stores.
 SPAN_ERROR_KEY = "__error__"
 
+ErrorCategory = Literal["application", "platform", "unknown"]
+ERROR_CATEGORY_UNKNOWN: ErrorCategory = "unknown"
+_ERROR_CATEGORIES = frozenset({"application", "platform", "unknown"})
 
-def set_span_error(span: Span, exc: BaseException) -> None:
+
+def _normalize_error_category(value: object) -> ErrorCategory | None:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _ERROR_CATEGORIES:
+            return cast(ErrorCategory, normalized)
+    return None
+
+
+def _error_category(
+    exc: BaseException,
+    explicit_category: ErrorCategory | str | None = None,
+) -> ErrorCategory:
+    """Return an explicit producer classification, defaulting safely to unknown."""
+    return (
+        _normalize_error_category(explicit_category)
+        or _normalize_error_category(getattr(exc, "error_category", None))
+        or ERROR_CATEGORY_UNKNOWN
+    )
+
+
+def set_span_error(
+    span: Span,
+    exc: BaseException,
+    *,
+    error_category: ErrorCategory | str | None = None,
+) -> None:
     """Record an exception on ``span`` under ``data[SPAN_ERROR_KEY]``.
 
+    An explicit ``error_category`` takes precedence over an exception's
+    ``error_category`` attribute. Invalid or absent categories become unknown.
     No-op when ``span.data`` is a list (matching ``_add_source_to_span``, which
     only attaches metadata to dict-shaped data).
     """
-    error = {"type": type(exc).__name__, "message": str(exc)}
+    error = {
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "category": _error_category(exc, error_category),
+    }
     if span.data is None:
         span.data = {}
     if isinstance(span.data, dict):

--- a/src/agentex/lib/core/tracing/span_error.py
+++ b/src/agentex/lib/core/tracing/span_error.py
@@ -18,6 +18,31 @@ ERROR_CATEGORY_UNKNOWN: ErrorCategory = "unknown"
 _ERROR_CATEGORIES = frozenset({"application", "platform", "unknown"})
 
 
+class CategorizedError(Exception):
+    """Base class for failures with known operational ownership.
+
+    Use ``ApplicationError`` for failures owned by agent or caller code, such
+    as business logic, user input, tools, or application configuration. Use
+    ``PlatformError`` only at a known Agentex/SGP-owned boundary, such as
+    managed runtime, tracing, persistence, or platform networking. Leave
+    unclassified failures as ordinary exceptions so they remain ``unknown``.
+    """
+
+    error_category: ErrorCategory = ERROR_CATEGORY_UNKNOWN
+
+
+class ApplicationError(CategorizedError):
+    """Failure owned by the agent application or its caller."""
+
+    error_category: ErrorCategory = "application"
+
+
+class PlatformError(CategorizedError):
+    """Failure owned by Agentex/SGP or a platform-managed dependency."""
+
+    error_category: ErrorCategory = "platform"
+
+
 def _normalize_error_category(value: object) -> ErrorCategory | None:
     if isinstance(value, str):
         normalized = value.strip().lower()
@@ -33,7 +58,7 @@ def _error_category(
     """Return an explicit producer classification, defaulting safely to unknown."""
     return (
         _normalize_error_category(explicit_category)
-        or _normalize_error_category(getattr(exc, "error_category", None))
+        or (exc.error_category if isinstance(exc, CategorizedError) else None)
         or ERROR_CATEGORY_UNKNOWN
     )
 
@@ -46,8 +71,8 @@ def set_span_error(
 ) -> None:
     """Record an exception on ``span`` under ``data[SPAN_ERROR_KEY]``.
 
-    An explicit ``error_category`` takes precedence over an exception's
-    ``error_category`` attribute. Invalid or absent categories become unknown.
+    An explicit ``error_category`` takes precedence over a ``CategorizedError``
+    classification. Invalid or absent categories become unknown.
     No-op when ``span.data`` is a list (matching ``_add_source_to_span``, which
     only attaches metadata to dict-shaped data).
     """

--- a/src/agentex/lib/core/tracing/span_error.py
+++ b/src/agentex/lib/core/tracing/span_error.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Literal, cast
+from typing import Any, cast
+
+from scale_gp_beta.lib.tracing import (
+    PlatformError as PlatformError,
+    ApplicationError as ApplicationError,
+    CategorizedError,
+)
+from scale_gp_beta.lib.tracing.types import ErrorCategory
 
 from agentex.types.span import Span
 
@@ -13,34 +20,8 @@ from agentex.types.span import Span
 # SGP and agentex-native span stores.
 SPAN_ERROR_KEY = "__error__"
 
-ErrorCategory = Literal["application", "platform", "unknown"]
 ERROR_CATEGORY_UNKNOWN: ErrorCategory = "unknown"
 _ERROR_CATEGORIES = frozenset({"application", "platform", "unknown"})
-
-
-class CategorizedError(Exception):
-    """Base class for failures with known operational ownership.
-
-    Use ``ApplicationError`` for failures owned by agent or caller code, such
-    as business logic, user input, tools, or application configuration. Use
-    ``PlatformError`` only at a known Agentex/SGP-owned boundary, such as
-    managed runtime, tracing, persistence, or platform networking. Leave
-    unclassified failures as ordinary exceptions so they remain ``unknown``.
-    """
-
-    error_category: ErrorCategory = ERROR_CATEGORY_UNKNOWN
-
-
-class ApplicationError(CategorizedError):
-    """Failure owned by the agent application or its caller."""
-
-    error_category: ErrorCategory = "application"
-
-
-class PlatformError(CategorizedError):
-    """Failure owned by Agentex/SGP or a platform-managed dependency."""
-
-    error_category: ErrorCategory = "platform"
 
 
 def _normalize_error_category(value: object) -> ErrorCategory | None:

--- a/tests/lib/adk/test_tracing_module.py
+++ b/tests/lib/adk/test_tracing_module.py
@@ -10,6 +10,7 @@ import agentex.lib.adk._modules.tracing as _tracing_mod
 from agentex.types.span import Span
 from agentex.lib.core.harness.types import TurnUsage
 from agentex.lib.adk._modules.tracing import TurnSpan, TracingModule
+from agentex.lib.core.tracing.span_error import get_span_error
 from agentex.lib.core.services.adk.tracing import TracingService
 
 
@@ -248,6 +249,24 @@ class TestSpanContextManager:
 
         assert mock_service.start_span.call_args.kwargs["task_id"] == "task-abc"
         mock_service.end_span.assert_called_once()
+
+    async def test_span_context_manager_records_and_reraises_body_error(self):
+        mock_service, module = _make_module()
+        started = _make_span()
+        mock_service.start_span.return_value = started
+        mock_service.end_span.return_value = started
+
+        with patch.object(_tracing_mod, "in_temporal_workflow", return_value=False):
+            with pytest.raises(RuntimeError, match="boom"):
+                async with module.span(trace_id="trace-123", name="test-span"):
+                    raise RuntimeError("boom")
+
+        assert get_span_error(started) == {
+            "type": "RuntimeError",
+            "message": "boom",
+            "category": "unknown",
+        }
+        mock_service.end_span.assert_called_once_with(trace_id="trace-123", span=started)
 
     async def test_span_context_manager_noop_when_no_trace_id(self):
         mock_service, module = _make_module()

--- a/tests/lib/core/tracing/test_span_error.py
+++ b/tests/lib/core/tracing/test_span_error.py
@@ -6,6 +6,11 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from scale_gp_beta.lib.tracing import (
+    PlatformError as SGPPlatformError,
+    ApplicationError as SGPApplicationError,
+    CategorizedError as SGPCategorizedError,
+)
 
 from agentex.types.span import Span
 from agentex.lib.core.tracing.trace import Trace, AsyncTrace
@@ -13,6 +18,7 @@ from agentex.lib.core.tracing.span_error import (
     SPAN_ERROR_KEY,
     PlatformError,
     ApplicationError,
+    CategorizedError,
     get_span_error,
     set_span_error,
 )
@@ -36,6 +42,11 @@ def _make_span(data=None) -> Span:
 
 
 class TestSpanErrorHelpers:
+    def test_uses_canonical_sgp_error_types(self):
+        assert CategorizedError is SGPCategorizedError
+        assert ApplicationError is SGPApplicationError
+        assert PlatformError is SGPPlatformError
+
     def test_set_then_get_on_none_data(self):
         span = _make_span(data=None)
         set_span_error(span, ValueError("boom"))

--- a/tests/lib/core/tracing/test_span_error.py
+++ b/tests/lib/core/tracing/test_span_error.py
@@ -11,6 +11,8 @@ from agentex.types.span import Span
 from agentex.lib.core.tracing.trace import Trace, AsyncTrace
 from agentex.lib.core.tracing.span_error import (
     SPAN_ERROR_KEY,
+    PlatformError,
+    ApplicationError,
     get_span_error,
     set_span_error,
 )
@@ -50,30 +52,30 @@ class TestSpanErrorHelpers:
         }
 
     def test_set_uses_explicit_exception_category(self):
-        class PlatformFailure(RuntimeError):
-            error_category = " PLATFORM "
-
         span = _make_span(data=None)
-        set_span_error(span, PlatformFailure("unavailable"))
+        set_span_error(span, PlatformError("unavailable"))
         assert get_span_error(span) == {
-            "type": "PlatformFailure",
+            "type": "PlatformError",
             "message": "unavailable",
             "category": "platform",
         }
 
     def test_explicit_category_takes_precedence(self):
-        class PlatformFailure(RuntimeError):
+        span = _make_span(data=None)
+        set_span_error(span, PlatformError("bad input"), error_category="application")
+        assert get_span_error(span)["category"] == "application"  # type: ignore[index]
+
+    def test_set_uses_application_error_category(self):
+        span = _make_span(data=None)
+        set_span_error(span, ApplicationError("bad input"))
+        assert get_span_error(span)["category"] == "application"  # type: ignore[index]
+
+    def test_bare_exception_attribute_does_not_opt_in(self):
+        class ImplicitlyCategorizedError(RuntimeError):
             error_category = "platform"
 
         span = _make_span(data=None)
-        set_span_error(span, PlatformFailure("bad input"), error_category="application")
-        assert get_span_error(span)["category"] == "application"  # type: ignore[index]
-
-    def test_set_rejects_invalid_exception_category(self):
-        exc = RuntimeError("boom")
-        exc.error_category = "infrastructure"  # type: ignore[attr-defined]
-        span = _make_span(data=None)
-        set_span_error(span, exc)
+        set_span_error(span, ImplicitlyCategorizedError("boom"))
         assert get_span_error(span)["category"] == "unknown"  # type: ignore[index]
 
     def test_set_preserves_existing_dict_keys(self):

--- a/tests/lib/core/tracing/test_span_error.py
+++ b/tests/lib/core/tracing/test_span_error.py
@@ -37,9 +37,44 @@ class TestSpanErrorHelpers:
     def test_set_then_get_on_none_data(self):
         span = _make_span(data=None)
         set_span_error(span, ValueError("boom"))
-        assert get_span_error(span) == {"type": "ValueError", "message": "boom"}
+        assert get_span_error(span) == {
+            "type": "ValueError",
+            "message": "boom",
+            "category": "unknown",
+        }
         assert isinstance(span.data, dict)
-        assert span.data[SPAN_ERROR_KEY] == {"type": "ValueError", "message": "boom"}
+        assert span.data[SPAN_ERROR_KEY] == {
+            "type": "ValueError",
+            "message": "boom",
+            "category": "unknown",
+        }
+
+    def test_set_uses_explicit_exception_category(self):
+        class PlatformFailure(RuntimeError):
+            error_category = " PLATFORM "
+
+        span = _make_span(data=None)
+        set_span_error(span, PlatformFailure("unavailable"))
+        assert get_span_error(span) == {
+            "type": "PlatformFailure",
+            "message": "unavailable",
+            "category": "platform",
+        }
+
+    def test_explicit_category_takes_precedence(self):
+        class PlatformFailure(RuntimeError):
+            error_category = "platform"
+
+        span = _make_span(data=None)
+        set_span_error(span, PlatformFailure("bad input"), error_category="application")
+        assert get_span_error(span)["category"] == "application"  # type: ignore[index]
+
+    def test_set_rejects_invalid_exception_category(self):
+        exc = RuntimeError("boom")
+        exc.error_category = "infrastructure"  # type: ignore[attr-defined]
+        span = _make_span(data=None)
+        set_span_error(span, exc)
+        assert get_span_error(span)["category"] == "unknown"  # type: ignore[index]
 
     def test_set_preserves_existing_dict_keys(self):
         span = _make_span(data={"__span_type__": "LLM"})
@@ -76,7 +111,11 @@ class TestContextManagerCapture:
                 captured["span"] = span
                 raise ValueError("boom")
         err = get_span_error(captured["span"])
-        assert err == {"type": "ValueError", "message": "boom"}
+        assert err == {
+            "type": "ValueError",
+            "message": "boom",
+            "category": "unknown",
+        }
 
     def test_sync_span_success_has_no_error(self):
         trace = Trace(processors=[], client=MagicMock(), trace_id="t1")
@@ -93,7 +132,11 @@ class TestContextManagerCapture:
                 captured["span"] = span
                 raise RuntimeError("kaboom")
         err = get_span_error(captured["span"])
-        assert err == {"type": "RuntimeError", "message": "kaboom"}
+        assert err == {
+            "type": "RuntimeError",
+            "message": "kaboom",
+            "category": "unknown",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -111,7 +154,7 @@ class _FakeSGPSpan:
         self,
         error_type: str | None = None,
         error_message: str | None = None,
-        exception: BaseException | None = None,
+        exception: BaseException | None = None,  # noqa: ARG002
     ) -> None:
         self.status = "ERROR"
         self.metadata["error"] = True
@@ -131,7 +174,15 @@ class TestBuildSGPSpanMapping:
     def test_error_maps_to_status_error(self):
         from agentex.lib.core.tracing.processors.sgp_tracing_processor import _build_sgp_span
 
-        span = _make_span(data={SPAN_ERROR_KEY: {"type": "ValueError", "message": "boom"}})
+        span = _make_span(
+            data={
+                SPAN_ERROR_KEY: {
+                    "type": "ValueError",
+                    "message": "boom",
+                    "category": "application",
+                }
+            }
+        )
         with patch(f"{PROCESSOR_MODULE}.create_span", side_effect=_fake_create_span):
             sgp_span = _build_sgp_span(span, self._env())
 
@@ -139,6 +190,7 @@ class TestBuildSGPSpanMapping:
         assert sgp_span.metadata["error"] is True
         assert sgp_span.metadata["error_type"] == "ValueError"
         assert sgp_span.metadata["error_message"] == "boom"
+        assert sgp_span.metadata["error_category"] == "application"
 
     def test_no_error_leaves_status_success(self):
         from agentex.lib.core.tracing.processors.sgp_tracing_processor import _build_sgp_span

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ requires-dist = [
     { name = "redis", specifier = ">=5.2.0,<8" },
     { name = "rich", specifier = ">=13.9.2,<14" },
     { name = "scale-gp", specifier = ">=0.1.0a59" },
-    { name = "scale-gp-beta", specifier = ">=0.2.0" },
+    { name = "scale-gp-beta", specifier = ">=0.5.0" },
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "temporalio", specifier = ">=1.26.0,<2" },
     { name = "typer", specifier = ">=0.16,<0.17" },
@@ -2791,7 +2791,7 @@ wheels = [
 
 [[package]]
 name = "scale-gp-beta"
-version = "0.2.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2801,9 +2801,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/13/181f6b5a0e3fe5c2ca8b7b39e024ed11feba2cf0c879a6d77d84c8060383/scale_gp_beta-0.2.0.tar.gz", hash = "sha256:d4eac4a178ea4b7f21cfe2b421107009b69c4a5c1cbd2c7c864142c30ffda01c", size = 434620, upload-time = "2026-05-04T16:35:53.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/a6/623e122dd271f3c01852a65d57343bafbfd4b712068f63d49144c6210faa/scale_gp_beta-0.5.0.tar.gz", hash = "sha256:9f0de217d7bacd1880a7b9df6cf4f8be5d0620e24c382da14f7c0bd55423977e", size = 480740, upload-time = "2026-08-05T20:57:09.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e0/84d284fd5268c4dcaa54dd7209d43dbe41d2120834ee7a8b245184fe13d5/scale_gp_beta-0.2.0-py3-none-any.whl", hash = "sha256:87946b4618c464711bb7c8b132540112a1a558a57b31999f93cccb5da8339643", size = 410408, upload-time = "2026-05-04T16:35:52.286Z" },
+    { url = "https://files.pythonhosted.org/packages/50/95/4580c7e8d5e6d2354b09eb010d666f6359946a177b32dee8511d50a35f73/scale_gp_beta-0.5.0-py3-none-any.whl", hash = "sha256:1b1c6415a2c476c47ce5658bc0d8d2487b9aa61d95adb1002e0d5fbbe0b256c2", size = 472607, upload-time = "2026-08-05T20:57:07.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- capture exceptions raised inside ADK span context managers before ending the span
- require `scale-gp-beta>=0.5.0` and re-export its canonical `ErrorCategory`, `CategorizedError`, `ApplicationError`, and `PlatformError` types
- keep ordinary or unreliable failures classified as `unknown`
- emit flat `error_category` metadata alongside SGP `status=ERROR`, while remaining compatible with legacy records
- add coverage for canonical type identity, explicit precedence, fallback behavior, ADK capture, and SGP mapping

## Test plan
- [x] `.venv/bin/pytest -n 0 tests/lib/core/tracing/test_span_error.py tests/lib/adk/test_tracing_module.py tests/lib/core/tracing/processors/test_sgp_tracing_processor.py` (66 passed)
- [x] Ruff checks on changed files
- [x] Pyright checks on changed implementation files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds canonical error categorization to traced failures.
- Re-exports the error types supplied by `scale-gp-beta`.
- Records normalized categories in span error data and maps them to SGP metadata.
- Captures exceptions raised inside ADK span context managers before ending spans.
- Upgrades `scale-gp-beta` to version 0.5.0 and expands tracing coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/span_error.py | Adds canonical error-type exports, category normalization, explicit precedence, and categorized span-error records. |
| src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py | Maps recorded error categories into flat SGP span metadata while defaulting legacy records to unknown. |
| src/agentex/lib/adk/_modules/tracing.py | Integrates span-error capture into ADK tracing context-manager exception handling. |
| adk/pyproject.toml | Raises the minimum scale-gp-beta dependency version to 0.5.0 for canonical error-category support. |
| uv.lock | Resolves scale-gp-beta 0.5.0 and updates its distribution artifacts. |
| tests/lib/core/tracing/test_span_error.py | Covers canonical type identity, category precedence and fallback behavior, context-manager capture, and SGP mapping. |
| tests/lib/adk/test_tracing_module.py | Verifies ADK context managers record body exceptions before ending spans and preserve propagation. |
| tests/test_adk_tracing_span_error.py | Updates integration expectations for categorized errors recorded and persisted by ADK spans. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Exception raised in traced operation] --> B[ADK or core span context manager]
    B --> C[set_span_error]
    C --> D{Canonical categorized error?}
    D -->|Yes| E[Use application or platform category]
    D -->|No| F[Use unknown category]
    E --> G[Store error record on span]
    F --> G
    G --> H[End span]
    H --> I[SGP tracing processor]
    I --> J[Set ERROR status and flat error_category metadata]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["merge: resolve latest next tracing chang..."](https://github.com/scaleapi/scale-agentex-python/commit/0f63017cd94305a62276a66586c518602fa696d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49739060)</sub>

<!-- /greptile_comment -->