### PR TITLE
fix(task-create): handle WorkflowAlreadyStartedError gracefully

### DIFF
--- a/src/agentex/lib/core/clients/temporal/temporal_client.py
+++ b/src/agentex/lib/core/clients/temporal/temporal_client.py
@@ -5,7 +5,11 @@ from datetime import timedelta
 from collections.abc import Callable
 
 from temporalio.client import Client, WorkflowExecutionStatus
-from temporalio.common import RetryPolicy as TemporalRetryPolicy, WorkflowIDReusePolicy
+from temporalio.common import (
+    RetryPolicy as TemporalRetryPolicy,
+    WorkflowIDReusePolicy,
+    WorkflowIDConflictPolicy,
+)
 from temporalio.service import RPCError, RPCStatusCode
 from temporalio.converter import PayloadCodec, DataConverter
 
@@ -151,6 +155,7 @@ class TemporalClient:
         self,
         *args: Any,
         duplicate_policy: DuplicateWorkflowPolicy = DuplicateWorkflowPolicy.ALLOW_DUPLICATE,
+        id_conflict_policy: WorkflowIDConflictPolicy = WorkflowIDConflictPolicy.UNSPECIFIED,
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
         task_timeout: timedelta = timedelta(seconds=10),
         execution_timeout: timedelta | None = None,
@@ -163,6 +168,7 @@ class TemporalClient:
             task_timeout=task_timeout,
             execution_timeout=execution_timeout,
             id_reuse_policy=DUPLICATE_POLICY_TO_ID_REUSE_POLICY[duplicate_policy],
+            id_conflict_policy=id_conflict_policy,
             **kwargs,
         )
         return workflow_handle.id

--- a/src/agentex/lib/core/clients/temporal/temporal_client.py
+++ b/src/agentex/lib/core/clients/temporal/temporal_client.py
@@ -19,6 +19,7 @@ from agentex.lib.core.clients.temporal.types import (
     TaskStatus,
     RetryPolicy,
     WorkflowState,
+    ConflictWorkflowPolicy,
     DuplicateWorkflowPolicy,
 )
 from agentex.lib.core.clients.temporal.utils import get_temporal_client
@@ -77,6 +78,13 @@ DUPLICATE_POLICY_TO_ID_REUSE_POLICY = {
     DuplicateWorkflowPolicy.ALLOW_DUPLICATE_FAILED_ONLY: WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
     DuplicateWorkflowPolicy.REJECT_DUPLICATE: WorkflowIDReusePolicy.REJECT_DUPLICATE,
     DuplicateWorkflowPolicy.TERMINATE_IF_RUNNING: WorkflowIDReusePolicy.TERMINATE_IF_RUNNING,
+}
+
+CONFLICT_POLICY_TO_ID_CONFLICT_POLICY = {
+    ConflictWorkflowPolicy.UNSPECIFIED: WorkflowIDConflictPolicy.UNSPECIFIED,
+    ConflictWorkflowPolicy.FAIL: WorkflowIDConflictPolicy.FAIL,
+    ConflictWorkflowPolicy.USE_EXISTING: WorkflowIDConflictPolicy.USE_EXISTING,
+    ConflictWorkflowPolicy.TERMINATE_EXISTING: WorkflowIDConflictPolicy.TERMINATE_EXISTING,
 }
 
 
@@ -155,12 +163,20 @@ class TemporalClient:
         self,
         *args: Any,
         duplicate_policy: DuplicateWorkflowPolicy = DuplicateWorkflowPolicy.ALLOW_DUPLICATE,
-        id_conflict_policy: WorkflowIDConflictPolicy = WorkflowIDConflictPolicy.UNSPECIFIED,
+        conflict_policy: ConflictWorkflowPolicy = ConflictWorkflowPolicy.UNSPECIFIED,
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
         task_timeout: timedelta = timedelta(seconds=10),
         execution_timeout: timedelta | None = None,
         **kwargs: Any,
     ) -> str:
+        if (
+            duplicate_policy == DuplicateWorkflowPolicy.TERMINATE_IF_RUNNING
+            and conflict_policy != ConflictWorkflowPolicy.UNSPECIFIED
+        ):
+            raise ValueError(
+                "conflict_policy cannot be set when duplicate_policy is TERMINATE_IF_RUNNING; "
+                "use ConflictWorkflowPolicy.TERMINATE_EXISTING instead"
+            )
         temporal_retry_policy = TemporalRetryPolicy(**retry_policy.model_dump(exclude_unset=True))
         workflow_handle = await self.client.start_workflow(
             *args,
@@ -168,7 +184,7 @@ class TemporalClient:
             task_timeout=task_timeout,
             execution_timeout=execution_timeout,
             id_reuse_policy=DUPLICATE_POLICY_TO_ID_REUSE_POLICY[duplicate_policy],
-            id_conflict_policy=id_conflict_policy,
+            id_conflict_policy=CONFLICT_POLICY_TO_ID_CONFLICT_POLICY[conflict_policy],
             **kwargs,
         )
         return workflow_handle.id

--- a/src/agentex/lib/core/clients/temporal/types.py
+++ b/src/agentex/lib/core/clients/temporal/types.py
@@ -40,6 +40,13 @@ class DuplicateWorkflowPolicy(str, Enum):
     TERMINATE_IF_RUNNING = "TERMINATE_IF_RUNNING"
 
 
+class ConflictWorkflowPolicy(str, Enum):
+    UNSPECIFIED = "UNSPECIFIED"
+    FAIL = "FAIL"
+    USE_EXISTING = "USE_EXISTING"
+    TERMINATE_EXISTING = "TERMINATE_EXISTING"
+
+
 class TaskStatus(str, Enum):
     CANCELED = "CANCELED"
     COMPLETED = "COMPLETED"

--- a/src/agentex/lib/core/temporal/services/temporal_task_service.py
+++ b/src/agentex/lib/core/temporal/services/temporal_task_service.py
@@ -6,6 +6,8 @@ from datetime import timedelta
 from contextlib import contextmanager
 from collections.abc import Iterator
 
+from temporalio.common import WorkflowIDConflictPolicy
+
 from agentex.types.task import Task
 from agentex.types.agent import Agent
 from agentex.types.event import Event
@@ -89,6 +91,8 @@ class TemporalTaskService:
         # value bounds the whole continue-as-new chain's wall-clock lifetime.
         timeout_seconds = self._env_vars.WORKFLOW_EXECUTION_TIMEOUT_SECONDS
         execution_timeout = timedelta(seconds=timeout_seconds) if timeout_seconds and timeout_seconds > 0 else None
+        # USE_EXISTING makes task/create idempotent
+        # If same task ID is already running Temporal returns a handle to the existing run instead of raising WorkflowAlreadyStarted
         with _acp_dispatch_span("acp.task_create", task_id=task.id):
             return await self._temporal_client.start_workflow(
                 workflow=self._env_vars.WORKFLOW_NAME,
@@ -100,6 +104,7 @@ class TemporalTaskService:
                 id=task.id,
                 task_queue=self._env_vars.WORKFLOW_TASK_QUEUE,
                 execution_timeout=execution_timeout,
+                id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
             )
 
     async def get_state(self, task_id: str) -> WorkflowState:

--- a/src/agentex/lib/core/temporal/services/temporal_task_service.py
+++ b/src/agentex/lib/core/temporal/services/temporal_task_service.py
@@ -6,14 +6,12 @@ from datetime import timedelta
 from contextlib import contextmanager
 from collections.abc import Iterator
 
-from temporalio.common import WorkflowIDConflictPolicy
-
 from agentex.types.task import Task
 from agentex.types.agent import Agent
 from agentex.types.event import Event
 from agentex.protocol.acp import SendEventParams, CreateTaskParams, InterruptTaskParams
 from agentex.lib.environment_variables import EnvironmentVariables
-from agentex.lib.core.clients.temporal.types import WorkflowState
+from agentex.lib.core.clients.temporal.types import WorkflowState, ConflictWorkflowPolicy
 from agentex.lib.core.temporal.types.workflow import SignalName
 from agentex.lib.core.clients.temporal.temporal_client import TemporalClient
 
@@ -104,7 +102,7 @@ class TemporalTaskService:
                 id=task.id,
                 task_queue=self._env_vars.WORKFLOW_TASK_QUEUE,
                 execution_timeout=execution_timeout,
-                id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+                conflict_policy=ConflictWorkflowPolicy.USE_EXISTING,
             )
 
     async def get_state(self, task_id: str) -> WorkflowState:

--- a/tests/lib/core/services/test_temporal_task_service.py
+++ b/tests/lib/core/services/test_temporal_task_service.py
@@ -1,0 +1,110 @@
+"""Unit tests for TemporalTaskService idempotency behavior.
+
+Covers the ``task/create`` idempotency guarantee: duplicate submits for the
+same task ID must not raise ``WorkflowAlreadyStartedError``. The service
+achieves this by passing ``WorkflowIDConflictPolicy.USE_EXISTING`` to Temporal,
+which returns a handle to the existing run instead of erroring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, AsyncMock
+
+import pytest
+from temporalio.common import WorkflowIDConflictPolicy
+
+from agentex.types.task import Task
+from agentex.types.agent import Agent
+from agentex.lib.core.clients.temporal.temporal_client import TemporalClient
+from agentex.lib.core.temporal.services.temporal_task_service import TemporalTaskService
+
+
+def _agent() -> Agent:
+    return Agent(
+        id="test-agent-456",
+        name="test-agent",
+        description="test-agent",
+        acp_type="async",
+        created_at="2023-01-01T00:00:00Z",
+        updated_at="2023-01-01T00:00:00Z",
+    )
+
+
+def _task() -> Task:
+    return Task(id="test-task-123", status="RUNNING")
+
+
+def _env_vars() -> Mock:
+    env_vars = Mock()
+    env_vars.WORKFLOW_NAME = "test-workflow"
+    env_vars.WORKFLOW_TASK_QUEUE = "test-queue"
+    env_vars.WORKFLOW_EXECUTION_TIMEOUT_SECONDS = 0
+    return env_vars
+
+
+class TestSubmitTaskIdempotency:
+    async def test_submit_task_uses_use_existing_conflict_policy(self) -> None:
+        """Duplicate task/create must be idempotent.
+
+        Passing ``WorkflowIDConflictPolicy.USE_EXISTING`` tells Temporal to
+        return the existing workflow handle instead of raising
+        ``WorkflowAlreadyStartedError`` when a run with that ID is already
+        active. Without this, load-balanced agentex-agent replicas racing on
+        the same task ID surface Temporal's start conflict as an error log.
+        """
+        temporal_client = Mock()
+        temporal_client.start_workflow = AsyncMock(return_value="test-task-123")
+
+        service = TemporalTaskService(temporal_client=temporal_client, env_vars=_env_vars())
+
+        result = await service.submit_task(agent=_agent(), task=_task(), params=None)
+
+        temporal_client.start_workflow.assert_awaited_once()
+        kwargs = temporal_client.start_workflow.await_args.kwargs
+        assert kwargs["id_conflict_policy"] == WorkflowIDConflictPolicy.USE_EXISTING
+        assert kwargs["id"] == "test-task-123"
+        assert result == "test-task-123"
+
+
+class TestTemporalClientConflictPolicyPlumbing:
+    """Boundary tests: TemporalClient.start_workflow must forward
+    ``id_conflict_policy`` to the underlying temporalio client, and default
+    to ``UNSPECIFIED`` so callers that don't opt in keep their current
+    behavior (Temporal server treats UNSPECIFIED as FAIL on start).
+    """
+
+    async def test_forwards_id_conflict_policy_when_set(self) -> None:
+        inner_client = Mock()
+        inner_handle = Mock()
+        inner_handle.id = "wf-1"
+        inner_client.start_workflow = AsyncMock(return_value=inner_handle)
+
+        tc = TemporalClient(temporal_client=inner_client)
+
+        await tc.start_workflow(
+            workflow="w",
+            arg={},
+            id="id-1",
+            task_queue="q",
+            id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+        )
+
+        kwargs = inner_client.start_workflow.await_args.kwargs
+        assert kwargs["id_conflict_policy"] == WorkflowIDConflictPolicy.USE_EXISTING
+
+    async def test_default_conflict_policy_is_unspecified(self) -> None:
+        inner_client = Mock()
+        inner_handle = Mock()
+        inner_handle.id = "wf-1"
+        inner_client.start_workflow = AsyncMock(return_value=inner_handle)
+
+        tc = TemporalClient(temporal_client=inner_client)
+
+        await tc.start_workflow(workflow="w", arg={}, id="id-1", task_queue="q")
+
+        kwargs = inner_client.start_workflow.await_args.kwargs
+        assert kwargs["id_conflict_policy"] == WorkflowIDConflictPolicy.UNSPECIFIED
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/lib/core/services/test_temporal_task_service.py
+++ b/tests/lib/core/services/test_temporal_task_service.py
@@ -2,8 +2,10 @@
 
 Covers the ``task/create`` idempotency guarantee: duplicate submits for the
 same task ID must not raise ``WorkflowAlreadyStartedError``. The service
-achieves this by passing ``WorkflowIDConflictPolicy.USE_EXISTING`` to Temporal,
-which returns a handle to the existing run instead of erroring.
+achieves this by passing ``ConflictWorkflowPolicy.USE_EXISTING`` through the
+``TemporalClient`` wrapper, which maps to ``WorkflowIDConflictPolicy.USE_EXISTING``
+on the underlying temporalio client so Temporal returns a handle to the
+existing run instead of erroring.
 """
 
 from __future__ import annotations
@@ -15,6 +17,10 @@ from temporalio.common import WorkflowIDConflictPolicy
 
 from agentex.types.task import Task
 from agentex.types.agent import Agent
+from agentex.lib.core.clients.temporal.types import (
+    ConflictWorkflowPolicy,
+    DuplicateWorkflowPolicy,
+)
 from agentex.lib.core.clients.temporal.temporal_client import TemporalClient
 from agentex.lib.core.temporal.services.temporal_task_service import TemporalTaskService
 
@@ -46,7 +52,7 @@ class TestSubmitTaskIdempotency:
     async def test_submit_task_uses_use_existing_conflict_policy(self) -> None:
         """Duplicate task/create must be idempotent.
 
-        Passing ``WorkflowIDConflictPolicy.USE_EXISTING`` tells Temporal to
+        Passing ``ConflictWorkflowPolicy.USE_EXISTING`` tells Temporal to
         return the existing workflow handle instead of raising
         ``WorkflowAlreadyStartedError`` when a run with that ID is already
         active. Without this, load-balanced agentex-agent replicas racing on
@@ -61,19 +67,22 @@ class TestSubmitTaskIdempotency:
 
         temporal_client.start_workflow.assert_awaited_once()
         kwargs = temporal_client.start_workflow.await_args.kwargs
-        assert kwargs["id_conflict_policy"] == WorkflowIDConflictPolicy.USE_EXISTING
+        assert kwargs["conflict_policy"] == ConflictWorkflowPolicy.USE_EXISTING
         assert kwargs["id"] == "test-task-123"
         assert result == "test-task-123"
 
 
 class TestTemporalClientConflictPolicyPlumbing:
-    """Boundary tests: TemporalClient.start_workflow must forward
-    ``id_conflict_policy`` to the underlying temporalio client, and default
-    to ``UNSPECIFIED`` so callers that don't opt in keep their current
-    behavior (Temporal server treats UNSPECIFIED as FAIL on start).
+    """Boundary tests: ``TemporalClient.start_workflow`` wraps
+    ``WorkflowIDConflictPolicy`` in a local ``ConflictWorkflowPolicy`` enum
+    (mirroring the existing ``DuplicateWorkflowPolicy`` pattern) so SDK users
+    don't have to import ``temporalio.common`` to opt into non-default behavior.
+    Also guards the incompatible ``TERMINATE_IF_RUNNING`` + explicit-conflict
+    combo client-side rather than letting it round-trip to the frontend as
+    ``InvalidArgument``.
     """
 
-    async def test_forwards_id_conflict_policy_when_set(self) -> None:
+    async def test_forwards_conflict_policy_when_set(self) -> None:
         inner_client = Mock()
         inner_handle = Mock()
         inner_handle.id = "wf-1"
@@ -86,7 +95,7 @@ class TestTemporalClientConflictPolicyPlumbing:
             arg={},
             id="id-1",
             task_queue="q",
-            id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+            conflict_policy=ConflictWorkflowPolicy.USE_EXISTING,
         )
 
         kwargs = inner_client.start_workflow.await_args.kwargs
@@ -104,6 +113,27 @@ class TestTemporalClientConflictPolicyPlumbing:
 
         kwargs = inner_client.start_workflow.await_args.kwargs
         assert kwargs["id_conflict_policy"] == WorkflowIDConflictPolicy.UNSPECIFIED
+
+    async def test_terminate_if_running_with_explicit_conflict_policy_raises(self) -> None:
+        """temporalio rejects this combo at the frontend as InvalidArgument;
+        we fail fast client-side with a clearer message.
+        """
+        inner_client = Mock()
+        inner_client.start_workflow = AsyncMock()
+
+        tc = TemporalClient(temporal_client=inner_client)
+
+        with pytest.raises(ValueError, match="TERMINATE_EXISTING"):
+            await tc.start_workflow(
+                workflow="w",
+                arg={},
+                id="id-1",
+                task_queue="q",
+                duplicate_policy=DuplicateWorkflowPolicy.TERMINATE_IF_RUNNING,
+                conflict_policy=ConflictWorkflowPolicy.USE_EXISTING,
+            )
+
+        inner_client.start_workflow.assert_not_awaited()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

Makes `task/create` idempotent in the Temporal ACP path. Duplicate submits for the same task ID (e.g. load-balanced agentex-agent replicas racing on the same notification) no longer surface `WorkflowAlreadyStartedError`, Temporal returns the existing workflow handle instead.

## Change

- `TemporalTaskService.submit_task` now passes `id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING`.
- `TemporalClient.start_workflow` accepts an `id_conflict_policy` param (defaults to `UNSPECIFIED`, preserving current behavior for any other caller).

## Why

`WorkflowIDReusePolicy.ALLOW_DUPLICATE` (already set) only governs reuse *after* a run closes — it doesn't help when a run is currently open. Workflows are mainly just noise as the workflow still runs

## Test plan

- [x] New unit tests in `tests/lib/core/services/test_temporal_task_service.py`:
  - `submit_task` passes `USE_EXISTING` to the client
  - `TemporalClient.start_workflow` forwards `id_conflict_policy` when set
  - `TemporalClient.start_workflow` defaults to `UNSPECIFIED` (backwards-compat)
- [x] Existing `TemporalTaskService` tests still pass
- [ ] Sanity check in staging: fire two `task/create` calls with the same task ID, confirm both return 200 with the same workflow ID and no error log

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Temporal-backed `task/create` submissions idempotent while preserving the existing default behavior for other workflow starts.
- Adds a local conflict-policy enum and maps it to Temporal SDK policies.
- Uses `USE_EXISTING` when submitting task workflows.
- Adds unit coverage for service forwarding, default behavior, and invalid policy combinations.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/clients/temporal/temporal_client.py | Adds conflict-policy mapping and forwarding while retaining an unspecified default for existing callers. |
| src/agentex/lib/core/clients/temporal/types.py | Introduces a wrapper enum corresponding to Temporal workflow-ID conflict policies. |
| src/agentex/lib/core/temporal/services/temporal_task_service.py | Configures task workflow starts to return an existing handle when the workflow ID is already active. |
| tests/lib/core/services/test_temporal_task_service.py | Covers task-service idempotency configuration, policy mapping, defaults, and invalid combinations. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant TaskService as TemporalTaskService
    participant Wrapper as TemporalClient
    participant Temporal
    Caller->>TaskService: submit_task(task ID)
    TaskService->>Wrapper: start_workflow(USE_EXISTING)
    Wrapper->>Temporal: "start_workflow(id_conflict_policy=USE_EXISTING)"
    alt Workflow ID is already running
        Temporal-->>Wrapper: Existing workflow handle
    else Workflow ID is available
        Temporal-->>Wrapper: New workflow handle
    end
    Wrapper-->>TaskService: Workflow ID
    TaskService-->>Caller: Workflow ID
```
</details>

<sub>Reviews (3): Last reviewed commit: ["address comments"](https://github.com/scaleapi/scale-agentex-python/commit/f47ba5bc7bacb89c848399171ed14bc943509120) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50287517)</sub>

<!-- /greptile_comment -->