### PR TITLE
fix(tracing): continue inbound W3C trace context at the ACP boundary

### DIFF
--- a/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
+++ b/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
@@ -46,6 +46,43 @@ logger = make_logger(__name__)
 task_message_update_adapter = TypeAdapter(TaskMessageUpdate)
 
 
+def _attach_incoming_otel_context(scope_headers: list[tuple[bytes, bytes]]) -> object | None:
+    """Extract the inbound W3C trace context (traceparent/tracestate/baggage) from
+    ASGI headers and make it the active OpenTelemetry context for the request.
+
+    FastACP is not otherwise instrumented to *continue* an incoming trace: the
+    gateway forwards the traceparent header, but nothing on the Python side
+    extracts it, so the active context stays empty. Downstream that means the
+    Temporal ``start_workflow`` / ``signal`` (including the work dispatched via
+    ``asyncio.create_task``) fires with no active span, the interceptor injects
+    nothing, and the workflow + activities detach into fresh traces.
+
+    Attaching here (in the ASGI middleware that wraps the whole request) fixes
+    that: the request handler and the background task both run under the ingress
+    trace, so the interceptor propagates it across the Temporal boundary.
+    Returns a detach token (or None); fail-open.
+    """
+    try:
+        from opentelemetry import context as _otel_context
+        from opentelemetry.propagate import extract
+
+        carrier = {k.decode("latin-1"): v.decode("latin-1") for k, v in scope_headers}
+        return _otel_context.attach(extract(carrier))
+    except Exception:  # pragma: no cover - obs must never break a request
+        return None
+
+
+def _detach_otel_context(token: object | None) -> None:
+    if token is None:
+        return
+    try:
+        from opentelemetry import context as _otel_context
+
+        _otel_context.detach(token)  # type: ignore[arg-type]
+    except Exception:  # pragma: no cover - best-effort
+        pass
+
+
 class RequestIDMiddleware:
     """Pure ASGI middleware to set request IDs without buffering streaming responses."""
 
@@ -53,12 +90,20 @@ class RequestIDMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        otel_token: object | None = None
         if scope["type"] == "http":
-            headers = dict(scope.get("headers", []))
+            scope_headers = scope.get("headers", [])
+            headers = dict(scope_headers)
             raw_request_id = headers.get(b"x-request-id", b"")
             request_id = raw_request_id.decode() if raw_request_id else uuid.uuid4().hex
             ctx_var_request_id.set(request_id)
-        await self.app(scope, receive, send)
+            # Continue the ingress trace for this request (and its background
+            # Temporal dispatch); see _attach_incoming_otel_context.
+            otel_token = _attach_incoming_otel_context(scope_headers)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _detach_otel_context(otel_token)
 
 
 class BaseACPServer(FastAPI):

--- a/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
+++ b/src/agentex/lib/sdk/fastacp/base/base_acp_server.py
@@ -47,8 +47,8 @@ task_message_update_adapter = TypeAdapter(TaskMessageUpdate)
 
 
 def _attach_incoming_otel_context(scope_headers: list[tuple[bytes, bytes]]) -> object | None:
-    """Extract the inbound W3C trace context (traceparent/tracestate/baggage) from
-    ASGI headers and make it the active OpenTelemetry context for the request.
+    """Extract the inbound W3C trace context (traceparent/tracestate) from ASGI
+    headers and make it the active OpenTelemetry context for the request.
 
     FastACP is not otherwise instrumented to *continue* an incoming trace: the
     gateway forwards the traceparent header, but nothing on the Python side
@@ -64,10 +64,22 @@ def _attach_incoming_otel_context(scope_headers: list[tuple[bytes, bytes]]) -> o
     """
     try:
         from opentelemetry import context as _otel_context
-        from opentelemetry.propagate import extract
+        from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
-        carrier = {k.decode("latin-1"): v.decode("latin-1") for k, v in scope_headers}
-        return _otel_context.attach(extract(carrier))
+        # ASGI headers are a list that can repeat a name, and a dict comprehension
+        # keeps only the last value -- which silently drops repeated `tracestate`
+        # lines (W3C/RFC7230 say they MUST be combined). Build a dict-of-lists so
+        # the propagator's getter sees every value and `TraceState.from_header`
+        # combines them; `traceparent` is single-valued so it is unaffected.
+        carrier: dict[str, list[str]] = {}
+        for k, v in scope_headers:
+            carrier.setdefault(k.decode("latin-1").lower(), []).append(v.decode("latin-1"))
+        # Use the W3C propagator explicitly rather than the ambient global one:
+        # this ingress is W3C by contract, and `OTEL_PROPAGATORS=datadog` (plausible
+        # in a DD shop, and dd_only is the default mode) would otherwise silently
+        # extract nothing. It also parses only traceparent/tracestate, so arbitrary
+        # inbound `baggage` is not pulled into the downstream context.
+        return _otel_context.attach(TraceContextTextMapPropagator().extract(carrier))
     except Exception:  # pragma: no cover - obs must never break a request
         return None
 

--- a/tests/test_trace_context_extraction.py
+++ b/tests/test_trace_context_extraction.py
@@ -46,5 +46,42 @@ def test_no_inbound_traceparent_is_fail_open() -> None:
     _detach_otel_context(token)
 
 
+def test_repeated_tracestate_headers_are_combined() -> None:
+    # ASGI can deliver tracestate as multiple header lines; W3C/RFC7230 require
+    # combining them. The old dict-comprehension carrier kept only the last.
+    from opentelemetry import trace as _trace
+
+    trace_id = "0af7651916cd43dd8448eb211c80319c"
+    headers = [
+        (b"traceparent", f"00-{trace_id}-b7ad6b7169203331-01".encode()),
+        (b"tracestate", b"vendora=1"),
+        (b"tracestate", b"vendorb=2"),
+    ]
+    token = _attach_incoming_otel_context(headers)
+    try:
+        ts = _trace.get_current_span().get_span_context().trace_state
+        assert ts.get("vendora") == "1"
+        assert ts.get("vendorb") == "2"  # would be missing if repeats collapsed
+    finally:
+        _detach_otel_context(token)
+
+
+def test_inbound_baggage_is_not_extracted() -> None:
+    # W3C tracecontext-only extraction: arbitrary inbound baggage (attacker-
+    # controlled keys) must not be pulled into the downstream context.
+    from opentelemetry.baggage import get_all
+
+    trace_id = "0af7651916cd43dd8448eb211c80319c"
+    headers = [
+        (b"traceparent", f"00-{trace_id}-b7ad6b7169203331-01".encode()),
+        (b"baggage", b"user_id=secret,role=admin"),
+    ]
+    token = _attach_incoming_otel_context(headers)
+    try:
+        assert get_all() == {}
+    finally:
+        _detach_otel_context(token)
+
+
 def test_detach_none_is_safe() -> None:
     _detach_otel_context(None)

--- a/tests/test_trace_context_extraction.py
+++ b/tests/test_trace_context_extraction.py
@@ -1,0 +1,50 @@
+"""Unit tests for ACP inbound W3C trace-context extraction.
+
+Regression guard for the async end-to-end tracing fix: FastACP must *continue*
+an incoming traceparent (make it the active OpenTelemetry context) so the
+downstream Temporal start/signal — and the work dispatched via
+asyncio.create_task — run under the ingress trace instead of detaching into a
+fresh trace. See RequestIDMiddleware / _attach_incoming_otel_context.
+"""
+
+from __future__ import annotations
+
+from opentelemetry.propagate import inject
+
+from agentex.lib.sdk.fastacp.base.base_acp_server import (
+    _detach_otel_context,
+    _attach_incoming_otel_context,
+)
+
+
+def _active_traceparent() -> str | None:
+    carrier: dict[str, str] = {}
+    inject(carrier)
+    return carrier.get("traceparent")
+
+
+def test_attach_makes_inbound_traceparent_the_active_context() -> None:
+    trace_id = "0af7651916cd43dd8448eb211c80319c"
+    headers = [
+        (b"traceparent", f"00-{trace_id}-b7ad6b7169203331-01".encode()),
+        (b"content-type", b"application/json"),
+    ]
+    token = _attach_incoming_otel_context(headers)
+    try:
+        active = _active_traceparent()
+        assert active is not None, "no active traceparent after attach"
+        # The active context must carry the ingress trace id, so the Temporal
+        # interceptor propagates it downstream instead of starting a fresh trace.
+        assert trace_id in active, f"expected ingress trace {trace_id}, got {active}"
+    finally:
+        _detach_otel_context(token)
+
+
+def test_no_inbound_traceparent_is_fail_open() -> None:
+    # No traceparent header: must not raise, and detach must be safe.
+    token = _attach_incoming_otel_context([(b"content-type", b"application/json")])
+    _detach_otel_context(token)
+
+
+def test_detach_none_is_safe() -> None:
+    _detach_otel_context(None)


### PR DESCRIPTION
Targets `next`, and builds on the merged #484 (business↔obs correlation) and #485 (Temporal interceptor) — this is a single logical change, no longer stacked.

## Problem
After #484 (business↔obs correlation + Option A) and #485 (Temporal interceptor), an async turn's obs trace still **detached** from the ingress: the workflow + every activity started fresh traces, unlinked from the `event/send` API call.

Root cause (proven on infra-staging with per-hop `traceparent` probes): the ingress `traceparent` **arrives** at the agent's ACP server in the HTTP header, but **FastACP never extracts it** — the active OTel context stays empty. So `start_workflow`/`signal` (and the `asyncio.create_task` background dispatch) fire with no active span, the Temporal interceptor injects nothing, and the workflow/activities root fresh traces.

## Fix
Extract + attach the inbound W3C context in the ASGI `RequestIDMiddleware`, which wraps the whole request (so the background task inherits it via `create_task`'s context copy). Now the interceptor propagates the ingress trace across the Temporal boundary and the workflow/activity inherit it → **one connected trace**. Fail-open (obs never breaks a request).

Parsing is hardened: it uses the explicit `TraceContextTextMapPropagator` (immune to `OTEL_PROPAGATORS=datadog` silently disabling W3C), combines repeated `tracestate` header lines (W3C/RFC7230 MUST) instead of collapsing to the last, and excludes inbound `baggage` so attacker-controlled keys aren't pulled into downstream context. `traceparent` is single-valued, so trace linkage is unchanged.

## Verified (infra-staging)
Trace `12c6290e…`: **347 spans across all 4 services in one tree** — gateway `POST /agents/{id}/rpc` → agent ACP → `RunWorkflow` → `HandleSignal:receive_event` → `RunActivity` → egp/identity/DB. Per-hop probes confirmed `traceparent` went from `<none>` → the ingress trace at every hop (ACP + worker). (Requires the control-plane header-forward fix, scaleapi/scale-agentex#396, to deliver the header.)

## Tests
`tests/test_trace_context_extraction.py` — extract-makes-inbound-active, fail-open on missing header, safe detach, repeated `tracestate` combined, and inbound `baggage` not extracted. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR continues inbound W3C trace context at the ACP request boundary so asynchronous Temporal dispatch inherits the ingress trace.
- Adds fail-open extraction and lifecycle-safe detachment of inbound `traceparent` and `tracestate`.
- Preserves repeated `tracestate` header values while excluding inbound baggage.
- Adds focused tests for extraction, repeated headers, baggage exclusion, and safe cleanup.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agentex/lib/sdk/fastacp/base/base_acp_server.py | Adds request-scoped W3C context extraction, repeated-tracestate preservation, fail-open handling, and guaranteed context detachment. |
| tests/test_trace_context_extraction.py | Adds focused regression coverage for active trace continuation, repeated tracestate fields, baggage exclusion, and safe detachment. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Gateway
    participant ACP as ACP Middleware
    participant Handler
    participant Temporal
    Gateway->>ACP: HTTP request with traceparent/tracestate
    ACP->>ACP: Extract and attach W3C context
    ACP->>Handler: Run request under ingress context
    Handler->>Temporal: Start workflow or signal
    Note over Handler,Temporal: Async dispatch inherits attached context
    Temporal-->>Handler: Dispatch accepted
    Handler-->>ACP: Response
    ACP->>ACP: Detach context safely
    ACP-->>Gateway: HTTP response
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(tracing): parse ACP ingress headers ..."](https://github.com/scaleapi/scale-agentex-python/commit/f13c941d7902cca92942f8f2d12cd133ba72277a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50705737)</sub>

<!-- /greptile_comment -->
