### PR TITLE
feat(temporal_worker): add optional metrics_headers param to AgentexWorker and get_temporal_client

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 75
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/sgp/agentex-sdk-f639b00012e6e4329ead09cceb032a38f83db74efb88a0890505b01011942606.yml
-openapi_spec_hash: 1fef57cdbefab1119cdb5b81a261f06d
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/sgp/agentex-sdk-7acaeb315af90255109ae17afc71e32a8e5851bb8a956a2a284cb4d344dfab51.yml
+openapi_spec_hash: 3044e94b48d60311b6048e8df88e7552
 config_hash: 593e89b291976a5e84e4c3c3f8324354

--- a/src/agentex/lib/adk/__init__.py
+++ b/src/agentex/lib/adk/__init__.py
@@ -29,6 +29,10 @@ from agentex.lib.adk._modules.streaming import StreamingModule
 from agentex.lib.adk._modules.tasks import TasksModule
 from agentex.lib.adk._modules.tracing import TracingModule, TurnSpan
 
+# Data-source refs for lineage (SGP-6513); implementation lives in core.tracing
+from agentex.lib.core.tracing import lineage
+from agentex.lib.core.tracing.lineage import DataSourceRef, data_sources
+
 # Unified harness surface (AGX1-375)
 from agentex.lib.core.harness import (
     UnifiedEmitter,
@@ -67,6 +71,10 @@ __all__ = [
     "events",
     "agent_task_tracker",
     "TurnSpan",
+    # Lineage data-source refs (SGP-6513)
+    "lineage",
+    "DataSourceRef",
+    "data_sources",
     # Checkpointing / LangGraph
     "create_checkpointer",
     "stream_langgraph_events",

--- a/src/agentex/lib/adk/providers/_modules/sync_provider.py
+++ b/src/agentex/lib/adk/providers/_modules/sync_provider.py
@@ -19,6 +19,7 @@ from agents.models.openai_provider import OpenAIProvider
 from agentex import AsyncAgentex
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.core.tracing.tracer import AsyncTracer
+from agentex.lib.core.tracing.lineage import merge_refs_into_data, resolve_refs_from_items
 
 logger = make_logger(__name__)
 
@@ -185,6 +186,9 @@ class SyncStreamingModel(Model):
                         "new_items": new_items,
                         "final_output": final_output,
                     }
+                    lineage_refs = resolve_refs_from_items(new_items)
+                    if lineage_refs:
+                        span.data = merge_refs_into_data(span.data, lineage_refs)
 
                 return response
         else:
@@ -303,6 +307,9 @@ class SyncStreamingModel(Model):
                     "new_items": new_items,
                     "final_output": final_response_text if final_response_text else None,
                 }
+                lineage_refs = resolve_refs_from_items(new_items)
+                if lineage_refs:
+                    span.data = merge_refs_into_data(span.data, lineage_refs)
             finally:
                 # End the span after all events have been yielded
                 await trace.end_span(span)

--- a/src/agentex/lib/core/harness/tracer.py
+++ b/src/agentex/lib/core/harness/tracer.py
@@ -7,6 +7,17 @@ from typing import Any
 from agentex.lib.core.harness.types import OpenSpan, CloseSpan, SpanSignal
 
 try:
+    from agentex.lib.core.tracing.lineage import resolve_refs, merge_refs_into_data
+except Exception:  # keep the harness importable without optional tracing deps
+
+    def resolve_refs(tool_name: str, arguments: dict[str, Any] | None) -> list[dict[str, Any]]:  # noqa: ARG001
+        return []
+
+    def merge_refs_into_data(data: dict[str, Any] | None, refs: list[dict[str, Any]]) -> dict[str, Any]:  # noqa: ARG001
+        return dict(data or {})
+
+
+try:
     from agentex.lib.utils.logging import make_logger
 
     logger = make_logger(__name__)
@@ -80,6 +91,11 @@ class SpanTracer:
                     task_id=self.task_id,
                 )
                 if span is not None:
+                    if signal.kind == "tool":
+                        refs = resolve_refs(signal.name, signal.input if isinstance(signal.input, dict) else {})
+                        if refs:
+                            data = span.data if isinstance(span.data, dict) else {}
+                            span.data = merge_refs_into_data(data, refs)
                     self._open[signal.key] = span
             elif isinstance(signal, CloseSpan):
                 span = self._open.pop(signal.key, None)

--- a/src/agentex/lib/core/services/adk/providers/openai.py
+++ b/src/agentex/lib/core/services/adk/providers/openai.py
@@ -25,6 +25,7 @@ from agentex.lib.utils.mcp import redact_mcp_server_params
 from agentex.lib.utils.temporal import heartbeat_if_in_workflow
 from agentex.lib.core.tracing.tracer import AsyncTracer
 from agentex.lib.core.harness.emitter import UnifiedEmitter
+from agentex.lib.core.tracing.lineage import merge_refs_into_data, resolve_refs_from_items
 from agentex.types.task_message_update import StreamTaskMessageFull
 from agentex.types.task_message_content import (
     TextContent,
@@ -286,13 +287,17 @@ class OpenAIService:
                     result = await Runner.run(starting_agent=agent, input=input_list)
 
                 if span:
+                    serialized_items = [
+                        item.raw_item.model_dump() if isinstance(item.raw_item, BaseModel) else item.raw_item
+                        for item in result.new_items
+                    ]
                     span.output = {
-                        "new_items": [
-                            item.raw_item.model_dump() if isinstance(item.raw_item, BaseModel) else item.raw_item
-                            for item in result.new_items
-                        ],
+                        "new_items": serialized_items,
                         "final_output": result.final_output,
                     }
+                    lineage_refs = resolve_refs_from_items(serialized_items)
+                    if lineage_refs:
+                        span.data = merge_refs_into_data(span.data, lineage_refs)
 
         return result
 
@@ -431,13 +436,17 @@ class OpenAIService:
                     result = await Runner.run(starting_agent=agent, input=input_list)
 
                 if span:
+                    serialized_items = [
+                        item.raw_item.model_dump() if isinstance(item.raw_item, BaseModel) else item.raw_item
+                        for item in result.new_items
+                    ]
                     span.output = {
-                        "new_items": [
-                            item.raw_item.model_dump() if isinstance(item.raw_item, BaseModel) else item.raw_item
-                            for item in result.new_items
-                        ],
+                        "new_items": serialized_items,
                         "final_output": result.final_output,
                     }
+                    lineage_refs = resolve_refs_from_items(serialized_items)
+                    if lineage_refs:
+                        span.data = merge_refs_into_data(span.data, lineage_refs)
 
                 tool_call_map: dict[str, Any] = {}
 
@@ -646,13 +655,17 @@ class OpenAIService:
                     result = Runner.run_streamed(starting_agent=agent, input=input_list)
 
                 if span:
+                    serialized_items = [
+                        item.raw_item.model_dump() if isinstance(item.raw_item, BaseModel) else item.raw_item
+                        for item in result.new_items
+                    ]
                     span.output = {
-                        "new_items": [
-                            item.raw_item.model_dump() if isinstance(item.raw_item, BaseModel) else item.raw_item
-                            for item in result.new_items
-                        ],
+                        "new_items": serialized_items,
                         "final_output": result.final_output,
                     }
+                    lineage_refs = resolve_refs_from_items(serialized_items)
+                    if lineage_refs:
+                        span.data = merge_refs_into_data(span.data, lineage_refs)
 
         return result
 
@@ -906,12 +919,16 @@ class OpenAIService:
                     raise
 
                 if span:
+                    serialized_items = [
+                        item.raw_item.model_dump() if isinstance(item.raw_item, BaseModel) else item.raw_item
+                        for item in result.new_items
+                    ]
                     span.output = {
-                        "new_items": [
-                            item.raw_item.model_dump() if isinstance(item.raw_item, BaseModel) else item.raw_item
-                            for item in result.new_items
-                        ],
+                        "new_items": serialized_items,
                         "final_output": result.final_output,
                     }
+                    lineage_refs = resolve_refs_from_items(serialized_items)
+                    if lineage_refs:
+                        span.data = merge_refs_into_data(span.data, lineage_refs)
 
         return result

--- a/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
+++ b/src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
@@ -64,6 +64,7 @@ from openai.types.responses.response_prompt_param import ResponsePromptParam
 from agentex.lib import adk
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.core.tracing.tracer import AsyncTracer
+from agentex.lib.core.tracing.lineage import merge_refs_into_data, resolve_refs_from_items
 from agentex.types.task_message_delta import TextDelta, ToolRequestDelta, ReasoningContentDelta, ReasoningSummaryDelta
 from agentex.types.task_message_update import StreamTaskMessageFull, StreamTaskMessageDelta
 from agentex.types.task_message_content import TextContent, ReasoningContent, ToolRequestContent, ToolResponseContent
@@ -1257,6 +1258,9 @@ class TemporalStreamingModel(Model):
                         output_data["tool_outputs"] = tool_outputs
 
                     span.output = output_data
+                    lineage_refs = resolve_refs_from_items(new_items)
+                    if lineage_refs:
+                        span.data = merge_refs_into_data(span.data, lineage_refs)
 
                 # Streaming-only metrics. Token counters and the success request
                 # counter are emitted by LLMMetricsHooks.on_llm_end so they fire

--- a/src/agentex/lib/core/temporal/workers/worker.py
+++ b/src/agentex/lib/core/temporal/workers/worker.py
@@ -95,6 +95,7 @@ def _validate_interceptors(interceptors: list) -> None:
 async def get_temporal_client(
     temporal_address: str,
     metrics_url: str | None = None,
+    metrics_headers: dict[str, str] | None = None,
     plugins: list = [],
     payload_codec: PayloadCodec | None = None,
     data_converter: DataConverter | None = None,
@@ -143,7 +144,10 @@ async def get_temporal_client(
     if not metrics_url:
         client = await Client.connect(**connect_kwargs)
     else:
-        runtime = Runtime(telemetry=TelemetryConfig(metrics=OpenTelemetryConfig(url=metrics_url)))
+        runtime = Runtime(telemetry=TelemetryConfig(metrics=OpenTelemetryConfig(
+            url=metrics_url,
+            headers=metrics_headers or {},
+        )))
         connect_kwargs["runtime"] = runtime
         client = await Client.connect(**connect_kwargs)
     return client
@@ -159,6 +163,7 @@ class AgentexWorker:
         plugins: list = [],
         interceptors: list = [],
         metrics_url: str | None = None,
+        metrics_headers: dict[str, str] | None = None,
         payload_codec: PayloadCodec | None = None,
         data_converter: DataConverter | None = None,
     ):
@@ -174,6 +179,7 @@ class AgentexWorker:
         self.plugins = plugins
         self.interceptors = interceptors
         self.metrics_url = metrics_url
+        self.metrics_headers = metrics_headers
         self.payload_codec = payload_codec
         self.data_converter = data_converter
 
@@ -211,6 +217,7 @@ class AgentexWorker:
             temporal_address=os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"),
             plugins=self.plugins,
             metrics_url=self.metrics_url,
+            metrics_headers=self.metrics_headers,
             payload_codec=self.payload_codec,
             data_converter=self.data_converter,
         )

--- a/src/agentex/lib/core/tracing/lineage.py
+++ b/src/agentex/lib/core/tracing/lineage.py
@@ -1,0 +1,174 @@
+"""Data-source reference capture for lineage: tools declare which sources they
+touch and the refs land in span data under the ``sgp.lineage.refs`` key."""
+
+from __future__ import annotations
+
+import re
+import json
+from typing import Any, Literal, Callable, Iterable
+
+from pydantic import Field, BaseModel, field_validator
+
+try:
+    from agentex.lib.utils.logging import make_logger
+
+    logger = make_logger(__name__)
+except Exception:  # ddtrace may be absent in some envs; fall back to stdlib
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+LINEAGE_REFS_KEY = "sgp.lineage.refs"
+
+# The URI arm of the lineage namespace identifier rule (namespace-conventions.md):
+# lowercase scheme and host (dots/hyphens only — normalize `_` to `-`), one optional path segment.
+_URI_NAMESPACE_RE = re.compile(r"^[a-z][a-z0-9._-]*://[a-z0-9.-]+(/[a-zA-Z0-9._-]*)?$")
+
+RefResolver = Callable[[dict[str, Any]], "list[DataSourceRef]"]
+
+
+class DataSourceRef(BaseModel):
+    """One data source a tool call touched, as a lineage coordinate."""
+
+    namespace: str = Field(max_length=512)
+    name: str = Field(min_length=1, max_length=512)
+    version: str | None = Field(default=None, max_length=256)
+    role: Literal["input", "output"] = "input"
+
+    def __init__(self, namespace: str | None = None, name: str | None = None, **kwargs: Any) -> None:
+        if namespace is not None:
+            kwargs["namespace"] = namespace
+        if name is not None:
+            kwargs["name"] = name
+        super().__init__(**kwargs)
+
+    @field_validator("namespace")
+    @classmethod
+    def _namespace_is_uri_form(cls, value: str) -> str:
+        if not _URI_NAMESPACE_RE.match(value):
+            raise ValueError(f"namespace must be URI-form (scheme://system), got: {value!r}")
+        return value
+
+
+class _ToolSources(BaseModel):
+    refs: list[DataSourceRef] = Field(default_factory=list)
+    resolver: RefResolver | None = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+_tool_sources: dict[str, _ToolSources] = {}
+
+
+def register_tool_sources(
+    tool_name: str,
+    refs: Iterable[DataSourceRef] | None = None,
+    resolver: RefResolver | None = None,
+) -> None:
+    """Declare the data sources a tool touches, keyed by its tool name.
+
+    Use for tools the agent does not own (e.g. MCP proxy tools). Static refs and
+    a resolver over the tool's parsed arguments may be combined; repeated
+    registration for the same name replaces the prior entry. The registry is
+    process-wide: co-located agents sharing a tool name share (and overwrite)
+    one entry, so disambiguate shared names before co-locating agent types.
+    """
+    _tool_sources[tool_name] = _ToolSources(refs=list(refs or []), resolver=resolver)
+
+
+def data_sources(*refs: DataSourceRef, resolver: RefResolver | None = None) -> Callable[[Any], Any]:
+    """Decorator form of ``register_tool_sources`` for tools the agent owns.
+
+    Works below or above ``@function_tool``: the tool name is taken from the
+    decorated object's ``name`` attribute when present, else ``__name__``.
+    """
+
+    def _register(obj: Any) -> Any:
+        tool_name = getattr(obj, "name", None) or getattr(obj, "__name__", None)
+        if isinstance(tool_name, str) and tool_name:
+            register_tool_sources(tool_name, refs=refs, resolver=resolver)
+        else:
+            logger.warning("data_sources could not determine a tool name for %r; refs not registered", obj)
+        return obj
+
+    return _register
+
+
+def clear_tool_sources() -> None:
+    """Reset the registry (test isolation)."""
+    _tool_sources.clear()
+
+
+def resolve_refs(tool_name: str, arguments: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Resolve registered refs for one tool call to serialized, deduplicated dicts.
+
+    Resolver failures are logged and swallowed: ref capture must never break a
+    tool call or its tracing.
+    """
+    entry = _tool_sources.get(tool_name)
+    if entry is None:
+        return []
+    refs = list(entry.refs)
+    if entry.resolver is not None:
+        try:
+            refs.extend(entry.resolver(arguments or {}))
+        except Exception:
+            logger.warning("data-source resolver for tool %s failed; static refs kept", tool_name, exc_info=True)
+    return _dedupe(refs)
+
+
+def resolve_refs_from_items(items: Iterable[Any]) -> list[dict[str, Any]]:
+    """Resolve refs across serialized run items, matching ``function_call`` entries.
+
+    Accepts the item dicts the providers already build for span output; string
+    ``arguments`` are parsed as JSON for resolver-based registrations.
+    """
+    refs: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict) or item.get("type") != "function_call":
+            continue
+        tool_name = item.get("name")
+        if not isinstance(tool_name, str) or not tool_name:
+            continue
+        arguments = item.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except (ValueError, TypeError):
+                arguments = {}
+        refs.extend(resolve_refs(tool_name, arguments if isinstance(arguments, dict) else {}))
+    return _dedupe_dicts(refs)
+
+
+def record(span: Any, refs: Iterable[DataSourceRef]) -> None:
+    """Attach refs to a manually managed span (no-op when the span is None)."""
+    if span is None:
+        return
+    merged = merge_refs_into_data(getattr(span, "data", None), _dedupe(list(refs)))
+    span.data = merged
+
+
+def merge_refs_into_data(data: dict[str, Any] | None, refs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge serialized refs into a span data dict, deduplicating with any present."""
+    out = dict(data) if isinstance(data, dict) else {}
+    if refs:
+        existing = out.get(LINEAGE_REFS_KEY)
+        combined = list(existing) if isinstance(existing, list) else []
+        combined.extend(refs)
+        out[LINEAGE_REFS_KEY] = _dedupe_dicts(combined)
+    return out
+
+
+def _dedupe(refs: list[DataSourceRef]) -> list[dict[str, Any]]:
+    return _dedupe_dicts([ref.model_dump(exclude_none=True) for ref in refs])
+
+
+def _dedupe_dicts(refs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[Any, ...]] = set()
+    out: list[dict[str, Any]] = []
+    for ref in refs:
+        key = (ref.get("namespace"), ref.get("name"), ref.get("version"), ref.get("role"))
+        if key not in seen:
+            seen.add(key)
+            out.append(ref)
+    return out

--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -65,6 +65,8 @@ def _add_source_to_span(span: Span, env_vars: EnvironmentVariables) -> None:
             span.data["__agent_name__"] = env_vars.AGENT_NAME
         if env_vars.AGENT_ID is not None:
             span.data["__agent_id__"] = env_vars.AGENT_ID
+        if env_vars.AGENT_VERSION is not None:
+            span.data["__agent_version__"] = env_vars.AGENT_VERSION
 
 
 def _build_sgp_span(span: Span, env_vars: EnvironmentVariables) -> SGPSpan:

--- a/src/agentex/lib/environment_variables.py
+++ b/src/agentex/lib/environment_variables.py
@@ -24,6 +24,7 @@ class EnvVarKeys(str, Enum):
     AGENT_NAME = "AGENT_NAME"
     AGENT_DESCRIPTION = "AGENT_DESCRIPTION"
     AGENT_ID = "AGENT_ID"
+    AGENT_VERSION = "AGENT_VERSION"
     AGENT_API_KEY = "AGENT_API_KEY"
     # ACP Configuration
     ACP_URL = "ACP_URL"
@@ -64,6 +65,8 @@ class EnvironmentVariables(BaseModel):
     AGENT_NAME: str
     AGENT_DESCRIPTION: str | None = None
     AGENT_ID: str | None = None
+    # Build/version discriminator (image tag or git sha), set by the deployment
+    AGENT_VERSION: str | None = None
     AGENT_API_KEY: str | None = None
     ACP_TYPE: str | None = "async"
     AGENT_INPUT_TYPE: str | None = None

--- a/tests/lib/core/harness/test_tracer_lineage.py
+++ b/tests/lib/core/harness/test_tracer_lineage.py
@@ -1,0 +1,53 @@
+"""SpanTracer stamps registered data-source refs onto tool spans (SGP-6513)."""
+
+import pytest
+
+from agentex.lib.core.harness.types import OpenSpan, CloseSpan
+from agentex.lib.core.harness.tracer import SpanTracer
+from agentex.lib.core.tracing.lineage import (
+    LINEAGE_REFS_KEY,
+    DataSourceRef,
+    clear_tool_sources,
+    register_tool_sources,
+)
+
+from ._fakes import FakeTracing
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_tool_sources()
+    yield
+    clear_tool_sources()
+
+
+@pytest.mark.asyncio
+async def test_tool_open_span_carries_registered_refs():
+    register_tool_sources(
+        "query_guidance",
+        refs=[DataSourceRef("databricks://ey-tax", "guidance.rulings")],
+        resolver=lambda args: [DataSourceRef("elasticsearch://ey", args["index"])],
+    )
+    fake = FakeTracing()
+    tracer = SpanTracer(trace_id="t1", parent_span_id="p1", tracing=fake)
+
+    await tracer.handle(OpenSpan(key="c1", kind="tool", name="query_guidance", input={"index": "filings"}))
+    await tracer.handle(CloseSpan(key="c1", output={"ok": True}, is_complete=True))
+
+    (span,) = fake.ended_spans
+    namespaces = {ref["namespace"] for ref in span.data[LINEAGE_REFS_KEY]}
+    assert namespaces == {"databricks://ey-tax", "elasticsearch://ey"}
+
+
+@pytest.mark.asyncio
+async def test_unregistered_tool_and_reasoning_spans_carry_no_refs():
+    fake = FakeTracing()
+    tracer = SpanTracer(trace_id="t1", parent_span_id=None, tracing=fake)
+
+    await tracer.handle(OpenSpan(key="c1", kind="tool", name="unregistered", input={}))
+    await tracer.handle(CloseSpan(key="c1", output=None, is_complete=True))
+    await tracer.handle(OpenSpan(key="reasoning:0", kind="reasoning", name="reasoning", input={}))
+    await tracer.handle(CloseSpan(key="reasoning:0", output="thought", is_complete=True))
+
+    for span in fake.ended_spans:
+        assert not (isinstance(span.data, dict) and LINEAGE_REFS_KEY in span.data)

--- a/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
@@ -39,6 +39,30 @@ def _make_mock_sgp_span() -> MagicMock:
     return sgp_span
 
 
+class TestSourceStamps:
+    def test_agent_identity_and_version_stamped_into_span_data(self):
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _add_source_to_span
+
+        env = MagicMock(ACP_TYPE="async", AGENT_NAME="emu-tax", AGENT_ID="a1", AGENT_VERSION="sha-abc123")
+        span = _make_span()
+        _add_source_to_span(span, env)
+        assert span.data == {
+            "__source__": "agentex",
+            "__acp_type__": "async",
+            "__agent_name__": "emu-tax",
+            "__agent_id__": "a1",
+            "__agent_version__": "sha-abc123",
+        }
+
+    def test_unset_identity_fields_are_omitted(self):
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _add_source_to_span
+
+        env = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
+        span = _make_span()
+        _add_source_to_span(span, env)
+        assert span.data == {"__source__": "agentex"}
+
+
 # ---------------------------------------------------------------------------
 # Sync processor tests
 # ---------------------------------------------------------------------------
@@ -48,7 +72,7 @@ class TestSGPSyncTracingProcessor:
     @staticmethod
     def _make_processor():
         mock_env = MagicMock()
-        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None)
+        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
         mock_create_span = MagicMock(side_effect=lambda **kwargs: _make_mock_sgp_span())
 
         with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(f"{MODULE}.SGPClient"), patch(
@@ -150,7 +174,7 @@ class TestSGPAsyncTracingProcessor:
     @staticmethod
     def _make_processor():
         mock_env = MagicMock()
-        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None)
+        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
         mock_create_span = MagicMock(side_effect=lambda **kwargs: _make_mock_sgp_span())
 
         mock_async_client = MagicMock()
@@ -319,11 +343,9 @@ class TestSGPAsyncTracingProcessor:
         keepalive instead of paying a TLS handshake per span.
         """
         mock_env = MagicMock()
-        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None)
+        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
 
-        with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(
-            f"{MODULE}.AsyncSGPClient"
-        ) as mock_sgp_cls:
+        with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(f"{MODULE}.AsyncSGPClient") as mock_sgp_cls:
             mock_sgp_cls.side_effect = lambda **kwargs: MagicMock()
 
             from agentex.lib.core.tracing.processors.sgp_tracing_processor import (
@@ -365,11 +387,11 @@ class TestSGPAsyncTracingProcessor:
             return original_async_client(*args, **kwargs)
 
         mock_env = MagicMock()
-        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None)
+        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
 
-        with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(
-            f"{MODULE}.AsyncSGPClient"
-        ), patch("httpx.AsyncClient", side_effect=capture_limits):
+        with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(f"{MODULE}.AsyncSGPClient"), patch(
+            "httpx.AsyncClient", side_effect=capture_limits
+        ):
             from agentex.lib.core.tracing.processors.sgp_tracing_processor import (
                 SGPAsyncTracingProcessor,
             )
@@ -380,8 +402,7 @@ class TestSGPAsyncTracingProcessor:
         assert len(captured_limits) == 1
         max_keepalive = captured_limits[0].max_keepalive_connections
         assert max_keepalive is not None and max_keepalive > 0, (
-            f"SGP async client should have keepalive enabled, got "
-            f"max_keepalive_connections={max_keepalive}"
+            f"SGP async client should have keepalive enabled, got max_keepalive_connections={max_keepalive}"
         )
 
     def test_cache_is_weakkeydict_and_evicts_dead_loops(self):
@@ -395,7 +416,7 @@ class TestSGPAsyncTracingProcessor:
         import weakref
 
         mock_env = MagicMock()
-        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None)
+        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
 
         with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(f"{MODULE}.AsyncSGPClient"):
             from agentex.lib.core.tracing.processors.sgp_tracing_processor import (
@@ -428,18 +449,14 @@ class TestSGPAsyncTracingProcessor:
         from agentex.lib.types.tracing import SGPTracingProcessorConfig
 
         mock_env = MagicMock()
-        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None)
+        mock_env.refresh.return_value = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
 
-        with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(
-            f"{MODULE}.AsyncSGPClient"
-        ) as mock_sgp_cls:
+        with patch(f"{MODULE}.EnvironmentVariables", mock_env), patch(f"{MODULE}.AsyncSGPClient") as mock_sgp_cls:
             from agentex.lib.core.tracing.processors.sgp_tracing_processor import (
                 SGPAsyncTracingProcessor,
             )
 
-            processor = SGPAsyncTracingProcessor(
-                SGPTracingProcessorConfig(sgp_api_key="", sgp_account_id="")
-            )
+            processor = SGPAsyncTracingProcessor(SGPTracingProcessorConfig(sgp_api_key="", sgp_account_id=""))
 
             assert processor._get_client() is None
             assert mock_sgp_cls.call_count == 0

--- a/tests/lib/core/tracing/test_lineage.py
+++ b/tests/lib/core/tracing/test_lineage.py
@@ -1,0 +1,147 @@
+"""Unit tests for the data-source ref module (sgp.lineage.refs capture)."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from agentex.lib.core.tracing.lineage import (
+    LINEAGE_REFS_KEY,
+    DataSourceRef,
+    record,
+    data_sources,
+    resolve_refs,
+    clear_tool_sources,
+    merge_refs_into_data,
+    register_tool_sources,
+    resolve_refs_from_items,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_tool_sources()
+    yield
+    clear_tool_sources()
+
+
+ES_REF = DataSourceRef("elasticsearch://ey-embryonic", "companies_v3")
+DBX_REF = DataSourceRef("databricks://ey-tax", "guidance.rulings", role="input")
+
+
+class TestDataSourceRef:
+    def test_positional_construction(self):
+        ref = DataSourceRef("s3://bucket", "key", version="v1", role="output")
+        assert ref.namespace == "s3://bucket"
+        assert ref.name == "key"
+        assert ref.version == "v1"
+        assert ref.role == "output"
+
+    def test_non_uri_namespace_rejected(self):
+        with pytest.raises(ValidationError):
+            DataSourceRef("not-a-uri", "name")
+
+    def test_underscore_host_rejected(self):
+        with pytest.raises(ValidationError):
+            DataSourceRef("mcp://ey_tax_server", "competitive-edge")
+
+    def test_host_with_path_segment_allowed(self):
+        DataSourceRef("confluence://ey-tax/TAX", "page-123")
+
+    def test_empty_name_rejected(self):
+        with pytest.raises(ValidationError):
+            DataSourceRef("s3://bucket", "")
+
+    def test_bad_role_rejected(self):
+        with pytest.raises(ValidationError):
+            DataSourceRef("s3://bucket", "key", role="sideways")
+
+
+class TestRegistryAndResolve:
+    def test_unregistered_tool_resolves_empty(self):
+        assert resolve_refs("unknown_tool", {}) == []
+
+    def test_static_refs(self):
+        register_tool_sources("search", refs=[ES_REF])
+        refs = resolve_refs("search", {"q": "acme"})
+        assert refs == [{"namespace": "elasticsearch://ey-embryonic", "name": "companies_v3", "role": "input"}]
+
+    def test_resolver_refs_combined_with_static(self):
+        register_tool_sources(
+            "query_table",
+            refs=[ES_REF],
+            resolver=lambda args: [DataSourceRef("databricks://ey-tax", args["table"])],
+        )
+        refs = resolve_refs("query_table", {"table": "guidance.rulings"})
+        assert {r["namespace"] for r in refs} == {"elasticsearch://ey-embryonic", "databricks://ey-tax"}
+
+    def test_resolver_failure_keeps_static_refs(self):
+        register_tool_sources("flaky", refs=[ES_REF], resolver=lambda args: args["missing"])
+        refs = resolve_refs("flaky", {})
+        assert len(refs) == 1
+
+    def test_reregistration_replaces(self):
+        register_tool_sources("search", refs=[ES_REF])
+        register_tool_sources("search", refs=[DBX_REF])
+        assert resolve_refs("search", {})[0]["namespace"] == "databricks://ey-tax"
+
+    def test_dedupe(self):
+        register_tool_sources("search", refs=[ES_REF, ES_REF])
+        assert len(resolve_refs("search", {})) == 1
+
+
+class TestDecorator:
+    def test_registers_by_function_name(self):
+        @data_sources(ES_REF)
+        def search_companies(q: str) -> str:
+            return q
+
+        assert search_companies("x") == "x"
+        assert resolve_refs("search_companies", {}) != []
+
+    def test_registers_by_name_attribute(self):
+        class FakeFunctionTool:
+            name = "mcp_search"
+
+        data_sources(DBX_REF)(FakeFunctionTool())
+        assert resolve_refs("mcp_search", {}) != []
+
+
+class TestResolveFromItems:
+    def test_matches_function_call_items_and_parses_string_arguments(self):
+        register_tool_sources(
+            "query_table",
+            resolver=lambda args: [DataSourceRef("databricks://ey-tax", args["table"])],
+        )
+        items = [
+            {"type": "message", "content": []},
+            {"type": "function_call", "name": "query_table", "arguments": json.dumps({"table": "t1"})},
+            {"type": "function_call", "name": "unregistered", "arguments": "{}"},
+            "not-a-dict",
+        ]
+        refs = resolve_refs_from_items(items)
+        assert refs == [{"namespace": "databricks://ey-tax", "name": "t1", "role": "input"}]
+
+    def test_malformed_arguments_fall_back_to_static(self):
+        register_tool_sources("search", refs=[ES_REF])
+        items = [{"type": "function_call", "name": "search", "arguments": "{not json"}]
+        assert len(resolve_refs_from_items(items)) == 1
+
+
+class TestRecordAndMerge:
+    def test_record_on_none_span_is_noop(self):
+        record(None, [ES_REF])
+
+    def test_record_merges_into_span_data(self):
+        class Span:
+            data = {"__span_type__": "CUSTOM"}
+
+        span = Span()
+        record(span, [ES_REF])
+        assert span.data["__span_type__"] == "CUSTOM"
+        assert span.data[LINEAGE_REFS_KEY][0]["name"] == "companies_v3"
+
+    def test_merge_dedupes_against_existing(self):
+        data = merge_refs_into_data(None, [ES_REF.model_dump(exclude_none=True)])
+        data = merge_refs_into_data(data, [ES_REF.model_dump(exclude_none=True)])
+        assert len(data[LINEAGE_REFS_KEY]) == 1


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds authenticated Temporal metrics-export configuration and introduces data-source lineage metadata across ADK, harness, provider, and tracing paths. It also stamps agent versions onto SGP spans.
- Adds optional `metrics_headers` forwarding to Temporal OpenTelemetry configuration.
- Adds public lineage registration, resolution, deduplication, and span-merging APIs.
- Integrates lineage capture into harness and OpenAI provider spans.
- Adds `AGENT_VERSION` to emitted SGP span metadata and expands tracing tests.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The Temporal streaming lineage path should be fixed before merging because it records input tool calls on spans while dropping their registered data-source references.

The new lineage integration passes only response-derived items to the resolver even though the same code separately extracts input function calls, causing those calls to reach the tracing backend without their expected lineage metadata.

**Files Needing Attention:** src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/lineage.py | Introduces the lineage reference model, process-wide registration, item resolution, deduplication, and span-data merging. |
| src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py | Adds lineage capture but excludes function calls extracted from input when resolving the completed span's references. |
| src/agentex/lib/core/temporal/workers/worker.py | Adds optional metrics exporter headers and forwards them through worker client initialization. |
| src/agentex/lib/core/harness/tracer.py | Attaches registered lineage references when opening harness tool spans. |
| src/agentex/lib/core/services/adk/providers/openai.py | Reuses serialized run items for span output and lineage resolution across OpenAI service execution paths. |
| src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py | Adds the optional agent deployment version to SGP span metadata. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Tool[Registered tool and data-source refs] --> Registry[Process lineage registry]
  Call[Function-call item] --> Resolver[Resolve and deduplicate refs]
  Registry --> Resolver
  Resolver --> Span[Attach sgp.lineage.refs to span data]
  Span --> Processor[SGP tracing processor]
  Processor --> Backend[Tracing backend]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20scaleapi%2Fscale-agentex-python%20PR%20%23500%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=500&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Fmodels%2Ftemporal_streaming_model.py%3A1261%0A**Input%20tool%20lineage%20is%20dropped**%0A%0AWhen%20a%20Temporal%20model%20invocation%20receives%20a%20registered%20%60function_call%60%20in%20its%20input%20and%20the%20response%20does%20not%20repeat%20it%20in%20%60new_items%60%2C%20lineage%20resolution%20examines%20only%20%60new_items%60%2C%20causing%20the%20span%20to%20record%20the%20call%20in%20%60tool_calls%60%20while%20omitting%20its%20registered%20data-source%20references.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lineage_refs%20%3D%20resolve_refs_from_items%28%5B*new_items%2C%20*tool_calls%5D%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=500&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Fmodels%2Ftemporal_streaming_model.py%3A1261%0A**Input%20tool%20lineage%20is%20dropped**%0A%0AWhen%20a%20Temporal%20model%20invocation%20receives%20a%20registered%20%60function_call%60%20in%20its%20input%20and%20the%20response%20does%20not%20repeat%20it%20in%20%60new_items%60%2C%20lineage%20resolution%20examines%20only%20%60new_items%60%2C%20causing%20the%20span%20to%20record%20the%20call%20in%20%60tool_calls%60%20while%20omitting%20its%20registered%20data-source%20references.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lineage_refs%20%3D%20resolve_refs_from_items%28%5B*new_items%2C%20*tool_calls%5D%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex-python&pr=500&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex-python%22%20on%20the%20existing%20branch%20%22akam%2Ftemporal-metrics-headers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22akam%2Ftemporal-metrics-headers%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fagentex%2Flib%2Fcore%2Ftemporal%2Fplugins%2Fopenai_agents%2Fmodels%2Ftemporal_streaming_model.py%3A1261%0A**Input%20tool%20lineage%20is%20dropped**%0A%0AWhen%20a%20Temporal%20model%20invocation%20receives%20a%20registered%20%60function_call%60%20in%20its%20input%20and%20the%20response%20does%20not%20repeat%20it%20in%20%60new_items%60%2C%20lineage%20resolution%20examines%20only%20%60new_items%60%2C%20causing%20the%20span%20to%20record%20the%20call%20in%20%60tool_calls%60%20while%20omitting%20its%20registered%20data-source%20references.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lineage_refs%20%3D%20resolve_refs_from_items%28%5B*new_items%2C%20*tool_calls%5D%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex-python&pr=500&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/agentex/lib/core/temporal/plugins/openai_agents/models/temporal_streaming_model.py:1261
**Input tool lineage is dropped**

When a Temporal model invocation receives a registered `function_call` in its input and the response does not repeat it in `new_items`, lineage resolution examines only `new_items`, causing the span to record the call in `tool_calls` while omitting its registered data-source references.

```suggestion
                    lineage_refs = resolve_refs_from_items([*new_items, *tool_calls])
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add optional metrics\_headers param to Ag..."](https://github.com/scaleapi/scale-agentex-python/commit/410e35d74212b90e6eef5bc4ce93861fca9898f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56872257)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Temporal execution](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex-python/-/docs/temporal-execution.md)
- Knowledge Base — [Agent framework integrations](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex-python/-/docs/agent-framework-integrations.md)
- Knowledge Base — [Tracing pipeline](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex-python/-/docs/tracing-pipeline.md)
</details>


<!-- /greptile_comment -->