### PR TITLE
feat(cli): stamp global.agent.version from the image tag on helm deploys

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 75
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/sgp/agentex-sdk-7acaeb315af90255109ae17afc71e32a8e5851bb8a956a2a284cb4d344dfab51.yml
-openapi_spec_hash: 3044e94b48d60311b6048e8df88e7552
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/sgp/agentex-sdk-7074b9156acbeefa63e9ca2173e9c22768268e894a48f511ec902fdcff043407.yml
+openapi_spec_hash: 400e8dc4ce4d49db45e2943f67fe255a
 config_hash: 593e89b291976a5e84e4c3c3f8324354

--- a/src/agentex/lib/cli/handlers/deploy_handlers.py
+++ b/src/agentex/lib/cli/handlers/deploy_handlers.py
@@ -279,6 +279,9 @@ def merge_deployment_configs(
                 "name": manifest.agent.name,
                 "description": manifest.agent.description,
                 "acp_type": manifest.agent.acp_type,
+                # Rendered as the pod's AGENT_VERSION (chart >=0.6.0), stamped
+                # onto every span as __agent_version__ by the SGP processor.
+                "version": image_tag,
             },
         },
         "replicaCount": manifest.deployment.global_config.replicaCount,


### PR DESCRIPTION
CLI (classic helm) deploys now set `global.agent.version` to the resolved image tag in the rendered helm values. With agentex-agent chart ≥ 0.6.0 (scaleapi/sgp#5466) that lands as the pod's `AGENT_VERSION` env var, which the SGP tracing processor (agentex-sdk ≥ 0.25.0, #469) stamps onto every span as `__agent_version__` — build provenance on traces, keyed by the same image identity the lineage build/deploy graph uses.

Ordering is free in both directions: old charts ignore the key; the new chart omits the env var when the key is absent. Siblings: chart = scaleapi/sgp#5466; agentex cloud deploy = scaleapi/scaleapi#158940. Set the version via the image tag here or an explicit `AGENT_VERSION` in manifest `env`, not both — repeating a chart-generated name renders duplicate env entries.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=58001897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<h3>Summary</h3>

Classic Helm deploys now copy the resolved image tag into `global.agent.version`, so supported charts can expose the same build identity to tracing. Explicit `AGENT_VERSION` settings still take priority to avoid duplicate environment entries.

- Stamps the resolved image tag into rendered Helm values.
- Preserves explicit version overrides and environment declarations.
- Adds coverage for image tags, overrides, and duplicate-prevention paths.

<details><summary>Diagram</summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Values as Helm values
    participant Helm
    User->>CLI: Deploy manifest and overrides
    CLI->>Values: Build image and agent values
    CLI->>Values: Merge environment Helm overrides
    alt AGENT_VERSION is declared
        CLI->>Values: Keep the declared environment value
    else No AGENT_VERSION is declared
        CLI->>Values: Set global.agent.version from final image tag
    end
    CLI->>Helm: Install or upgrade with merged values
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["fix(cli): derive agent version after ove..."](https://github.com/scaleapi/scale-agentex-python/commit/02c1f0245922e674788d78459d2f8c4263d60eaa)</sub>

<!-- /greptile_comment -->