### PR TITLE
feat(tracing): add opt-in commit SHA stamping for SGP spans

### DIFF
--- a/src/agentex/lib/adk/__init__.py
+++ b/src/agentex/lib/adk/__init__.py
@@ -31,6 +31,9 @@ from agentex.lib.adk._modules.tracing import TracingModule, TurnSpan
 
 # Data-source refs for lineage (SGP-6513); implementation lives in core.tracing
 from agentex.lib.core.tracing import lineage
+
+# Opt-in commit-SHA stamping (AGX1-969); implementation in core.tracing
+from agentex.lib.core.tracing import code_revision
 from agentex.lib.core.tracing.lineage import DataSourceRef, data_sources
 
 # Unified harness surface (AGX1-375)
@@ -73,6 +76,7 @@ __all__ = [
     "TurnSpan",
     # Lineage data-source refs (SGP-6513)
     "lineage",
+    "code_revision",
     "DataSourceRef",
     "data_sources",
     # Checkpointing / LangGraph

--- a/src/agentex/lib/core/tracing/code_revision.py
+++ b/src/agentex/lib/core/tracing/code_revision.py
@@ -1,0 +1,105 @@
+"""Opt-in stamping of the agent's source commit onto its spans.
+
+Nothing is stamped until the agent calls :func:`enable`, mirroring the
+``lineage`` registry next door: a process-wide switch the agent sets once at
+import, rather than automatic behaviour every agent inherits. When enabled the
+resolved commit lands in span data under ``__commit_sha__`` and is searchable in
+the SGP Traces UI as ``__commit_sha__:<sha>``.
+
+This is deliberately separate from ``__agent_version__``, which is automatic and
+carries the deployed image tag verbatim ("image tag or git sha"). That tag is a
+real commit on some build paths but an ``<image-name>-<sha>`` composite (AWS
+ECR), ``latest``, or a hand-passed tag on others -- so a field named for a commit
+must not simply mirror it. Values that are not git object names are refused, and
+a field named ``__commit_sha__`` therefore only ever holds one.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from agentex.lib.utils.logging import make_logger
+
+__all__ = ("COMMIT_SHA_KEY", "enable", "disable", "is_enabled", "commit_sha")
+
+logger = make_logger(__name__)
+
+COMMIT_SHA_KEY = "__commit_sha__"
+
+# A git object name: 40 hex for SHA-1, 64 for SHA-256, or an abbreviation down to
+# git's own 7-character minimum.
+_GIT_SHA_RE = re.compile(r"[0-9a-fA-F]{7,64}")
+
+_COMMIT_SHA_ENV = "AGENT_COMMIT_SHA"
+# Fallback only: automatic, and only usable when it happens to be SHA-shaped.
+_AGENT_VERSION_ENV = "AGENT_VERSION"
+
+# Resolved once at enable() rather than per span: the value is fixed for the
+# life of the process, and resolving eagerly means a bad value is reported at
+# startup instead of silently producing unstamped spans.
+_commit_sha: str | None = None
+
+
+def enable(commit_sha: str | None = None) -> None:
+    """Opt this process in to stamping ``__commit_sha__`` onto every span.
+
+    Value precedence: the explicit ``commit_sha`` argument, else
+    ``AGENT_COMMIT_SHA``, else ``AGENT_VERSION`` when the deployment happened to
+    set it to a bare commit SHA. A value that is not a git object name is
+    refused with a warning and leaves stamping off -- better an absent field
+    than one named for a commit that holds an image tag.
+    """
+    global _commit_sha
+
+    for value, source in (
+        (commit_sha, "the commit_sha argument"),
+        (os.environ.get(_COMMIT_SHA_ENV), _COMMIT_SHA_ENV),
+        (os.environ.get(_AGENT_VERSION_ENV), _AGENT_VERSION_ENV),
+    ):
+        candidate = (value or "").strip()
+        if not candidate:
+            continue
+        if _GIT_SHA_RE.fullmatch(candidate):
+            _commit_sha = candidate
+            logger.info("code revision stamping enabled from %s", source)
+            return
+        # An explicit argument or AGENT_COMMIT_SHA is a direct statement of
+        # intent, so a bad value there is worth surfacing. AGENT_VERSION is only
+        # a fallback and is expected to be a non-SHA tag much of the time, so
+        # falling through it quietly is correct, not a silent failure.
+        if source != _AGENT_VERSION_ENV:
+            logger.warning(
+                "%s=%r is not a git commit SHA; __commit_sha__ will not be stamped.",
+                source,
+                candidate,
+            )
+            _commit_sha = None
+            return
+
+    _commit_sha = None
+    logger.warning(
+        "code revision stamping was enabled but no commit SHA was found "
+        "(checked the commit_sha argument, %s, and %s); __commit_sha__ will not "
+        "be stamped. Set %s in the agent's environment -- e.g. bake it at build "
+        "time with a Dockerfile ARG/ENV.",
+        _COMMIT_SHA_ENV,
+        _AGENT_VERSION_ENV,
+        _COMMIT_SHA_ENV,
+    )
+
+
+def disable() -> None:
+    """Turn stamping back off (also used for test isolation)."""
+    global _commit_sha
+    _commit_sha = None
+
+
+def is_enabled() -> bool:
+    """Whether a commit SHA resolved and will be stamped."""
+    return _commit_sha is not None
+
+
+def commit_sha() -> str | None:
+    """The resolved commit SHA, or ``None`` when stamping is not enabled."""
+    return _commit_sha

--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -11,6 +11,7 @@ from scale_gp_beta.lib.tracing import create_span, flush_queue
 from scale_gp_beta.lib.tracing.span import Span as SGPSpan
 
 from agentex.types.span import Span
+from agentex.lib.core.tracing import code_revision
 from agentex.lib.types.tracing import SGPTracingProcessorConfig
 from agentex.lib.utils.logging import make_logger
 from agentex.lib.core.observability import tracing_metrics_recording as _metrics
@@ -67,6 +68,11 @@ def _add_source_to_span(span: Span, env_vars: EnvironmentVariables) -> None:
             span.data["__agent_id__"] = env_vars.AGENT_ID
         if env_vars.AGENT_VERSION is not None:
             span.data["__agent_version__"] = env_vars.AGENT_VERSION
+        # Opt-in only (adk.code_revision.enable()); None unless the agent asked
+        # for it, so no agent inherits this by upgrading the SDK.
+        commit_sha = code_revision.commit_sha()
+        if commit_sha is not None:
+            span.data[code_revision.COMMIT_SHA_KEY] = commit_sha
 
 
 def _build_sgp_span(span: Span, env_vars: EnvironmentVariables) -> SGPSpan:

--- a/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
+++ b/src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import asyncio
 import weakref
-from typing import cast, override
+from typing import Any, cast, override
 
 import scale_gp_beta.lib.tracing as tracing
 from scale_gp_beta import SGPClient, AsyncSGPClient
@@ -68,11 +68,29 @@ def _add_source_to_span(span: Span, env_vars: EnvironmentVariables) -> None:
             span.data["__agent_id__"] = env_vars.AGENT_ID
         if env_vars.AGENT_VERSION is not None:
             span.data["__agent_version__"] = env_vars.AGENT_VERSION
-        # Opt-in only (adk.code_revision.enable()); None unless the agent asked
-        # for it, so no agent inherits this by upgrading the SDK.
-        commit_sha = code_revision.commit_sha()
-        if commit_sha is not None:
-            span.data[code_revision.COMMIT_SHA_KEY] = commit_sha
+
+
+def _sgp_metadata(span: Span) -> Any:
+    """Metadata for the SGP write: ``span.data`` plus the opt-in commit SHA.
+
+    Returns a COPY rather than mutating ``span``. ``trace.py`` hands the same
+    Span instance to every registered processor, so anything written onto
+    ``span.data`` here would also be serialized by the Agentex processor and
+    show up in caller-visible span data. ``__commit_sha__`` is opt-in and
+    SGP-scoped, so it must not leak that way.
+
+    (The ``__source__`` / ``__agent_*`` keys set by ``_add_source_to_span`` do
+    leak like that today. Left as-is: changing five long-shipped fields is not
+    this change's business.)
+    """
+    commit_sha = code_revision.commit_sha()
+    if commit_sha is None:
+        return span.data
+    if isinstance(span.data, dict):
+        return {**span.data, code_revision.COMMIT_SHA_KEY: commit_sha}
+    # List-shaped data is an accepted `data` shape and has nowhere to put a
+    # metadata key; leave it untouched rather than dropping the caller's data.
+    return span.data
 
 
 def _build_sgp_span(span: Span, env_vars: EnvironmentVariables) -> SGPSpan:
@@ -88,7 +106,7 @@ def _build_sgp_span(span: Span, env_vars: EnvironmentVariables) -> SGPSpan:
             trace_id=span.trace_id,
             input=span.input,
             output=span.output,
-            metadata=span.data,
+            metadata=_sgp_metadata(span),
         ),
     )
     sgp_span.start_time = span.start_time.isoformat()  # type: ignore[union-attr]

--- a/src/agentex/lib/environment_variables.py
+++ b/src/agentex/lib/environment_variables.py
@@ -25,6 +25,7 @@ class EnvVarKeys(str, Enum):
     AGENT_DESCRIPTION = "AGENT_DESCRIPTION"
     AGENT_ID = "AGENT_ID"
     AGENT_VERSION = "AGENT_VERSION"
+    AGENT_COMMIT_SHA = "AGENT_COMMIT_SHA"
     AGENT_API_KEY = "AGENT_API_KEY"
     # ACP Configuration
     ACP_URL = "ACP_URL"
@@ -67,6 +68,12 @@ class EnvironmentVariables(BaseModel):
     AGENT_ID: str | None = None
     # Build/version discriminator (image tag or git sha), set by the deployment
     AGENT_VERSION: str | None = None
+    # The agent's source commit, baked into the image or set by the deployment.
+    # Unlike AGENT_VERSION this is expected to be a git SHA and nothing else, and
+    # it is OPT-IN: nothing is stamped unless the agent calls
+    # `adk.code_revision.enable()`, which also refuses a value that is not a git
+    # object name. See agentex.lib.core.tracing.code_revision.
+    AGENT_COMMIT_SHA: str | None = None
     AGENT_API_KEY: str | None = None
     ACP_TYPE: str | None = "async"
     AGENT_INPUT_TYPE: str | None = None

--- a/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
@@ -66,6 +66,7 @@ class TestSourceStamps:
         env = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
         span = _make_span()
         _add_source_to_span(span, env)
+        assert isinstance(span.data, dict)
         assert "__commit_sha__" not in span.data
 
     def test_commit_sha_is_stamped_after_opt_in(self, monkeypatch):
@@ -79,6 +80,7 @@ class TestSourceStamps:
             env = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
             span = _make_span()
             _add_source_to_span(span, env)
+            assert isinstance(span.data, dict)
             assert span.data["__commit_sha__"] == sha
         finally:
             code_revision.disable()

--- a/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
@@ -54,6 +54,35 @@ class TestSourceStamps:
             "__agent_version__": "sha-abc123",
         }
 
+    def test_commit_sha_is_not_stamped_without_opt_in(self, monkeypatch):
+        """Upgrading the SDK must not start emitting __commit_sha__ on its own,
+        even when the environment carries a perfectly good SHA."""
+        from agentex.lib.core.tracing import code_revision
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _add_source_to_span
+
+        monkeypatch.setenv("AGENT_COMMIT_SHA", "b362b171a9c4e1f09d8e7a6b5c4d3e2f1a0b9c8d")
+        code_revision.disable()
+
+        env = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
+        span = _make_span()
+        _add_source_to_span(span, env)
+        assert "__commit_sha__" not in span.data
+
+    def test_commit_sha_is_stamped_after_opt_in(self, monkeypatch):
+        from agentex.lib.core.tracing import code_revision
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _add_source_to_span
+
+        sha = "b362b171a9c4e1f09d8e7a6b5c4d3e2f1a0b9c8d"
+        monkeypatch.setenv("AGENT_COMMIT_SHA", sha)
+        code_revision.enable()
+        try:
+            env = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
+            span = _make_span()
+            _add_source_to_span(span, env)
+            assert span.data["__commit_sha__"] == sha
+        finally:
+            code_revision.disable()
+
     def test_unset_identity_fields_are_omitted(self):
         from agentex.lib.core.tracing.processors.sgp_tracing_processor import _add_source_to_span
 

--- a/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
+++ b/tests/lib/core/tracing/processors/test_sgp_tracing_processor.py
@@ -54,34 +54,63 @@ class TestSourceStamps:
             "__agent_version__": "sha-abc123",
         }
 
+    SHA = "b362b171a9c4e1f09d8e7a6b5c4d3e2f1a0b9c8d"
+
     def test_commit_sha_is_not_stamped_without_opt_in(self, monkeypatch):
         """Upgrading the SDK must not start emitting __commit_sha__ on its own,
         even when the environment carries a perfectly good SHA."""
         from agentex.lib.core.tracing import code_revision
-        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _add_source_to_span
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _sgp_metadata
 
-        monkeypatch.setenv("AGENT_COMMIT_SHA", "b362b171a9c4e1f09d8e7a6b5c4d3e2f1a0b9c8d")
+        monkeypatch.setenv("AGENT_COMMIT_SHA", self.SHA)
         code_revision.disable()
 
-        env = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
-        span = _make_span()
-        _add_source_to_span(span, env)
-        assert isinstance(span.data, dict)
-        assert "__commit_sha__" not in span.data
+        span = _make_span(); span.data = {}
+        assert "__commit_sha__" not in (_sgp_metadata(span) or {})
 
     def test_commit_sha_is_stamped_after_opt_in(self, monkeypatch):
         from agentex.lib.core.tracing import code_revision
-        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _add_source_to_span
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _sgp_metadata
 
-        sha = "b362b171a9c4e1f09d8e7a6b5c4d3e2f1a0b9c8d"
-        monkeypatch.setenv("AGENT_COMMIT_SHA", sha)
+        monkeypatch.setenv("AGENT_COMMIT_SHA", self.SHA)
         code_revision.enable()
         try:
-            env = MagicMock(ACP_TYPE=None, AGENT_NAME=None, AGENT_ID=None, AGENT_VERSION=None)
-            span = _make_span()
-            _add_source_to_span(span, env)
-            assert isinstance(span.data, dict)
-            assert span.data["__commit_sha__"] == sha
+            span = _make_span(); span.data = {"caller": "kept"}
+            metadata = _sgp_metadata(span)
+            assert metadata["__commit_sha__"] == self.SHA
+            assert metadata["caller"] == "kept"
+        finally:
+            code_revision.disable()
+
+    def test_commit_sha_does_not_leak_onto_the_shared_span(self, monkeypatch):
+        """trace.py hands ONE Span to every processor. If the commit SHA were
+        written onto span.data, a co-registered Agentex processor would
+        serialize it too, and it would surface in caller-visible span data."""
+        from agentex.lib.core.tracing import code_revision
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _sgp_metadata
+        from agentex.lib.core.tracing.processors.agentex_tracing_processor import _create_kwargs
+
+        monkeypatch.setenv("AGENT_COMMIT_SHA", self.SHA)
+        code_revision.enable()
+        try:
+            span = _make_span(); span.data = {}
+            assert _sgp_metadata(span)["__commit_sha__"] == self.SHA   # SGP sees it
+            assert "__commit_sha__" not in span.data                   # the span does not
+            assert "__commit_sha__" not in (_create_kwargs(span)["data"] or {})
+        finally:
+            code_revision.disable()
+
+    def test_list_shaped_data_is_left_alone(self, monkeypatch):
+        """`data` may be a list of dicts; there is nowhere to put a metadata key,
+        and dropping the caller's data would be worse than omitting the field."""
+        from agentex.lib.core.tracing import code_revision
+        from agentex.lib.core.tracing.processors.sgp_tracing_processor import _sgp_metadata
+
+        monkeypatch.setenv("AGENT_COMMIT_SHA", self.SHA)
+        code_revision.enable()
+        try:
+            span = _make_span(); span.data = [{"a": 1}]
+            assert _sgp_metadata(span) == [{"a": 1}]
         finally:
             code_revision.disable()
 

--- a/tests/lib/core/tracing/test_code_revision.py
+++ b/tests/lib/core/tracing/test_code_revision.py
@@ -1,0 +1,109 @@
+"""Opt-in commit-SHA stamping.
+
+The contract that matters: an agent that does not call ``enable()`` gets nothing,
+so upgrading the SDK never starts emitting this field on its own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentex.lib.core.tracing import code_revision
+
+SHA = "b362b171a9c4e1f09d8e7a6b5c4d3e2f1a0b9c8d"
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    """State is process-wide (like the lineage registry), so isolate each test."""
+    code_revision.disable()
+    yield
+    code_revision.disable()
+
+
+class TestOptIn:
+    def test_disabled_by_default(self, monkeypatch):
+        """Even with the env fully populated, nothing resolves until enable()."""
+        monkeypatch.setenv("AGENT_COMMIT_SHA", SHA)
+        monkeypatch.setenv("AGENT_VERSION", SHA)
+        assert code_revision.commit_sha() is None
+        assert code_revision.is_enabled() is False
+
+    def test_enable_reads_agent_commit_sha(self, monkeypatch):
+        monkeypatch.setenv("AGENT_COMMIT_SHA", SHA)
+        code_revision.enable()
+        assert code_revision.commit_sha() == SHA
+        assert code_revision.is_enabled() is True
+
+    def test_explicit_argument_wins(self, monkeypatch):
+        monkeypatch.setenv("AGENT_COMMIT_SHA", SHA)
+        code_revision.enable("7f3a91c2")
+        assert code_revision.commit_sha() == "7f3a91c2"
+
+    def test_disable_turns_it_back_off(self, monkeypatch):
+        monkeypatch.setenv("AGENT_COMMIT_SHA", SHA)
+        code_revision.enable()
+        code_revision.disable()
+        assert code_revision.commit_sha() is None
+
+
+class TestValueIsAlwaysACommit:
+    """A field named for a commit must never hold an image tag."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "latest",
+            "v1.2.3",
+            "0.2.4-v4",
+            "rocket_mock_agent-b362b171a9c4e1f09d8e7a6b5c4d3e2f1a0b9c8d",  # AWS ECR composite
+            "abc",  # shorter than git's 7-char minimum
+            "z" * 40,  # right length, not hex
+        ],
+    )
+    def test_non_sha_is_refused(self, monkeypatch, value):
+        monkeypatch.setenv("AGENT_COMMIT_SHA", value)
+        code_revision.enable()
+        assert code_revision.commit_sha() is None
+
+    @pytest.mark.parametrize("value", [SHA, SHA.upper(), "b362b17", "a" * 64])
+    def test_git_object_names_are_accepted(self, monkeypatch, value):
+        monkeypatch.setenv("AGENT_COMMIT_SHA", value)
+        code_revision.enable()
+        assert code_revision.commit_sha() == value
+
+    def test_whitespace_only_is_refused(self, monkeypatch):
+        monkeypatch.setenv("AGENT_COMMIT_SHA", "   ")
+        code_revision.enable()
+        assert code_revision.commit_sha() is None
+
+    def test_enable_with_nothing_available_is_a_no_op(self, monkeypatch):
+        monkeypatch.delenv("AGENT_COMMIT_SHA", raising=False)
+        monkeypatch.delenv("AGENT_VERSION", raising=False)
+        code_revision.enable()
+        assert code_revision.commit_sha() is None
+
+
+class TestAgentVersionFallback:
+    def test_falls_back_to_agent_version_when_sha_shaped(self, monkeypatch):
+        """A platform deploy already sets AGENT_VERSION; on GCP/Azure it is a
+        bare SHA, so an opting-in agent needs no extra plumbing."""
+        monkeypatch.delenv("AGENT_COMMIT_SHA", raising=False)
+        monkeypatch.setenv("AGENT_VERSION", SHA)
+        code_revision.enable()
+        assert code_revision.commit_sha() == SHA
+
+    def test_does_not_fall_back_to_a_non_sha_agent_version(self, monkeypatch):
+        """AGENT_VERSION is 'latest' or an AWS composite much of the time."""
+        monkeypatch.delenv("AGENT_COMMIT_SHA", raising=False)
+        monkeypatch.setenv("AGENT_VERSION", "latest")
+        code_revision.enable()
+        assert code_revision.commit_sha() is None
+
+    def test_bad_explicit_value_does_not_fall_through(self, monkeypatch):
+        """An explicit AGENT_COMMIT_SHA is a statement of intent: if it is wrong,
+        say so rather than silently substituting the image tag."""
+        monkeypatch.setenv("AGENT_COMMIT_SHA", "not-a-sha")
+        monkeypatch.setenv("AGENT_VERSION", SHA)
+        code_revision.enable()
+        assert code_revision.commit_sha() is None


### PR DESCRIPTION
## What

Adds opt-in stamping of the agent's source commit onto its spans, so a request
in the SGP Traces UI can be tied back to the code that served it:

```
search  __commit_sha__:<full-sha>
```

Part of [AGX1-969](https://linear.app/scale-epd/issue/AGX1-969) / the
[Version Request Visibility](https://app.notion.com/p/Observability-Version-Request-Visibility-3c7904d6e6cb80f2a350fc6f0f852a9e)
scope doc, Dimension 1 (Code Revision).

## Why span metadata is the only option

Agent spans never reach the OTel collector — the SDK POSTs them straight to SGP,
agent pods set no `OTEL_*` env vars, and there is no auto-instrumentation
annotation. So the commit has to be attached in the agent's own process, and
`span.data` (→ `operation_metadata`, indexed, no key allowlist) is the carrier.

## Opt-in

Nothing is emitted until an agent calls:

```python
from agentex.lib import adk
adk.code_revision.enable()          # value from AGENT_COMMIT_SHA
```

Modelled on the `lineage` registry next door — the module global's default *is*
the off state, so `commit_sha()` returns `None` and the stamp site needs no flag,
no config field, and no env toggle. **No agent inherits this field by upgrading
the SDK.** The existing test asserting `span.data == {...}` exactly still passes,
which proves that independently.

## Why not just reuse `__agent_version__`

`__agent_version__` (v0.25.0, #469) is automatic and carries the deployed image
tag verbatim. That tag is a real commit on some paths but not others:

| Deploy path | `image.tag` |
|---|---|
| CI → GCP / Azure | `b362b171…` — a real SHA |
| CI → **AWS ECR** | `rocket_mock_agent-b362b171…` — the gateway rewrites it to `<image-name>-<tag>` |
| Local `agentex agents deploy` | `latest` — 129 of 133 fleet manifests declare it |
| Manual dispatch | whatever was passed |

A field named for a commit must not mirror that. Values that are not git object
names (7–64 hex) are refused with a warning, so `__commit_sha__` only ever holds
one — absence is the honest answer where a commit isn't known.

## Value precedence

`enable()` argument → `AGENT_COMMIT_SHA` → `AGENT_VERSION`, the last **only** when
already SHA-shaped. So an opting-in agent on GCP/Azure needs no extra plumbing,
while a custom build path bakes the value at build time:

```dockerfile
ARG GIT_SHA
ENV AGENT_COMMIT_SHA=${GIT_SHA}
```

A bad *explicit* value stops with a warning rather than silently falling through
to the image tag — setting it is a statement of intent.

## Stamp site

`_add_source_to_span` in the SGP processor, not at span creation. Two consequences,
both deliberate:

- **Scoped to the SGP backend** — the user story here, and 92 of the fleet's agents
  register `SGPTracingProcessorConfig` vs 3 on the Agentex one. The scope doc asked
  for both backends; that's the one point where this diverges, agreed as SGP-only.
- **Re-runs at span end.** `_build_sgp_span()` is called from both `on_span_start`
  and `on_span_end`, and end-only ingest is the default — so the value survives an
  agent replacing `span.data` mid-span, which real agent code does today
  (`eval_dashboard_agent/project/workflow.py:273,357`).

## Test plan

- `tests/lib/core/tracing/test_code_revision.py` — 19 tests: disabled by default even
  with the env fully populated, precedence, `disable()`, and a parametrised set
  proving non-SHAs (`latest`, `v1.2.3`, the AWS composite, non-hex, too-short) are
  refused while git object names (40-hex, 64-hex, short, uppercase) are accepted.
- `test_sgp_tracing_processor.py` — 2 tests pinning the opt-in gate at the stamp site.
- Full `tests/lib`: 1058 passed, 3 skipped. ruff clean, pyright 0 errors.

## Not in this PR

- Populating `AGENT_VERSION` at deploy time (it is set nowhere today, so
  `__agent_version__` is inert in production) — separate PR.
- The Loki half of the scope doc: pod label + `k8sattributes` mapping in `sgp`.
- Agentex-backend parity for this key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in commit-SHA resolution and stamps the resolved revision into SGP metadata without mutating the shared span.

- Exposes `adk.code_revision` with explicit enable and disable controls.
- Validates explicit and environment-derived revisions as SHA-shaped values.
- Copies dictionary metadata before adding `__commit_sha__`, resolving the previously reported cross-processor leak.
- Adds coverage for opt-in behavior, precedence, validation, processor isolation, and non-dictionary span data.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the copied SGP metadata keeps the opt-in commit field off the shared span and therefore out of the AgentEx processor path.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/core/tracing/code_revision.py | Adds process-wide opt-in revision resolution with documented precedence, strict SHA-shape validation, and explicit reset behavior. |
| src/agentex/lib/core/tracing/processors/sgp_tracing_processor.py | Adds the revision only to copied SGP metadata, preventing the previously reported mutation of shared span data. |
| tests/lib/core/tracing/processors/test_sgp_tracing_processor.py | Verifies opt-in stamping, shared-span isolation, preservation of existing metadata, and list-shaped data behavior. |
| tests/lib/core/tracing/test_code_revision.py | Covers default-off behavior, source precedence, disable semantics, accepted SHA forms, and invalid-value rejection. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Agent calls code_revision.enable] --> B[Resolve and validate commit SHA]
    B --> C[_build_sgp_span]
    C --> D[_sgp_metadata copies dictionary data]
    D --> E[Add __commit_sha__ to copied metadata]
    E --> F[SGP span]
    C --> G[Shared AgentEx Span remains unchanged]
    G --> H[AgentEx processor]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tracing): keep the commit SHA out of..."](https://github.com/scaleapi/scale-agentex-python/commit/45747c823dce1fc6d847e2b6b18b0b21cea21334) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58005577)</sub>

<!-- /greptile_comment -->