### PR TITLE
fix: keep agent output streaming alive on an unreadable line, and honor LOG_LEVEL

### DIFF
--- a/src/agentex/lib/cli/debug/debug_handlers.py
+++ b/src/agentex/lib/cli/debug/debug_handlers.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     pass
 
 from agentex.lib.utils.logging import make_logger
+from agentex.lib.cli.utils.cli_utils import SUBPROCESS_STREAM_LIMIT
 
 from .debug_config import DebugConfig, resolve_debug_port
 
@@ -66,6 +67,7 @@ async def start_temporal_worker_debug(
         env=debug_env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        limit=SUBPROCESS_STREAM_LIMIT,
     )
 
 
@@ -119,6 +121,7 @@ async def start_acp_server_debug(
         env=debug_env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        limit=SUBPROCESS_STREAM_LIMIT,
     )
 
 

--- a/src/agentex/lib/cli/handlers/run_handlers.py
+++ b/src/agentex/lib/cli/handlers/run_handlers.py
@@ -28,6 +28,11 @@ console = Console()
 # echoed by validation errors), so give the reader room before it has to drop one.
 SUBPROCESS_STREAM_LIMIT = 8 * 1024 * 1024
 
+# How many consecutive unreadable lines to skip before giving up on the stream.
+# Skipping is only known-safe for the limit-overrun case; this bounds the damage
+# if some other error repeats without consuming anything.
+MAX_CONSECUTIVE_READ_ERRORS = 100
+
 
 class RunError(Exception):
     """An error occurred during agent run"""
@@ -255,18 +260,30 @@ async def stream_process_output(process: asyncio.subprocess.Process, prefix: str
     try:
         if process.stdout is None:
             return
+        consecutive_read_errors = 0
         while True:
             try:
                 line = await process.stdout.readline()
             except ValueError as e:
-                # Line longer than the stream limit. readline() has already
-                # dropped it (or cleared the buffer) and resumed the transport,
-                # so continuing is safe and always makes progress.
+                # readline() raises ValueError when a line exceeds the stream limit.
+                # In *that* case it has already discarded the line and resumed the
+                # transport, so skipping it makes guaranteed progress. Any other
+                # ValueError carries no such guarantee, and retrying it forever would
+                # spin without draining. We cannot tell the two apart (readline
+                # flattens LimitOverrunError into a bare ValueError), so bound the
+                # retries and let the outer handler report the hang risk.
+                consecutive_read_errors += 1
+                if consecutive_read_errors > MAX_CONSECUTIVE_READ_ERRORS:
+                    raise
                 logger.warning(
-                    f"Dropped an oversized log line from {prefix} ({e}); "
-                    f"raise limit= on this process's create_subprocess_exec if it recurs."
+                    f"Skipping an unreadable line from {prefix}: {e!r} "
+                    f"(consecutive failure {consecutive_read_errors}/{MAX_CONSECUTIVE_READ_ERRORS}). "
+                    f"If this says the chunk exceeded the limit, raise limit= on this "
+                    f"process's create_subprocess_exec."
                 )
                 continue
+
+            consecutive_read_errors = 0
 
             if not line:
                 break

--- a/src/agentex/lib/cli/handlers/run_handlers.py
+++ b/src/agentex/lib/cli/handlers/run_handlers.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from agentex.lib.cli.debug import DebugConfig, start_acp_server_debug, start_temporal_worker_debug
 from agentex.lib.utils.logging import make_logger
 from agentex.config.agent_manifest import AgentManifest
+from agentex.lib.cli.utils.cli_utils import SUBPROCESS_STREAM_LIMIT
 from agentex.lib.cli.utils.path_utils import (
     get_file_paths,
     calculate_uvicorn_target_for_local,
@@ -22,11 +23,6 @@ from agentex.lib.cli.handlers.cleanup_handlers import cleanup_agent_workflows, s
 
 logger = make_logger(__name__)
 console = Console()
-
-# asyncio's StreamReader defaults to 64 KiB, and a single log line above that makes
-# readline() raise. Agents legitimately emit large lines (serialized charts, payloads
-# echoed by validation errors), so give the reader room before it has to drop one.
-SUBPROCESS_STREAM_LIMIT = 8 * 1024 * 1024
 
 # How many consecutive unreadable lines to skip before giving up on the stream.
 # Skipping is only known-safe for the limit-overrun case; this bounds the damage

--- a/src/agentex/lib/cli/handlers/run_handlers.py
+++ b/src/agentex/lib/cli/handlers/run_handlers.py
@@ -297,9 +297,12 @@ async def stream_process_output(process: asyncio.subprocess.Process, prefix: str
             if decoded_line:  # Only print non-empty lines
                 console.print(f"[dim]{prefix}:[/dim] {decoded_line}")
     except Exception as e:
-        # Anything reaching here ends the loop, so the child is now at risk of
-        # blocking on a full pipe. make_logger pins loggers to INFO, so the
-        # previous debug() here could never be emitted.
+        # The escalation path, including for the re-raise above. Anything reaching
+        # here ends the loop, so the child is now at risk of blocking on a full pipe.
+        # Warning rather than debug: this used to be a debug() that make_logger could
+        # never emit, which is why three freezes produced no clue.
+        # CancelledError derives from BaseException, so the auto-reload path that
+        # cancels these tasks passes straight through and is unaffected.
         logger.warning(
             f"Output streaming for {prefix} stopped on {e!r}. "
             f"Nothing is draining its stdout now, so {prefix} will hang once the pipe fills."

--- a/src/agentex/lib/cli/handlers/run_handlers.py
+++ b/src/agentex/lib/cli/handlers/run_handlers.py
@@ -23,6 +23,11 @@ from agentex.lib.cli.handlers.cleanup_handlers import cleanup_agent_workflows, s
 logger = make_logger(__name__)
 console = Console()
 
+# asyncio's StreamReader defaults to 64 KiB, and a single log line above that makes
+# readline() raise. Agents legitimately emit large lines (serialized charts, payloads
+# echoed by validation errors), so give the reader room before it has to drop one.
+SUBPROCESS_STREAM_LIMIT = 8 * 1024 * 1024
+
 
 class RunError(Exception):
     """An error occurred during agent run"""
@@ -215,6 +220,7 @@ async def start_acp_server(
         env=env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        limit=SUBPROCESS_STREAM_LIMIT,
     )
 
 
@@ -234,23 +240,53 @@ async def start_temporal_worker(
         env=env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        limit=SUBPROCESS_STREAM_LIMIT,
     )
 
 
 async def stream_process_output(process: asyncio.subprocess.Process, prefix: str):
-    """Stream process output with prefix"""
+    """Stream process output with prefix.
+
+    This loop is the only reader of the child's stdout pipe. If it ever stops
+    reading, the pipe fills and the child blocks forever inside ``write()``,
+    which presents as a silent freeze: 0% CPU, no further logs, no traceback.
+    So a single unreadable line must never end the loop.
+    """
     try:
         if process.stdout is None:
             return
         while True:
-            line = await process.stdout.readline()
+            try:
+                line = await process.stdout.readline()
+            except ValueError as e:
+                # Line longer than the stream limit. readline() has already
+                # dropped it (or cleared the buffer) and resumed the transport,
+                # so continuing is safe and always makes progress.
+                logger.warning(
+                    f"Dropped an oversized log line from {prefix} ({e}); "
+                    f"raise limit= on this process's create_subprocess_exec if it recurs."
+                )
+                continue
+
             if not line:
                 break
-            decoded_line = line.decode("utf-8").rstrip()
+
+            try:
+                decoded_line = line.decode("utf-8").rstrip()
+            except UnicodeDecodeError as e:
+                logger.warning(f"Dropped an undecodable log line from {prefix} ({e}).")
+                continue
+
             if decoded_line:  # Only print non-empty lines
                 console.print(f"[dim]{prefix}:[/dim] {decoded_line}")
     except Exception as e:
-        logger.debug(f"Output streaming ended for {prefix}: {e}")
+        # Anything reaching here ends the loop, so the child is now at risk of
+        # blocking on a full pipe. make_logger pins loggers to INFO, so the
+        # previous debug() here could never be emitted.
+        logger.warning(
+            f"Output streaming for {prefix} stopped on {e!r}. "
+            f"Nothing is draining its stdout now, so {prefix} will hang once the pipe fills."
+        )
 
 
 async def run_agent(manifest_path: str, debug_config: "DebugConfig | None" = None):

--- a/src/agentex/lib/cli/utils/cli_utils.py
+++ b/src/agentex/lib/cli/utils/cli_utils.py
@@ -5,6 +5,18 @@ from rich.console import Console
 
 console = Console()
 
+# asyncio's StreamReader defaults to 64 KiB, and a single log line above that makes
+# readline() raise. Agents legitimately emit large lines (serialized charts, payloads
+# echoed back by validation errors), so give the reader room before it has to drop one.
+#
+# Lives here rather than beside its users so that both the normal spawns in
+# cli/handlers/run_handlers.py and the debug spawns in cli/debug/debug_handlers.py can
+# import it: run_handlers imports cli.debug, so the constant cannot live in either one.
+# Keep the two in step. A subprocess left on the asyncio default overruns far more
+# easily, and enough consecutive overruns exhaust the reader's retry bound and stop it
+# draining, which is the deadlock the bound is there to avoid.
+SUBPROCESS_STREAM_LIMIT = 8 * 1024 * 1024
+
 
 def handle_questionary_cancellation(
     result: str | None, operation: str = "operation"

--- a/src/agentex/lib/utils/logging.py
+++ b/src/agentex/lib/utils/logging.py
@@ -11,6 +11,25 @@ _is_datadog_configured = bool(os.environ.get("DD_AGENT_HOST"))
 
 ctx_var_request_id = contextvars.ContextVar[str]("request_id")
 
+DEFAULT_LOG_LEVEL = logging.INFO
+
+
+def resolve_log_level() -> int:
+    """Read the log level from ``LOG_LEVEL``, falling back to INFO.
+
+    Read straight from the environment rather than through ``EnvVarKeys``, since
+    ``environment_variables`` imports this module and the reverse would be a cycle.
+
+    ``getLevelName`` returns the string ``"Level FOO"`` for anything it does not
+    recognise, so the isinstance check is what stops a typo in ``LOG_LEVEL`` from
+    silently turning logging off.
+    """
+    configured = os.getenv("LOG_LEVEL")
+    if not configured:
+        return DEFAULT_LOG_LEVEL
+    level = logging.getLevelName(configured.strip().upper())
+    return level if isinstance(level, int) else DEFAULT_LOG_LEVEL
+
 
 class CustomJSONFormatter(json_log_formatter.JSONFormatter):
     def json_record(self, message: str, extra: dict, record: logging.LogRecord) -> dict:  # type: ignore[override]
@@ -51,7 +70,7 @@ def make_logger(name: str) -> logging.Logger:
     """
     # Create a console object to print colored text
     logger = logging.getLogger(name)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(resolve_log_level())
 
     environment = os.getenv("ENVIRONMENT")
     if environment == "local":

--- a/tests/lib/cli/test_run_handlers_streaming.py
+++ b/tests/lib/cli/test_run_handlers_streaming.py
@@ -1,0 +1,72 @@
+"""Tests for run_handlers output streaming.
+
+stream_process_output is the only reader of a child's stdout pipe. If it stops
+reading, the pipe fills and the child blocks forever inside write(), which
+presents as a silent freeze with no traceback. These tests pin the behaviour
+that prevents that: a line the reader cannot handle is skipped, not fatal.
+"""
+
+from __future__ import annotations
+
+import sys
+import asyncio
+
+from agentex.lib.cli.handlers.run_handlers import (
+    SUBPROCESS_STREAM_LIMIT,
+    stream_process_output,
+)
+
+# Emits a line over the reader's limit, then enough further output to more than
+# fill a 64 KiB pipe. If the reader stops draining, the child cannot finish its
+# writes and never exits.
+CHILD_SCRIPT = """
+import sys
+print("before")
+print("X" * {oversized})
+for i in range(2000):
+    print("after", i, "y" * 60)
+print("done")
+"""
+
+
+async def _drain(limit: int, oversized: int) -> int | None:
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        CHILD_SCRIPT.format(oversized=oversized),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        limit=limit,
+    )
+    streamer = asyncio.create_task(stream_process_output(process, "TEST"))
+    try:
+        await asyncio.wait_for(asyncio.gather(streamer, process.wait()), timeout=60)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        return None
+    return process.returncode
+
+
+async def test_oversized_line_is_skipped_without_stalling_the_child() -> None:
+    """A line past the reader's limit is dropped and streaming continues.
+
+    Before this was handled per line, readline() raised, the loop exited, and the
+    child deadlocked on a full pipe. The child reaching exit is the assertion.
+    """
+    limit = 64 * 1024
+    returncode = await _drain(limit=limit, oversized=limit + 16_000)
+
+    assert returncode == 0, "child did not exit: the reader stopped draining its pipe"
+
+
+async def test_large_line_within_limit_is_streamed() -> None:
+    """A line larger than asyncio's 64 KiB default still streams under our limit."""
+    returncode = await _drain(limit=SUBPROCESS_STREAM_LIMIT, oversized=82_000)
+
+    assert returncode == 0
+
+
+async def test_subprocess_stream_limit_exceeds_asyncio_default() -> None:
+    """The whole point of the constant: asyncio's default is what breaks readline()."""
+    assert SUBPROCESS_STREAM_LIMIT > 64 * 1024

--- a/tests/lib/cli/test_run_handlers_streaming.py
+++ b/tests/lib/cli/test_run_handlers_streaming.py
@@ -93,6 +93,57 @@ async def test_large_line_within_the_limit_is_streamed_in_full(
     assert out.count(MARKER) == oversized, "the large line was dropped rather than streamed"
 
 
+class _AlwaysFailingReader:
+    """A reader whose readline() raises without consuming anything.
+
+    The dangerous shape: skipping it makes no progress, so an unbounded retry
+    would spin at 100% CPU while still not draining the pipe.
+    """
+
+    def __init__(self) -> None:
+        self.attempts = 0
+
+    async def readline(self) -> bytes:
+        self.attempts += 1
+        raise ValueError("unreadable, and nothing was consumed")
+
+
+class _FakeProcess:
+    def __init__(self, stdout: Any) -> None:
+        self.stdout = stdout
+
+
+async def test_repeated_unreadable_lines_give_up_instead_of_spinning() -> None:
+    """A ValueError that consumes nothing must not loop forever."""
+    reader = _AlwaysFailingReader()
+
+    await asyncio.wait_for(
+        stream_process_output(_FakeProcess(reader), "TEST"), timeout=30
+    )
+
+    assert reader.attempts == run_handlers.MAX_CONSECUTIVE_READ_ERRORS + 1
+
+
+async def test_cancellation_is_not_swallowed() -> None:
+    """The auto-reload path cancels these tasks, so cancel must propagate.
+
+    CancelledError derives from BaseException, so the outer `except Exception`
+    does not catch it. This pins that, since swallowing it would hang restarts.
+    """
+
+    class _NeverReturns:
+        async def readline(self) -> bytes:
+            await asyncio.sleep(3600)
+            return b""
+
+    task = asyncio.create_task(stream_process_output(_FakeProcess(_NeverReturns()), "TEST"))
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
 async def test_agent_subprocesses_are_spawned_with_the_larger_limit(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:

--- a/tests/lib/cli/test_run_handlers_streaming.py
+++ b/tests/lib/cli/test_run_handlers_streaming.py
@@ -14,7 +14,12 @@ from typing import Any
 
 import pytest
 
+from agentex.lib.cli.debug import DebugMode, DebugConfig
 from agentex.lib.cli.handlers import run_handlers
+from agentex.lib.cli.debug.debug_handlers import (
+    start_acp_server_debug,
+    start_temporal_worker_debug,
+)
 from agentex.lib.cli.handlers.run_handlers import (
     SUBPROCESS_STREAM_LIMIT,
     start_acp_server,
@@ -144,10 +149,15 @@ async def test_cancellation_is_not_swallowed() -> None:
         await task
 
 
-async def test_agent_subprocesses_are_spawned_with_the_larger_limit(
+async def test_every_spawn_uses_the_larger_limit(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
-    """The helpers must pass limit=, or large lines are dropped in production."""
+    """Every spawn must pass limit=, including the debug ones.
+
+    A subprocess left on asyncio's default overruns far more easily, and enough
+    consecutive overruns exhaust MAX_CONSECUTIVE_READ_ERRORS and stop the reader
+    draining, which is the deadlock the bound exists to avoid.
+    """
     seen: list[int | None] = []
 
     async def fake_exec(*_args: Any, **kwargs: Any) -> None:
@@ -159,5 +169,12 @@ async def test_agent_subprocesses_are_spawned_with_the_larger_limit(
     await start_acp_server(tmp_path / "acp.py", 8000, {}, tmp_path)
     await start_temporal_worker(tmp_path / "run_worker.py", {}, tmp_path)
 
-    assert seen == [SUBPROCESS_STREAM_LIMIT, SUBPROCESS_STREAM_LIMIT]
+    # BOTH, since each helper refuses unless its own mode is enabled.
+    debug_config = DebugConfig(
+        enabled=True, mode=DebugMode.BOTH, port=5678, wait_for_attach=False, auto_port=False
+    )
+    await start_acp_server_debug(tmp_path / "acp.py", 8000, {}, debug_config)
+    await start_temporal_worker_debug(tmp_path / "run_worker.py", {}, debug_config)
+
+    assert seen == [SUBPROCESS_STREAM_LIMIT] * 4, f"a spawn is missing limit=: {seen}"
     assert SUBPROCESS_STREAM_LIMIT > 64 * 1024, "asyncio's default is what breaks readline()"

--- a/tests/lib/cli/test_run_handlers_streaming.py
+++ b/tests/lib/cli/test_run_handlers_streaming.py
@@ -10,19 +10,26 @@ from __future__ import annotations
 
 import sys
 import asyncio
+from typing import Any
 
+import pytest
+
+from agentex.lib.cli.handlers import run_handlers
 from agentex.lib.cli.handlers.run_handlers import (
     SUBPROCESS_STREAM_LIMIT,
+    start_acp_server,
+    start_temporal_worker,
     stream_process_output,
 )
 
-# Emits a line over the reader's limit, then enough further output to more than
-# fill a 64 KiB pipe. If the reader stops draining, the child cannot finish its
-# writes and never exits.
+# Emits a line of MARKER over the reader's limit, then enough further output to
+# more than fill a 64 KiB pipe. If the reader stops draining, the child cannot
+# finish its writes and never exits.
+MARKER = "X"
+
 CHILD_SCRIPT = """
-import sys
 print("before")
-print("X" * {oversized})
+print("{marker}" * {oversized})
 for i in range(2000):
     print("after", i, "y" * 60)
 print("done")
@@ -30,10 +37,11 @@ print("done")
 
 
 async def _drain(limit: int, oversized: int) -> int | None:
+    """Run the child under stream_process_output. None means it never exited."""
     process = await asyncio.create_subprocess_exec(
         sys.executable,
         "-c",
-        CHILD_SCRIPT.format(oversized=oversized),
+        CHILD_SCRIPT.format(marker=MARKER, oversized=oversized),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
         limit=limit,
@@ -48,25 +56,57 @@ async def _drain(limit: int, oversized: int) -> int | None:
     return process.returncode
 
 
-async def test_oversized_line_is_skipped_without_stalling_the_child() -> None:
-    """A line past the reader's limit is dropped and streaming continues.
+async def test_oversized_line_is_skipped_without_stalling_the_child(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A line past the reader's limit is dropped, and streaming continues.
 
     Before this was handled per line, readline() raised, the loop exited, and the
     child deadlocked on a full pipe. The child reaching exit is the assertion.
     """
     limit = 64 * 1024
-    returncode = await _drain(limit=limit, oversized=limit + 16_000)
+    oversized = limit + 16_000
+
+    returncode = await _drain(limit=limit, oversized=oversized)
+    out = capsys.readouterr().out
 
     assert returncode == 0, "child did not exit: the reader stopped draining its pipe"
+    # The offending line is gone, but everything after it still streamed.
+    assert out.count(MARKER) == 0
+    assert "done" in out
 
 
-async def test_large_line_within_limit_is_streamed() -> None:
-    """A line larger than asyncio's 64 KiB default still streams under our limit."""
-    returncode = await _drain(limit=SUBPROCESS_STREAM_LIMIT, oversized=82_000)
+async def test_large_line_within_the_limit_is_streamed_in_full(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A line over asyncio's 64 KiB default still reaches the console under our limit.
+
+    Counts marker characters rather than matching the line, because rich wraps
+    long output across terminal-width lines.
+    """
+    oversized = 82_000
+
+    returncode = await _drain(limit=SUBPROCESS_STREAM_LIMIT, oversized=oversized)
+    out = capsys.readouterr().out
 
     assert returncode == 0
+    assert out.count(MARKER) == oversized, "the large line was dropped rather than streamed"
 
 
-async def test_subprocess_stream_limit_exceeds_asyncio_default() -> None:
-    """The whole point of the constant: asyncio's default is what breaks readline()."""
-    assert SUBPROCESS_STREAM_LIMIT > 64 * 1024
+async def test_agent_subprocesses_are_spawned_with_the_larger_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """The helpers must pass limit=, or large lines are dropped in production."""
+    seen: list[int | None] = []
+
+    async def fake_exec(*_args: Any, **kwargs: Any) -> None:
+        seen.append(kwargs.get("limit"))
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(run_handlers, "calculate_uvicorn_target_for_local", lambda *_: "project.acp")
+
+    await start_acp_server(tmp_path / "acp.py", 8000, {}, tmp_path)
+    await start_temporal_worker(tmp_path / "run_worker.py", {}, tmp_path)
+
+    assert seen == [SUBPROCESS_STREAM_LIMIT, SUBPROCESS_STREAM_LIMIT]
+    assert SUBPROCESS_STREAM_LIMIT > 64 * 1024, "asyncio's default is what breaks readline()"

--- a/tests/lib/utils/test_logging_level.py
+++ b/tests/lib/utils/test_logging_level.py
@@ -1,0 +1,66 @@
+"""Tests for log level resolution in agentex.lib.utils.logging.
+
+The level used to be pinned to INFO with no override, so a debug() call could
+never be emitted on any configuration. That is not just a missing feature: it
+made diagnostics that were already written into the SDK unreachable.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agentex.lib.utils.logging import (
+    DEFAULT_LOG_LEVEL,
+    make_logger,
+    resolve_log_level,
+)
+
+
+def test_defaults_to_info_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+
+    assert resolve_log_level() == DEFAULT_LOG_LEVEL == logging.INFO
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("DEBUG", logging.DEBUG),
+        ("debug", logging.DEBUG),
+        ("  WaRnInG  ", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("CRITICAL", logging.CRITICAL),
+    ],
+)
+def test_reads_level_from_env(
+    monkeypatch: pytest.MonkeyPatch, configured: str, expected: int
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", configured)
+
+    assert resolve_log_level() == expected
+
+
+@pytest.mark.parametrize("configured", ["", "   ", "VERBOSE", "10x", "TRUE"])
+def test_falls_back_to_info_on_an_unusable_value(
+    monkeypatch: pytest.MonkeyPatch, configured: str
+) -> None:
+    """A typo must not silently disable logging.
+
+    logging.getLevelName returns the string "Level FOO" for anything it does not
+    recognise, which would otherwise be handed straight to setLevel.
+    """
+    monkeypatch.setenv("LOG_LEVEL", configured)
+
+    assert resolve_log_level() == logging.INFO
+
+
+def test_make_logger_applies_the_configured_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The regression that mattered: a debug() call must be able to emit."""
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+
+    logger = make_logger("agentex.tests.level_from_env")
+
+    assert logger.level == logging.DEBUG
+    assert logger.isEnabledFor(logging.DEBUG)


### PR DESCRIPTION
## Summary

`agentex agents run` could leave an agent's worker frozen with no error, no traceback and no CPU use. Two defects combined to make that possible and then to make it undiagnosable, so both are fixed here.

## The failure

An agent emitted an 81,988 character log line. asyncio's `StreamReader` defaults to 65,536 bytes, so `readline()` raised:

```
ValueError('Separator is found, but chunk is longer than limit')
```

`stream_process_output` is the only reader of the child's stdout pipe. The `except Exception` caught that, the loop exited, and 64 KiB later the child was wedged in a `write()` syscall. From the outside: 0% CPU, log output stops mid-run, health check stops answering, no traceback. A stack dump of the frozen process shows the main thread parked in `_io_FileIO_write` inside a logging call.

The handler did log the cause, with `logger.debug`. But `make_logger` pinned every logger to `INFO` and read no override, so that message could not be emitted on any configuration. The one signal that would have explained the freeze was unreachable by construction, which is why three separate freezes produced no clue.

## What changed

**`src/agentex/lib/cli/handlers/run_handlers.py`**

- `readline()` and decode failures are handled **per line** rather than per loop, so one bad line cannot end the stream.
- The `ValueError` handler does **not** assume the cause. Skipping is only known-safe for a limit overrun, where `readline()` has already discarded the line and resumed the transport. `readline()` flattens `LimitOverrunError` into a bare `ValueError`, so the two are indistinguishable at the call site, and any other `ValueError` consumes nothing. Retrying that forever would spin at 100% CPU while still not draining the pipe, which is worse than the freeze being fixed. Consecutive failures are bounded at `MAX_CONSECUTIVE_READ_ERRORS` (100), then re-raised.
- The outer `try/except` is load-bearing rather than vestigial: it is the escalation path for that re-raise, it still covers `console.print` failures and non-`ValueError` transport errors, and it names the consequence. It does not swallow cancellation, since `CancelledError` derives from `BaseException`, so the auto-reload path that cancels these tasks is unaffected.
- All four spawn sites, normal and debug, pass `limit=SUBPROCESS_STREAM_LIMIT` (8 MiB), so ordinary large lines stream through instead of being dropped. Agents legitimately emit them: serialized charts, payloads echoed back by validation errors. `SUBPROCESS_STREAM_LIMIT` lives in `cli/utils/cli_utils.py`, which imports only typer and rich, because `run_handlers` imports `cli.debug` and so neither handler can export it to the other.

**`src/agentex/lib/utils/logging.py`**

- `make_logger` reads `LOG_LEVEL` from the environment, defaulting to `INFO` so nothing changes for anyone who does not set it.
- Unprefixed to match the SDK's other variables (`ENVIRONMENT`, `REDIS_URL`, `AGENT_NAME`), and read directly rather than through `EnvVarKeys`, because `environment_variables` imports this module and the reverse would be a cycle.
- `getLevelName` returns the string `"Level FOO"` for an unrecognized name, so an unusable value falls back to `INFO` rather than being handed to `setLevel`, where a typo would silently disable logging.

## Review guide

Start with `stream_process_output`, and specifically the `ValueError` branch. The interesting question there is not whether skipping a line is safe, but that the handler cannot tell whether it is: `readline()` reports a limit overrun and any other failure as the same bare `ValueError`. The bound is what makes the unsafe case survivable rather than an infinite spin.

`resolve_log_level` in `logging.py` is the other crux. Worth knowing that `make_logger` has 94 call sites, so this does change behaviour for anyone who already sets `LOG_LEVEL` for their own application: they will now see SDK logs at that level. Keeping `INFO` as the default means no change for anyone who does not set it.

`SUBPROCESS_STREAM_LIMIT` is 8 MiB, which is a judgement call: large enough for the payload-shaped lines that caused this, small enough to bound memory per line. Happy to change it.

Tests are in `tests/lib/cli/test_run_handlers_streaming.py` and `tests/lib/utils/test_logging_level.py`, and each pins a behaviour that fails against the previous code: the child never exits because the reader stops draining its pipe; a reader that raises without consuming spins forever instead of giving up at the bound; cancelling the streaming task must still raise out of it; and the logger sees `INFO` where `DEBUG` was configured.

The limit and the retry bound have to stay in step, which is the one non-obvious coupling here. The bound counts every consecutive `ValueError`, including overruns that do make progress. That is harmless at 8 MiB and dangerous at 64 KiB: a spawn left on the default overruns easily enough that a burst of large lines can exhaust the bound, stop the reader, and deadlock the child. An earlier revision of this PR had exactly that gap, because the debug spawns kept the default. `test_every_spawn_uses_the_larger_limit` covers all four sites so a new spawn cannot be added on the default without failing.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This revision completes the large-line streaming fix by applying the shared 8 MiB stream limit to both debug subprocess helpers and extending the regression test across all four spawn sites.
- Moves `SUBPROCESS_STREAM_LIMIT` into a dependency-safe shared CLI utility module.
- Applies the larger stream limit to normal and debug subprocesses.
- Keeps output draining after isolated read or decoding failures while bounding repeated non-progressing errors.
- Honors `LOG_LEVEL`, with `INFO` as the fallback for missing or invalid values.
- Adds regression coverage for streaming continuity, cancellation, retry bounds, spawn configuration, and log-level resolution.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the previously reported debug streaming freeze is fully addressed and no new actionable failures remain.

Both debug subprocess helpers now pass the enlarged stream limit, and the regression test verifies all four normal and debug spawn paths. The shared constant introduces no import cycle, while the logging and per-line streaming changes retain safe defaults and cancellation behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/cli/debug/debug_handlers.py | Both debug subprocess helpers now use the shared enlarged stream limit, resolving the prior debug-mode freeze path. |
| src/agentex/lib/cli/handlers/run_handlers.py | Output streaming now tolerates isolated unreadable lines, bounds repeated non-progressing failures, and uses the shared subprocess stream limit. |
| src/agentex/lib/cli/utils/cli_utils.py | Defines the shared 8 MiB stream limit in a dependency-safe utility module. |
| src/agentex/lib/utils/logging.py | Resolves logger levels from `LOG_LEVEL` while safely defaulting missing or invalid values to `INFO`. |
| tests/lib/cli/test_run_handlers_streaming.py | Covers large-line draining, bounded read failures, cancellation propagation, and stream-limit configuration at every spawn site. |
| tests/lib/utils/test_logging_level.py | Covers default, normalized, invalid, and applied environment log levels. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Spawn agent subprocess] --> B[StreamReader with 8 MiB limit]
    B --> C{readline result}
    C -->|Valid bytes| D{UTF-8 decoding succeeds?}
    D -->|Yes| E[Print prefixed output]
    D -->|No| F[Warn and continue]
    C -->|ValueError| G[Increment consecutive error count]
    G --> H{More than 100?}
    H -->|No| B
    H -->|Yes| I[Warn that streaming stopped]
    E --> B
    F --> B
    C -->|EOF| J[Finish streaming]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Address greptile: give the debug spawns ..."](https://github.com/scaleapi/scale-agentex-python/commit/d0a1c2ea15445fa180b2d5918bc09d253c36246c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60769681)</sub>

<!-- /greptile_comment -->