### PR TITLE
feat(adk): make AgentEx client HTTP timeouts configurable by env var

### DIFF
--- a/src/agentex/lib/adk/utils/_modules/client.py
+++ b/src/agentex/lib/adk/utils/_modules/client.py
@@ -1,3 +1,4 @@
+import os
 from typing import override
 
 import httpx
@@ -26,21 +27,40 @@ class EnvAuth(httpx.Auth):
         yield request
 
 
+# HTTP timeouts for the AgentEx client, in seconds. Defaults match the SDK's
+# DEFAULT_TIMEOUT, so leaving these unset changes nothing.
+_TIMEOUT_ENV_DEFAULTS = {
+    "connect": ("AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS", 5.0),
+    "read": ("AGENTEX_CLIENT_READ_TIMEOUT_SECONDS", 300.0),
+    "write": ("AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS", 300.0),
+    "pool": ("AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS", 300.0),
+}
+
+
 def _timeout_from_env() -> httpx.Timeout:
     """Build the client timeout from environment variables.
 
-    Defaults match the SDK's DEFAULT_TIMEOUT, so an unconfigured process behaves
-    exactly as before. The connect timeout is the one worth raising: an AgentEx
-    backend accepts connections serially, so connect latency grows with the number
-    of callers and the 5s default is reached when a few hundred are in flight.
+    Read from ``os.environ`` rather than from ``EnvironmentVariables``. That model
+    is loaded by worker startup and by ``EnvAuth.auth_flow`` on every request, and
+    ``agentex.lib.adk.utils`` builds a client at import time, so a field added
+    there would make a malformed timeout break all three. Reading here keeps the
+    blast radius to the one value that is actually wrong.
+
+    The connect timeout is the one worth raising: an AgentEx backend accepts
+    connections serially, so connect latency grows with the number of callers and
+    the 5s default is reached when a few hundred are in flight.
     """
-    env_vars = EnvironmentVariables.refresh()
-    return httpx.Timeout(
-        connect=env_vars.AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS,
-        read=env_vars.AGENTEX_CLIENT_READ_TIMEOUT_SECONDS,
-        write=env_vars.AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS,
-        pool=env_vars.AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS,
-    )
+    values = {}
+    for field, (env_var, default) in _TIMEOUT_ENV_DEFAULTS.items():
+        raw = os.environ.get(env_var)
+        if raw is None or raw.strip() == "":
+            values[field] = default
+            continue
+        try:
+            values[field] = float(raw)
+        except ValueError as exc:
+            raise ValueError(f"{env_var} must be a number in seconds, got {raw!r}") from exc
+    return httpx.Timeout(**values)
 
 
 def create_async_agentex_client(**kwargs) -> AsyncAgentex:
@@ -50,11 +70,7 @@ def create_async_agentex_client(**kwargs) -> AsyncAgentex:
     AGENTEX_CLIENT_*_TIMEOUT_SECONDS environment variables.
     """
     if "timeout" not in kwargs:
-        try:
-            kwargs["timeout"] = _timeout_from_env()
-        except Exception as exc:
-            # Never let timeout configuration stop a client being created.
-            logger.warning("Falling back to SDK default timeout: %r", exc)
+        kwargs["timeout"] = _timeout_from_env()
     client = AsyncAgentex(**kwargs)
     client._client.auth = EnvAuth()
     return client

--- a/src/agentex/lib/adk/utils/_modules/client.py
+++ b/src/agentex/lib/adk/utils/_modules/client.py
@@ -26,7 +26,35 @@ class EnvAuth(httpx.Auth):
         yield request
 
 
+def _timeout_from_env() -> httpx.Timeout:
+    """Build the client timeout from environment variables.
+
+    Defaults match the SDK's DEFAULT_TIMEOUT, so an unconfigured process behaves
+    exactly as before. The connect timeout is the one worth raising: an AgentEx
+    backend accepts connections serially, so connect latency grows with the number
+    of callers and the 5s default is reached when a few hundred are in flight.
+    """
+    env_vars = EnvironmentVariables.refresh()
+    return httpx.Timeout(
+        connect=env_vars.AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS,
+        read=env_vars.AGENTEX_CLIENT_READ_TIMEOUT_SECONDS,
+        write=env_vars.AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS,
+        pool=env_vars.AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS,
+    )
+
+
 def create_async_agentex_client(**kwargs) -> AsyncAgentex:
+    """Create an AsyncAgentex client.
+
+    An explicit ``timeout=`` always wins; otherwise the timeout comes from the
+    AGENTEX_CLIENT_*_TIMEOUT_SECONDS environment variables.
+    """
+    if "timeout" not in kwargs:
+        try:
+            kwargs["timeout"] = _timeout_from_env()
+        except Exception as exc:
+            # Never let timeout configuration stop a client being created.
+            logger.warning("Falling back to SDK default timeout: %r", exc)
     client = AsyncAgentex(**kwargs)
     client._client.auth = EnvAuth()
     return client

--- a/src/agentex/lib/environment_variables.py
+++ b/src/agentex/lib/environment_variables.py
@@ -25,7 +25,6 @@ class EnvVarKeys(str, Enum):
     AGENT_DESCRIPTION = "AGENT_DESCRIPTION"
     AGENT_ID = "AGENT_ID"
     AGENT_VERSION = "AGENT_VERSION"
-    AGENT_COMMIT_SHA = "AGENT_COMMIT_SHA"
     AGENT_API_KEY = "AGENT_API_KEY"
     # ACP Configuration
     ACP_URL = "ACP_URL"
@@ -68,12 +67,6 @@ class EnvironmentVariables(BaseModel):
     AGENT_ID: str | None = None
     # Build/version discriminator (image tag or git sha), set by the deployment
     AGENT_VERSION: str | None = None
-    # The agent's source commit, baked into the image or set by the deployment.
-    # Unlike AGENT_VERSION this is expected to be a git SHA and nothing else, and
-    # it is OPT-IN: nothing is stamped unless the agent calls
-    # `adk.code_revision.enable()`, which also refuses a value that is not a git
-    # object name. See agentex.lib.core.tracing.code_revision.
-    AGENT_COMMIT_SHA: str | None = None
     AGENT_API_KEY: str | None = None
     ACP_TYPE: str | None = "async"
     AGENT_INPUT_TYPE: str | None = None

--- a/src/agentex/lib/environment_variables.py
+++ b/src/agentex/lib/environment_variables.py
@@ -20,16 +20,12 @@ class EnvVarKeys(str, Enum):
     TEMPORAL_ADDRESS = "TEMPORAL_ADDRESS"
     REDIS_URL = "REDIS_URL"
     AGENTEX_BASE_URL = "AGENTEX_BASE_URL"
-    # AgentEx client HTTP timeouts (seconds)
-    AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS = "AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS"
-    AGENTEX_CLIENT_READ_TIMEOUT_SECONDS = "AGENTEX_CLIENT_READ_TIMEOUT_SECONDS"
-    AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS = "AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS"
-    AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS = "AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS"
     # Agent Identifiers
     AGENT_NAME = "AGENT_NAME"
     AGENT_DESCRIPTION = "AGENT_DESCRIPTION"
     AGENT_ID = "AGENT_ID"
     AGENT_VERSION = "AGENT_VERSION"
+    AGENT_COMMIT_SHA = "AGENT_COMMIT_SHA"
     AGENT_API_KEY = "AGENT_API_KEY"
     # ACP Configuration
     ACP_URL = "ACP_URL"
@@ -66,20 +62,18 @@ class EnvironmentVariables(BaseModel):
     TEMPORAL_ADDRESS: str | None = "localhost:7233"
     REDIS_URL: str | None = None
     AGENTEX_BASE_URL: str | None = "http://localhost:5003"
-    # HTTP timeouts for the AgentEx client, in seconds. Defaults match the
-    # SDK's DEFAULT_TIMEOUT, so leaving these unset changes nothing.
-    # Raise the connect timeout when many concurrent activities share one
-    # backend: accepts queue, and 5s is reached at a few hundred in flight.
-    AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS: float = 5.0
-    AGENTEX_CLIENT_READ_TIMEOUT_SECONDS: float = 300.0
-    AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS: float = 300.0
-    AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS: float = 300.0
     # Agent Identifiers
     AGENT_NAME: str
     AGENT_DESCRIPTION: str | None = None
     AGENT_ID: str | None = None
     # Build/version discriminator (image tag or git sha), set by the deployment
     AGENT_VERSION: str | None = None
+    # The agent's source commit, baked into the image or set by the deployment.
+    # Unlike AGENT_VERSION this is expected to be a git SHA and nothing else, and
+    # it is OPT-IN: nothing is stamped unless the agent calls
+    # `adk.code_revision.enable()`, which also refuses a value that is not a git
+    # object name. See agentex.lib.core.tracing.code_revision.
+    AGENT_COMMIT_SHA: str | None = None
     AGENT_API_KEY: str | None = None
     ACP_TYPE: str | None = "async"
     AGENT_INPUT_TYPE: str | None = None

--- a/src/agentex/lib/environment_variables.py
+++ b/src/agentex/lib/environment_variables.py
@@ -20,6 +20,11 @@ class EnvVarKeys(str, Enum):
     TEMPORAL_ADDRESS = "TEMPORAL_ADDRESS"
     REDIS_URL = "REDIS_URL"
     AGENTEX_BASE_URL = "AGENTEX_BASE_URL"
+    # AgentEx client HTTP timeouts (seconds)
+    AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS = "AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS"
+    AGENTEX_CLIENT_READ_TIMEOUT_SECONDS = "AGENTEX_CLIENT_READ_TIMEOUT_SECONDS"
+    AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS = "AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS"
+    AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS = "AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS"
     # Agent Identifiers
     AGENT_NAME = "AGENT_NAME"
     AGENT_DESCRIPTION = "AGENT_DESCRIPTION"
@@ -61,6 +66,14 @@ class EnvironmentVariables(BaseModel):
     TEMPORAL_ADDRESS: str | None = "localhost:7233"
     REDIS_URL: str | None = None
     AGENTEX_BASE_URL: str | None = "http://localhost:5003"
+    # HTTP timeouts for the AgentEx client, in seconds. Defaults match the
+    # SDK's DEFAULT_TIMEOUT, so leaving these unset changes nothing.
+    # Raise the connect timeout when many concurrent activities share one
+    # backend: accepts queue, and 5s is reached at a few hundred in flight.
+    AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS: float = 5.0
+    AGENTEX_CLIENT_READ_TIMEOUT_SECONDS: float = 300.0
+    AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS: float = 300.0
+    AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS: float = 300.0
     # Agent Identifiers
     AGENT_NAME: str
     AGENT_DESCRIPTION: str | None = None

--- a/tests/lib/test_client_timeout_env.py
+++ b/tests/lib/test_client_timeout_env.py
@@ -13,32 +13,14 @@ from __future__ import annotations
 import httpx
 import pytest
 
-import agentex.lib.environment_variables as env_module
 from agentex.lib.adk.utils._modules.client import (
     _timeout_from_env,
     create_async_agentex_client,
 )
 
 
-@pytest.fixture(autouse=True)
-def _clear_env_cache():
-    """EnvironmentVariables.refresh() memoises into a module global."""
-    env_module.refreshed_environment_variables = None
-    yield
-    env_module.refreshed_environment_variables = None
-
-
-def _set_env(monkeypatch, **overrides: str) -> None:
-    # EnvironmentVariables has required fields; set them so construction succeeds.
-    monkeypatch.setenv("AGENT_NAME", "test-agent")
-    monkeypatch.setenv("ACP_URL", "http://localhost:8000")
-    for key, value in overrides.items():
-        monkeypatch.setenv(key, value)
-
-
-def test_defaults_match_the_sdk_default_timeout(monkeypatch):
+def test_defaults_match_the_sdk_default_timeout():
     """An unconfigured process must behave exactly as it did before."""
-    _set_env(monkeypatch)
     timeout = _timeout_from_env()
     assert timeout.connect == 5.0
     assert timeout.read == 300.0
@@ -47,7 +29,7 @@ def test_defaults_match_the_sdk_default_timeout(monkeypatch):
 
 
 def test_connect_timeout_is_configurable(monkeypatch):
-    _set_env(monkeypatch, AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="30")
+    monkeypatch.setenv("AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS", "30")
     timeout = _timeout_from_env()
     assert timeout.connect == 30.0
     # the others are untouched
@@ -55,13 +37,10 @@ def test_connect_timeout_is_configurable(monkeypatch):
 
 
 def test_all_four_are_configurable(monkeypatch):
-    _set_env(
-        monkeypatch,
-        AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="30",
-        AGENTEX_CLIENT_READ_TIMEOUT_SECONDS="120",
-        AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS="90",
-        AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS="60",
-    )
+    monkeypatch.setenv("AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS", "30")
+    monkeypatch.setenv("AGENTEX_CLIENT_READ_TIMEOUT_SECONDS", "120")
+    monkeypatch.setenv("AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS", "90")
+    monkeypatch.setenv("AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS", "60")
     timeout = _timeout_from_env()
     assert (timeout.connect, timeout.read, timeout.write, timeout.pool) == (
         30.0,
@@ -71,14 +50,21 @@ def test_all_four_are_configurable(monkeypatch):
     )
 
 
+def test_an_empty_value_falls_back_to_the_default():
+    """An unset variable and one set to the empty string mean the same thing."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS", "")
+        assert _timeout_from_env().connect == 5.0
+
+
 def test_client_picks_up_the_env_timeout(monkeypatch):
-    _set_env(monkeypatch, AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="30")
+    monkeypatch.setenv("AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS", "30")
     client = create_async_agentex_client(api_key="test", base_url="http://localhost:5003")
     assert client.timeout.connect == 30.0
 
 
 def test_explicit_timeout_wins_over_the_environment(monkeypatch):
-    _set_env(monkeypatch, AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="30")
+    monkeypatch.setenv("AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS", "30")
     client = create_async_agentex_client(
         api_key="test",
         base_url="http://localhost:5003",
@@ -87,15 +73,27 @@ def test_explicit_timeout_wins_over_the_environment(monkeypatch):
     assert client.timeout.connect == 7.0
 
 
-def test_env_auth_is_still_attached(monkeypatch):
+def test_env_auth_is_still_attached():
     """The factory's original job must survive the change."""
-    _set_env(monkeypatch)
     client = create_async_agentex_client(api_key="test", base_url="http://localhost:5003")
     assert client._client.auth is not None
 
 
-def test_a_bad_value_does_not_prevent_client_creation(monkeypatch):
-    """Timeout configuration must never be the reason a client fails to build."""
-    _set_env(monkeypatch, AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="not-a-number")
-    client = create_async_agentex_client(api_key="test", base_url="http://localhost:5003")
-    assert client is not None
+def test_a_bad_value_names_the_variable(monkeypatch):
+    """A malformed value is a configuration error, so it must not be swallowed."""
+    monkeypatch.setenv("AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS", "not-a-number")
+    with pytest.raises(ValueError, match="AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS"):
+        _timeout_from_env()
+
+
+def test_the_timeout_does_not_depend_on_the_shared_environment_model(monkeypatch):
+    """Regression: these must not become EnvironmentVariables fields.
+
+    That model has required fields, is loaded by worker startup and by
+    EnvAuth.auth_flow on every request, and agentex.lib.adk.utils builds a
+    client at import time. Routing timeouts through it makes all three depend
+    on a fully configured environment.
+    """
+    monkeypatch.delenv("AGENT_NAME", raising=False)
+    monkeypatch.delenv("ACP_URL", raising=False)
+    assert _timeout_from_env().connect == 5.0

--- a/tests/lib/test_client_timeout_env.py
+++ b/tests/lib/test_client_timeout_env.py
@@ -60,6 +60,8 @@ def test_an_empty_value_falls_back_to_the_default():
 def test_client_picks_up_the_env_timeout(monkeypatch):
     monkeypatch.setenv("AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS", "30")
     client = create_async_agentex_client(api_key="test", base_url="http://localhost:5003")
+    # client.timeout is float | Timeout | None; narrow before reading a component.
+    assert isinstance(client.timeout, httpx.Timeout)
     assert client.timeout.connect == 30.0
 
 
@@ -70,6 +72,7 @@ def test_explicit_timeout_wins_over_the_environment(monkeypatch):
         base_url="http://localhost:5003",
         timeout=httpx.Timeout(connect=7.0, read=8.0, write=9.0, pool=10.0),
     )
+    assert isinstance(client.timeout, httpx.Timeout)
     assert client.timeout.connect == 7.0
 
 

--- a/tests/lib/test_client_timeout_env.py
+++ b/tests/lib/test_client_timeout_env.py
@@ -18,7 +18,6 @@ from agentex.lib.adk.utils._modules.client import (
     _timeout_from_env,
     create_async_agentex_client,
 )
-from agentex.lib.environment_variables import EnvironmentVariables
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lib/test_client_timeout_env.py
+++ b/tests/lib/test_client_timeout_env.py
@@ -1,0 +1,102 @@
+"""Timeouts for the AgentEx client are configurable by environment variable.
+
+The connect timeout is the one that matters in practice. An AgentEx backend
+accepts connections serially, so connect latency grows with the number of
+concurrent callers, and the 5s default is reached once a few hundred are in
+flight. Before this was configurable, the only way to change it was to pass
+``timeout=`` at every construction site, which application code cannot do for
+the client the ADK builds internally.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import agentex.lib.environment_variables as env_module
+from agentex.lib.adk.utils._modules.client import (
+    _timeout_from_env,
+    create_async_agentex_client,
+)
+from agentex.lib.environment_variables import EnvironmentVariables
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_cache():
+    """EnvironmentVariables.refresh() memoises into a module global."""
+    env_module.refreshed_environment_variables = None
+    yield
+    env_module.refreshed_environment_variables = None
+
+
+def _set_env(monkeypatch, **overrides: str) -> None:
+    # EnvironmentVariables has required fields; set them so construction succeeds.
+    monkeypatch.setenv("AGENT_NAME", "test-agent")
+    monkeypatch.setenv("ACP_URL", "http://localhost:8000")
+    for key, value in overrides.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_defaults_match_the_sdk_default_timeout(monkeypatch):
+    """An unconfigured process must behave exactly as it did before."""
+    _set_env(monkeypatch)
+    timeout = _timeout_from_env()
+    assert timeout.connect == 5.0
+    assert timeout.read == 300.0
+    assert timeout.write == 300.0
+    assert timeout.pool == 300.0
+
+
+def test_connect_timeout_is_configurable(monkeypatch):
+    _set_env(monkeypatch, AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="30")
+    timeout = _timeout_from_env()
+    assert timeout.connect == 30.0
+    # the others are untouched
+    assert timeout.read == 300.0
+
+
+def test_all_four_are_configurable(monkeypatch):
+    _set_env(
+        monkeypatch,
+        AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="30",
+        AGENTEX_CLIENT_READ_TIMEOUT_SECONDS="120",
+        AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS="90",
+        AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS="60",
+    )
+    timeout = _timeout_from_env()
+    assert (timeout.connect, timeout.read, timeout.write, timeout.pool) == (
+        30.0,
+        120.0,
+        90.0,
+        60.0,
+    )
+
+
+def test_client_picks_up_the_env_timeout(monkeypatch):
+    _set_env(monkeypatch, AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="30")
+    client = create_async_agentex_client(api_key="test", base_url="http://localhost:5003")
+    assert client.timeout.connect == 30.0
+
+
+def test_explicit_timeout_wins_over_the_environment(monkeypatch):
+    _set_env(monkeypatch, AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="30")
+    client = create_async_agentex_client(
+        api_key="test",
+        base_url="http://localhost:5003",
+        timeout=httpx.Timeout(connect=7.0, read=8.0, write=9.0, pool=10.0),
+    )
+    assert client.timeout.connect == 7.0
+
+
+def test_env_auth_is_still_attached(monkeypatch):
+    """The factory's original job must survive the change."""
+    _set_env(monkeypatch)
+    client = create_async_agentex_client(api_key="test", base_url="http://localhost:5003")
+    assert client._client.auth is not None
+
+
+def test_a_bad_value_does_not_prevent_client_creation(monkeypatch):
+    """Timeout configuration must never be the reason a client fails to build."""
+    _set_env(monkeypatch, AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS="not-a-number")
+    client = create_async_agentex_client(api_key="test", base_url="http://localhost:5003")
+    assert client is not None


### PR DESCRIPTION
## Summary

The AgentEx client's HTTP timeout is fixed at the SDK default and cannot be changed from application code. This adds four environment variables to configure it, with defaults equal to today's values so nothing changes for an unconfigured process.

## The problem

`create_async_agentex_client()` passes no `timeout`, so every client falls back to `DEFAULT_TIMEOUT`:

```
Timeout(connect=5.0, read=300, write=300, pool=300)
```

An application cannot override this. The ADK builds its own clients internally at 14 sites across `messages`, `tasks`, `events` and `tracing`, all through that factory, and none takes a timeout from the caller. No environment variable controlled it either, so wrapping the factory locally only covers the paths an app constructs itself, not the ADK's.

The connect timeout is the one that bites. An AgentEx backend accepts connections serially, so connect latency grows with the number of concurrent callers. Measured against a local backend with `GET /readyz`, a 10s client timeout, and no failures at any level:

| Concurrent connects | p50 | max |
|---|---|---|
| 1 | 84 ms | 84 ms |
| 20 | 423 ms | 452 ms |
| 100 | 500 ms | 537 ms |
| 200 | 1,010 ms | 1,075 ms |

Latency is linear in concurrency, which is the signature of serialised accepts rather than slow request handling. An agent running 100 concurrent Temporal activities, each making ADK calls, crosses the 5s budget and fails with `httpcore.ConnectTimeout`. One run produced 197 such failures from a single activity type.

A 5s connect alongside a 300s read is also internally inconsistent: the client will wait five minutes for a response but only five seconds to open the socket.

## What changed

The whole change is in **`src/agentex/lib/adk/utils/_modules/client.py`**. `_timeout_from_env()` reads four variables from `os.environ`, and `create_async_agentex_client()` applies the result when the caller passes no `timeout`:

```
AGENTEX_CLIENT_CONNECT_TIMEOUT_SECONDS   default 5.0
AGENTEX_CLIENT_READ_TIMEOUT_SECONDS      default 300.0
AGENTEX_CLIENT_WRITE_TIMEOUT_SECONDS     default 300.0
AGENTEX_CLIENT_POOL_TIMEOUT_SECONDS      default 300.0
```

Because all 14 internal construction sites route through that factory, one change covers `messages`, `tasks`, `events` and `tracing`.

Three properties worth checking in review:

- Defaults equal the current `DEFAULT_TIMEOUT`, so an unconfigured process behaves exactly as before.
- An explicit `timeout=` argument still wins over the environment.
- A malformed value raises a `ValueError` naming the variable, at the point the value is used.

### Why not `EnvironmentVariables`

The first version of this PR declared the four values as fields on the shared `EnvironmentVariables` model, which is the repo's usual pattern. That turned out to be the wrong home for them, and the reasoning is worth recording because the failure was not obvious:

`EnvironmentVariables.refresh()` is called from about 20 places, none of which guard it, including `AgentWorker` startup and `EnvAuth.auth_flow()` on every authenticated request. A malformed timeout would therefore fail validation far from the client factory. The factory's `try/except` did not contain that; it only made the failure look handled at the one site that could have reported it clearly.

Removing that `try/except` exposed a second problem. `agentex/lib/adk/utils/__init__.py` constructs `TemplatingModule()` at module scope, and that constructor builds a client, so `import agentex.lib.adk` began requiring `AGENT_NAME` and `ACP_URL` to be set. The suppressed exception had been hiding an import-time dependency on a fully configured environment.

Reading `os.environ` directly avoids both. The shared model is untouched, so startup, authentication and import are unaffected, and a bad value affects only the timeout it describes.

## Review guide

`client.py` is the entire behavioural change; it and its test are the only two files this PR touches. `tests/lib/test_client_timeout_env.py` covers the defaults, each override, the empty-string case, precedence of an explicit argument, that `EnvAuth` survives, the malformed-value error, and a regression test asserting the timeouts do not depend on the shared environment model.

## Testing

`uv sync` requires `uv >= 0.9` and this machine has 0.8.13, so I ran the suite through `uvx` with both packages installed editable. The 9 new tests pass, and `tests/lib` is 1028 passed / 3 skipped. `pyright` at the pinned 1.1.399 is clean on the touched files. The 12 errors in that run are all `tests/lib/cli/test_agent_handlers.py` raising on a Click `DeprecationWarning` under `filterwarnings = error`; they come from unpinned resolution in the ad-hoc environment rather than from `uv.lock`, and are unrelated to this change. `ruff check` and `ruff format --check` are clean on the touched files.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds environment-variable configuration for the AgentEx async client's connect, read, write, and pool timeouts.
- Preserves the SDK’s existing timeout values when variables are unset or blank.
- Gives explicit caller-provided timeout arguments precedence.
- Reads timeout settings independently of the shared environment model, containing malformed-value failures to client construction.
- Adds focused tests for defaults, overrides, precedence, malformed values, authentication attachment, and environment-model independence.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no outstanding correctness, security, or repository-rule issues.

The previously reported shared-environment validation issue was fully addressed by reading timeout variables directly in the client factory, and that thread is resolved. The current implementation preserves existing defaults and explicit timeout precedence while limiting malformed configuration failures to client creation.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agentex/lib/adk/utils/_modules/client.py | Adds isolated environment parsing for all four HTTP timeout components while preserving explicit caller configuration. |
| tests/lib/test_client_timeout_env.py | Covers default and configured timeout behavior, malformed input, explicit precedence, authentication, and regression boundaries. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Drop an unrelated file change from the b..."](https://github.com/scaleapi/scale-agentex-python/commit/cb82208edacc5ac6e38198ef22a75ac2bc5cf908) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61065154)</sub>

<!-- /greptile_comment -->